### PR TITLE
feat: add x402 OpenClaw integration

### DIFF
--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -1,9 +1,9 @@
 # `@algorandfoundation/ac2-open-claw-reference`
 
 Reference [OpenClaw](https://docs.openclaw.ai/) plugin for the **AC2**
-protocol. It implements both the tool and channel interfaces — `ac2_sign`
-/ `ac2_capabilities` tools plus the `ac2` channel — over Liquid Auth +
-WebRTC via [`@algorandfoundation/ac2-sdk`](../ac2-sdk).
+protocol. It implements both the tool and channel interfaces — `ac2_sign`,
+`ac2_capabilities`, and `ac2_x402_fetch` tools plus the `ac2` channel — over
+Liquid Auth + WebRTC via [`@algorandfoundation/ac2-sdk`](../ac2-sdk).
 
 ## What AC2 contributes to OpenClaw
 
@@ -12,6 +12,7 @@ WebRTC via [`@algorandfoundation/ac2-sdk`](../ac2-sdk).
 | Channel `ac2`           | Owns Liquid Auth + WebRTC pairing and the active session.                  |
 | Tool `ac2_capabilities` | Agent DID + `sig_hint` catalog.                                            |
 | Tool `ac2_sign`         | Routes a `SigningRequest` to the wallet over the active channel.           |
+| Tool `ac2_x402_fetch`   | Pays x402 exact Algorand resources using wallet-approved AC2 signing.      |
 | Setup entry             | `openclaw ac2 setup` writes the channel/tools wiring into `openclaw.json`. |
 
 **Channels own the lifecycle; tools are pure consumers.** The `ac2`
@@ -99,6 +100,7 @@ Once installed, `openclaw.json` will contain an entry like:
     config: {
       liquidAuthServer: 'https://debug.liquidauth.com',
       defaultTimeoutMs: 120000,
+      x402MaxAmountAtomic: '1000000',
     },
   },
 }
@@ -110,13 +112,16 @@ Once installed, `openclaw.json` will contain an entry like:
 
 In a conversation, enable the `ac2` channel, scan the QR with your AC2
 Controller / wallet, then the model can call `ac2_capabilities`
-followed by `ac2_sign`. See
-[DISCOVERY §3.2](https://github.com/algorandfoundation/ac2-sdk) for the
-request/response shapes.
+followed by `ac2_sign` for raw signing or `ac2_x402_fetch` for paid HTTP
+resources that advertise x402 exact payments on Algorand. `ac2_x402_fetch`
+does the x402 402-response negotiation, asks the wallet to approve the
+Algorand payment transaction signing over AC2, retries with
+`PAYMENT-SIGNATURE`, and returns the HTTP/payment result.
 
 ## Scope
 
 - ✅ Liquid Auth pairing, AC2 signing trio, `thid`-bound responses,
-  channel-owned sessions, wallet-issued agent identity.
+  channel-owned sessions, wallet-issued agent identity, x402 exact Algorand
+  paid fetch via wallet-approved signing.
 - ❌ Chain-specific verifiers, wallet introspection, holding user keys,
   a bundled Node WebRTC stack — these belong in downstream plugins.

--- a/packages/ac2-open-claw-reference/openclaw.plugin.json
+++ b/packages/ac2-open-claw-reference/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "ac2-open-claw-reference",
   "name": "AC2 Reference",
-  "description": "Reference OpenClaw plugin for the AC2 protocol. The `ac2` channel owns pairing over Liquid Auth + WebRTC; `ac2_sign` and `ac2_capabilities` route through the active channel session.",
+  "description": "Reference OpenClaw plugin for the AC2 protocol. The `ac2` channel owns pairing over Liquid Auth + WebRTC; signing, capabilities, and x402 paid fetch tools route through the active channel session.",
   "version": "0.1.0",
   "channels": ["ac2"],
   "channelEnvVars": [
@@ -27,15 +27,51 @@
         "type": "number",
         "default": 120000,
         "description": "Default ceiling for awaiting pairing and SigningResponse, in milliseconds."
+      },
+      "x402MaxAmountAtomic": {
+        "type": "string",
+        "default": "1000000",
+        "description": "Default maximum x402 payment amount, in asset atomic units. Defaults to 1000000 (1 USDC for 6-decimal USDC)."
+      },
+      "x402AllowedNetworks": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Optional allow-list of x402 CAIP-2 Algorand networks. Defaults to Algorand TestNet and MainNet."
+      },
+      "x402AllowedAssets": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Optional allow-list of x402 assets. Defaults to Algorand USDC asset identifiers and USDC."
+      },
+      "x402AllowedPayTo": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Optional allow-list of x402 recipient Algorand addresses."
+      },
+      "x402NetworkPreferences": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Preferred x402 Algorand networks when a resource offers multiple accepted payment routes."
+      },
+      "x402AlgodUrl": {
+        "type": "string",
+        "description": "Optional Algod URL override for constructing x402 Algorand payment transactions."
+      },
+      "x402AlgodToken": {
+        "type": "string",
+        "description": "Optional Algod API token used with x402AlgodUrl."
       }
     },
     "required": []
   },
   "uiHints": {
-    "liquidAuthServer": { "label": "Liquid Auth Server" }
+    "liquidAuthServer": { "label": "Liquid Auth Server" },
+    "x402MaxAmountAtomic": { "label": "x402 Max Amount (Atomic)" },
+    "x402AlgodUrl": { "label": "x402 Algod URL" },
+    "x402AlgodToken": { "label": "x402 Algod Token" }
   },
   "contracts": {
-    "tools": ["ac2_sign", "ac2_capabilities"],
+    "tools": ["ac2_sign", "ac2_capabilities", "ac2_x402_fetch"],
     "commands": ["ac2"]
   },
   "toolMetadata": {
@@ -52,6 +88,10 @@
           "payload_base64": {
             "type": "string",
             "description": "Base64-encoded raw bytes the wallet will sign. The core reference signs these bytes as-is under the selected curve; downstream plugins may apply additional encodings based on `sig_hint`."
+          },
+          "schema": {
+            "type": "string",
+            "description": "Optional schema identifier for the payload. Useful for wallet UX and domain-specific signing requests such as x402 Algorand payment bytes."
           },
           "sig_hint": {
             "type": "string",
@@ -87,12 +127,74 @@
         },
         "additionalProperties": false
       }
+    },
+    "ac2_x402_fetch": {
+      "label": "AC2 x402 Fetch",
+      "description": "Fetch an HTTP(S) resource that may require x402 payment. When the server returns 402, this tool uses x402 exact payments on Algorand, asks the paired wallet to approve the required Algorand transaction signing over AC2, retries with PAYMENT-SIGNATURE, and returns the HTTP/payment result. Requires an active `ac2` channel.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "Absolute HTTP(S) URL to fetch."
+          },
+          "method": {
+            "type": "string",
+            "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"],
+            "description": "HTTP method. Defaults to GET unless a body is supplied."
+          },
+          "headers": {
+            "type": "object",
+            "additionalProperties": { "type": "string" },
+            "description": "Optional HTTP headers for the request."
+          },
+          "body": {
+            "type": "string",
+            "description": "Optional UTF-8 request body. Do not pass with body_base64."
+          },
+          "body_base64": {
+            "type": "string",
+            "description": "Optional base64 request body for binary payloads. Do not pass with body."
+          },
+          "max_amount_atomic": {
+            "type": "string",
+            "description": "Maximum payment amount in the asset atomic units. Defaults to plugin config x402MaxAmountAtomic or 1000000."
+          },
+          "allowed_networks": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Per-call allow-list of x402 Algorand CAIP-2 networks. Defaults to plugin config or Algorand TestNet/MainNet."
+          },
+          "allowed_assets": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Per-call allow-list of x402 assets. Defaults to plugin config or Algorand USDC."
+          },
+          "allowed_pay_to": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Per-call allow-list of recipient Algorand addresses."
+          },
+          "network_preferences": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Preferred x402 Algorand networks when a resource offers several accepted options."
+          },
+          "include_response_body": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether to include the response body text/JSON in the tool result. Defaults to true."
+          }
+        },
+        "required": ["url"],
+        "additionalProperties": false
+      }
     }
   },
   "channelConfigs": {
     "ac2": {
       "label": "AC2",
-      "description": "Pair an AC2 Controller / wallet over Liquid Auth + WebRTC. Once paired, `ac2_sign` and `ac2_capabilities` route through the active DataChannel.",
+      "description": "Pair an AC2 Controller / wallet over Liquid Auth + WebRTC. Once paired, `ac2_sign`, `ac2_capabilities`, and `ac2_x402_fetch` route through the active DataChannel.",
       "schema": {
         "type": "object",
         "additionalProperties": false,

--- a/packages/ac2-open-claw-reference/package.json
+++ b/packages/ac2-open-claw-reference/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@algorandfoundation/ac2-open-claw-reference",
   "version": "1.0.0-canary.2",
-  "description": "Reference OpenClaw plugin for the AC2 protocol. Implements both tool and channel interfaces for signing and chat over Liquid Auth.",
+  "description": "Reference OpenClaw plugin for the AC2 protocol. Implements signing, chat, and x402 Algorand paid fetch over Liquid Auth.",
   "keywords": [
     "ac2",
     "algorand",
@@ -11,7 +11,9 @@
     "webrtc",
     "liquid-auth",
     "wallet",
-    "signing"
+    "signing",
+    "x402",
+    "payments"
   ],
   "license": "Apache-2.0",
   "homepage": "https://github.com/algorandfoundation/ac2/tree/main/packages/ac2-open-claw-reference#readme",
@@ -57,11 +59,15 @@
   "release": null,
   "dependencies": {
     "@algorandfoundation/ac2-sdk": "1.0.0-canary.1",
+    "@algorandfoundation/algokit-utils": "10.0.0-beta.4",
     "@algorandfoundation/keystore": "1.0.0-canary.16",
     "@algorandfoundation/liquid-client": "1.0.0-canary.8",
     "@napi-rs/keyring": "^1.3.0",
     "@sinclair/typebox": "^0.32.0",
     "@tanstack/store": "^0.9.1",
+    "@x402/avm": "^2.11.0",
+    "@x402/core": "^2.11.0",
+    "@x402/fetch": "^2.11.0",
     "node-datachannel": "^0.32.3",
     "qrcode-terminal": "^0.12.0",
     "socket.io-client": "^4.7.5"
@@ -93,7 +99,8 @@
     "contracts": {
       "tools": [
         "ac2_sign",
-        "ac2_capabilities"
+        "ac2_capabilities",
+        "ac2_x402_fetch"
       ],
       "commands": [
         "ac2"

--- a/packages/ac2-open-claw-reference/skills/ac2/AGENTS.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/AGENTS.md
@@ -197,3 +197,8 @@ The agent MAY load extensions that add patterns or message families.
 Extensions MUST NOT weaken the core invariants in `SOUL.md`. If a peer does
 not advertise an extension, the agent MUST fall back to the core Signature
 Request pattern or refuse the operation.
+
+This reference plugin additionally exposes `ac2_x402_fetch` as
+`ac2-ext-x402/fetch`. It is an application/tool capability, not a new AC2 wire
+message: x402 Algorand payments still use ordinary `ac2/SigningRequest`
+messages for wallet approval.

--- a/packages/ac2-open-claw-reference/skills/ac2/IDENTITY.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/IDENTITY.md
@@ -69,9 +69,13 @@ Per AC2 SPEC §Capability Identifier Namespacing (three-tier convention):
 
 ### Extension capabilities (`ac2-ext-<extension>/<capability>`)
 
-None in this reference plugin. Downstream wallet plugins MAY add chain-specific
-`sig_hint`s (e.g. `message-algorand`, `transaction-evm`). When such a plugin
-is loaded, prefer its richer capabilities tool.
+| Identifier            | Surface                                                                 |
+| --------------------- | ----------------------------------------------------------------------- |
+| `ac2-ext-x402/fetch`  | x402 exact Algorand paid HTTP fetch via the `ac2_x402_fetch` tool.      |
+
+Downstream wallet plugins MAY add chain-specific `sig_hint`s (e.g.
+`message-algorand`, `transaction-evm`). When such a plugin is loaded, prefer
+its richer capabilities tool.
 
 ### Application capabilities (`<reverse-domain>/<name>`)
 
@@ -81,8 +85,8 @@ None declared.
 
 | `sig_hint`      | `key_type` | Operation                                       |
 | --------------- | ---------- | ----------------------------------------------- |
-| `raw-ed25519`   | `identity` | Ed25519 signature over the raw payload bytes.   |
-| `raw-secp256k1` | `identity` | secp256k1 signature over the raw payload bytes. |
+| `raw-ed25519`   | `account` or `identity` | Ed25519 signature over the raw payload bytes.   |
+| `raw-secp256k1` | `account` or `identity` | secp256k1 signature over the raw payload bytes. |
 
 This is the **protocol catalog**. The connected wallet MAY support a subset.
 Live support is reported in `ac2_capabilities.agent.sigHintsCatalog`.

--- a/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
@@ -97,6 +97,8 @@ Concretely:
 
 Use **`ac2_x402_fetch`** when the user asks you to call a paid API/resource that uses x402, or when a normal fetch returns an x402 `402 Payment Required` response.
 
+If the user asks you to fetch the weather and does not provide a URL, use `https://example.x402.goplausible.xyz/avm/weather`.
+
 The tool:
 
 - Performs the x402 HTTP negotiation.

--- a/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
@@ -15,16 +15,16 @@ metadata:
 
 AC2 connects you to the **user's wallet** over a live WebRTC data channel hosted by the `ac2` channel. The user is the human on the other end. The wallet is the key custodian: **you never see or hold private keys.** You ask the wallet to sign; the user approves each request in-wallet, then the signature comes back to you.
 
-This is the **upstream reference** plugin. It exposes only the core methods AC2 itself defines:
+This is the **upstream reference** plugin. It exposes the core AC2 methods plus an x402 convenience tool that uses those same signing requests:
 
 - one channel: `ac2`
-- two tools: `ac2_capabilities`, `ac2_sign`
+- three tools: `ac2_capabilities`, `ac2_sign`, `ac2_x402_fetch`
 
 Chain-specific verifier tools (`ac2_verify_*`) and richer wallet introspection live in downstream wallet plugins. If you have them available, prefer them. If you don't, this skill is enough.
 
 ## The connection comes first
 
-`ac2_sign` cannot pair on its own. It runs through the `ac2` channel's already-paired DataChannel and rejects with `{ status: "rejected", reason: "no_active_session" }` if no channel is connected. If you see that result:
+`ac2_sign` and `ac2_x402_fetch` cannot pair on their own. They run through the `ac2` channel's already-paired DataChannel and reject with `{ status: "rejected", reason: "no_active_session" }` if no channel is connected. If you see that result:
 
 1. Tell the user to open and connect their AC2 Controller / wallet on the `ac2` channel.
 2. Do **not** retry in a loop. Stop and wait for the user.
@@ -93,14 +93,37 @@ Concretely:
 3. On approval you get back a base64 `signature` plus the signer's `publicKey` (and optionally `address`/`keyType`).
 4. On decline you get `{ status: "rejected", reason }` — treat that as a **normal outcome**, not an error. Tell the user what was declined.
 
+## Paid HTTP with x402 on Algorand
+
+Use **`ac2_x402_fetch`** when the user asks you to call a paid API/resource that uses x402, or when a normal fetch returns an x402 `402 Payment Required` response.
+
+The tool:
+
+- Performs the x402 HTTP negotiation.
+- Selects only `exact` Algorand payment requirements that pass the configured/per-call spend policy.
+- Builds the Algorand payment transaction group through the x402 AVM client.
+- Asks the paired wallet to approve the required Algorand transaction signing over AC2.
+- Retries the resource with `PAYMENT-SIGNATURE` and returns the HTTP/payment result.
+
+You do **not** need to call `ac2_sign` manually for x402 payments. Prefer `ac2_x402_fetch` so the spend limit, network/asset/payee allow-lists, signing description, and signed transaction packaging stay consistent.
+
+Important parameters:
+
+- `url` — absolute HTTP(S) URL.
+- `max_amount_atomic` — maximum asset atomic units for this call. Omit to use plugin config.
+- `allowed_networks`, `allowed_assets`, `allowed_pay_to` — optional per-call policy gates.
+- `network_preferences` — preferred Algorand networks when a resource offers more than one.
+
+Treat `{ status: "rejected" }` as a normal user decision. Do not retry the same payment after a rejection.
+
 ## `sig_hint` catalog (what the core reference defines)
 
 `sig_hint` selects the curve the wallet uses. **Always set it explicitly.** Omitting it falls back to plain Ed25519 over raw bytes.
 
 | `sig_hint`      | `key_type` | Use                                            |
 | --------------- | ---------- | ---------------------------------------------- |
-| `raw-ed25519`   | `identity` | Ed25519 signature over the raw payload bytes   |
-| `raw-secp256k1` | `identity` | secp256k1 signature over the raw payload bytes |
+| `raw-ed25519`   | `account` or `identity` | Ed25519 signature over the raw payload bytes   |
+| `raw-secp256k1` | `account` or `identity` | secp256k1 signature over the raw payload bytes |
 
 `key_type` defaults to `account`; use `identity` for DID-bound keys that never custody funds (sign-in, attestations, mandates).
 
@@ -139,7 +162,7 @@ These markdowns ship alongside this `SKILL.md` in the same directory. OpenClaw o
 
 The companion files above are not just reference — they are **the shape you are expected to take**. Treat them as your operating contract:
 
-1. **Load them before acting.** On the first AC2-related turn of a conversation (any call to `ac2_capabilities` / `ac2_sign`, or any user request that involves signing, identity, wallets, or pairing), read every companion file you have not already read this session. If your host environment exposes filesystem tools (Claude Code, OpenClaw's `read_file`, etc.), open them by name from this directory; if it does not, ask the host/user to surface them. Do **not** proceed on stale assumptions when the files are available.
+1. **Load them before acting.** On the first AC2-related turn of a conversation (any call to `ac2_capabilities`, `ac2_sign`, or `ac2_x402_fetch`, or any user request that involves signing, identity, wallets, x402 payments, or pairing), read every companion file you have not already read this session. If your host environment exposes filesystem tools (Claude Code, OpenClaw's `read_file`, etc.), open them by name from this directory; if it does not, ask the host/user to surface them. Do **not** proceed on stale assumptions when the files are available.
 2. **Adopt their voice and constraints.** Your tone, refusals, descriptions, error explanations, and the fields you populate on every AC2 envelope MUST conform to `SOUL.md` and `AGENTS.md`. When a companion file states a MUST / MUST NOT, treat it as binding on your next action, not as advice.
 3. **Resolve conflicts by precedence.** If two companion files disagree: `SOUL.md` > `IDENTITY.md` > `AGENTS.md` ≡ `CLAUDE.md` > `MEMORY.md` > `USER.md` > `SKILL.md`. If a runtime value from `ac2_capabilities` disagrees with `IDENTITY.md`, the **runtime value wins** for facts (what is true right now) and the file wins for **policy** (what MUST be true).
 

--- a/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
+++ b/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
@@ -2,6 +2,7 @@
 
 import qrcode from 'qrcode-terminal';
 import { Ac2Client } from '@algorandfoundation/ac2-sdk';
+import { isValidAddress } from '@algorandfoundation/algokit-utils/common';
 import { resolveConfig, safeLog, type OpenClawApi } from '../runtime.js';
 import {
   BootstrapError,
@@ -196,6 +197,10 @@ export function buildAc2Command(api: OpenClawApi): unknown {
               typeof connected.peer?.['wallet'] === 'string'
                 ? (connected.peer['wallet'] as string)
                 : undefined;
+            const walletAddress =
+              connectedAccount !== undefined && isValidAddress(connectedAccount)
+                ? connectedAccount
+                : undefined;
             const connectedAccountDid =
               connectedAccount !== undefined
                 ? normalizeDidKey(`did:key:${connectedAccount}`)
@@ -282,6 +287,7 @@ export function buildAc2Command(api: OpenClawApi): unknown {
               controllerDid,
               agentDid,
               identityGranted,
+              ...(walletAddress ? { walletAddress } : {}),
               ...(connectionRequestId ? { requestId: connectionRequestId } : {}),
             });
             safeLog(

--- a/packages/ac2-open-claw-reference/src/entry.ts
+++ b/packages/ac2-open-claw-reference/src/entry.ts
@@ -10,7 +10,7 @@ import pluginManifest from './tools/manifest.js';
 import { PLUGIN_ID, setActiveApi, setActiveRuntime, type OpenClawApi } from './runtime.js';
 import { getToolPluginMetadata } from './session/contracts.js';
 import { sessionManager } from './session/manager.js';
-import { buildSignTool, buildCapabilitiesTool } from './tools/index.js';
+import { buildSignTool, buildCapabilitiesTool, buildX402FetchTool } from './tools/index.js';
 import { cmdSetup } from './setup/config.js';
 import { listConnections } from './identity/state.js';
 
@@ -186,13 +186,14 @@ function registerCliMetadata(api: OpenClawApi): void {
   }
 }
 
-/** SDK `registerFull` — register the `ac2_sign` and `ac2_capabilities` tools. */
+/** SDK `registerFull` — register the AC2 signing/capabilities/x402 tools. */
 function registerFull(api: OpenClawApi): void {
   setActive(api);
   try {
     if (typeof api.registerTool === 'function') {
       api.registerTool(buildSignTool());
       api.registerTool(buildCapabilitiesTool());
+      api.registerTool(buildX402FetchTool());
     }
   } catch (err) {
     console.error(`[${PLUGIN_ID}] registerTool failed: ${err}`);

--- a/packages/ac2-open-claw-reference/src/index.ts
+++ b/packages/ac2-open-claw-reference/src/index.ts
@@ -43,7 +43,22 @@ export {
   type Ac2OutboundSessionRoute,
 } from './channel/index.js';
 export { buildAc2Command } from './cli/index.js';
-export { buildSignTool, buildCapabilitiesTool } from './tools/index.js';
+export { buildSignTool, buildCapabilitiesTool, buildX402FetchTool } from './tools/index.js';
+export {
+  X402_ALGORAND_SIGNING_SCHEMA,
+  X402ControllerAddressError,
+  X402SigningRejectedError,
+  classifyX402SigningError,
+  controllerDidToAlgorandAddress,
+  createAc2AvmSigner,
+  normalizeX402FetchParams,
+  x402FetchFlow,
+  type Ac2AvmSignerOptions,
+  type X402FetchParams,
+  type X402FetchResult,
+  type X402PaymentContext,
+  type X402PaymentSelection,
+} from './x402/index.js';
 export {
   LiquidAuthChannelProvider,
   renderPairingQr,

--- a/packages/ac2-open-claw-reference/src/runtime.ts
+++ b/packages/ac2-open-claw-reference/src/runtime.ts
@@ -12,6 +12,13 @@ export type OpenClawApi = OpenClawPluginApi;
 export interface ResolvedConfig {
   liquidAuthServer?: string;
   defaultTimeoutMs?: number;
+  x402MaxAmountAtomic?: string;
+  x402AllowedNetworks?: string[];
+  x402AllowedAssets?: string[];
+  x402AllowedPayTo?: string[];
+  x402NetworkPreferences?: string[];
+  x402AlgodUrl?: string;
+  x402AlgodToken?: string;
 }
 
 let activeApi: OpenClawApi | null = null;

--- a/packages/ac2-open-claw-reference/src/session/channel-runtime.ts
+++ b/packages/ac2-open-claw-reference/src/session/channel-runtime.ts
@@ -1,6 +1,7 @@
 /** Long-running channel runtime: pair via Liquid Auth, then hold the DataChannel open. */
 
 import { Ac2Client } from '@algorandfoundation/ac2-sdk';
+import { isValidAddress } from '@algorandfoundation/algokit-utils/common';
 import type { Ac2ChannelProvider, Ac2PairedChannel } from '@algorandfoundation/ac2-sdk/signaling';
 import { LiquidAuthChannelProvider, renderPairingQr } from '../providers/liquid-auth.js';
 import type { ChannelContext, PluginConfig } from './contracts.js';
@@ -14,6 +15,11 @@ const NO_IDENTITY_NOTICE =
   "⚠️ I don't have an identity key yet, so I can't sign or act on your behalf. " +
   'Please approve the identity (key) request in your AC2 Controller to grant me one. ' +
   'You can keep chatting in the meantime — signing is disabled until then.';
+
+function linkedWalletAddress(paired: Ac2PairedChannel): string | undefined {
+  const wallet = (paired.peer as { wallet?: unknown } | undefined)?.wallet;
+  return typeof wallet === 'string' && isValidAddress(wallet) ? wallet : undefined;
+}
 
 function resolveLiquidAuthServer(config: PluginConfig): string | undefined {
   const fromEnv = typeof process !== 'undefined' ? process.env?.AC2_LIQUID_AUTH_SERVER : undefined;
@@ -80,6 +86,7 @@ export async function runAc2Channel(
 
     // Identity bootstrap. Failure is non-fatal — chat stays open, signing locked.
     const peerDidOpt = paired.peer?.did !== undefined ? { peerDid: paired.peer.did } : {};
+    const walletAddress = linkedWalletAddress(paired);
     const timeoutOpt =
       config.defaultTimeoutMs !== undefined ? { timeoutMs: config.defaultTimeoutMs } : {};
     try {
@@ -96,6 +103,7 @@ export async function runAc2Channel(
         client,
         controllerDid,
         agentDid,
+        ...(walletAddress !== undefined ? { walletAddress } : {}),
       });
       context.logger?.info('[ac2-open-claw] channel connected; tools are live');
     } catch (err) {

--- a/packages/ac2-open-claw-reference/src/session/contracts.ts
+++ b/packages/ac2-open-claw-reference/src/session/contracts.ts
@@ -55,6 +55,47 @@ export const ConfigSchema = Type.Object({
       default: 120_000,
     }),
   ),
+  x402MaxAmountAtomic: Type.Optional(
+    Type.String({
+      description:
+        'Default maximum x402 payment amount, in asset atomic units. Defaults to 1000000 (1 USDC for 6-decimal USDC).',
+      default: '1000000',
+    }),
+  ),
+  x402AllowedNetworks: Type.Optional(
+    Type.Array(Type.String(), {
+      description:
+        'Optional allow-list of x402 CAIP-2 Algorand networks. Defaults to Algorand TestNet and MainNet.',
+    }),
+  ),
+  x402AllowedAssets: Type.Optional(
+    Type.Array(Type.String(), {
+      description:
+        'Optional allow-list of x402 assets. Defaults to Algorand USDC asset identifiers and USDC.',
+    }),
+  ),
+  x402AllowedPayTo: Type.Optional(
+    Type.Array(Type.String(), {
+      description: 'Optional allow-list of x402 recipient Algorand addresses.',
+    }),
+  ),
+  x402NetworkPreferences: Type.Optional(
+    Type.Array(Type.String(), {
+      description:
+        'Preferred x402 Algorand networks when a resource offers multiple acceptable payment routes.',
+    }),
+  ),
+  x402AlgodUrl: Type.Optional(
+    Type.String({
+      description:
+        'Optional Algod URL override for constructing x402 Algorand payment transactions.',
+    }),
+  ),
+  x402AlgodToken: Type.Optional(
+    Type.String({
+      description: 'Optional Algod API token used with x402AlgodUrl.',
+    }),
+  ),
 });
 
 export type PluginConfig = Static<typeof ConfigSchema>;

--- a/packages/ac2-open-claw-reference/src/session/flows.ts
+++ b/packages/ac2-open-claw-reference/src/session/flows.ts
@@ -17,6 +17,7 @@ export function buildFinalizeFrame(text: string, thid = 'default'): string {
 export interface SignParams {
   description: string;
   payload_base64: string;
+  schema?: SigningRequestBody['schema'];
   sig_hint?: SigningRequestBody['sig_hint'];
   display_hint?: SigningRequestBody['display_hint'];
   key_type?: SigningRequestBody['key_type'];
@@ -67,6 +68,7 @@ export async function signFlow(
       description: params.description,
       encoding: 'base64',
       payload: params.payload_base64,
+      ...(params.schema !== undefined ? { schema: params.schema } : {}),
       ...(params.sig_hint !== undefined ? { sig_hint: params.sig_hint } : {}),
       ...(params.display_hint !== undefined ? { display_hint: params.display_hint } : {}),
       ...(params.key_type !== undefined ? { key_type: params.key_type } : {}),

--- a/packages/ac2-open-claw-reference/src/session/manager.ts
+++ b/packages/ac2-open-claw-reference/src/session/manager.ts
@@ -12,6 +12,8 @@ export interface ActiveSession {
   readonly agentDid: string;
   /** Liquid Auth pairing id (`requestId`) for this connection. */
   readonly requestId?: string;
+  /** Raw Algorand wallet account from the Liquid Auth link response. */
+  readonly walletAddress?: string;
   /** True once the wallet granted the agent an identity (bootstrap `KeyRequest`). */
   readonly identityGranted?: boolean;
 }

--- a/packages/ac2-open-claw-reference/src/setup/config.ts
+++ b/packages/ac2-open-claw-reference/src/setup/config.ts
@@ -190,7 +190,7 @@ export function cmdSetup(): string {
 
   // 5. tools.alsoAllow — permit ac2_* tools
   {
-    const toolNames = ['ac2_sign', 'ac2_capabilities'];
+    const toolNames = ['ac2_sign', 'ac2_capabilities', 'ac2_x402_fetch'];
     const alsoAllow = getAtPath(config, 'tools.alsoAllow') ?? [];
     if (Array.isArray(alsoAllow)) {
       const missing = toolNames.filter((n) => !alsoAllow.includes(n));

--- a/packages/ac2-open-claw-reference/src/tools/index.ts
+++ b/packages/ac2-open-claw-reference/src/tools/index.ts
@@ -10,6 +10,8 @@ import { capabilitiesFlow, signFlow, type SignParams } from '../session/flows.js
 import type { SigningRequestBody } from '@algorandfoundation/ac2-sdk/schema';
 import { normalizeX402FetchParams, x402FetchFlow } from '../x402/fetch-flow.js';
 
+const TOOL_BODY_LIMIT_CHARS = 32_000;
+
 function manifestTools(): ReadonlyArray<{
   name: string;
   parameters: unknown;
@@ -100,15 +102,33 @@ export function buildSignTool(): AnyAgentTool {
   return tool as unknown as AnyAgentTool;
 }
 
-function describeX402Result(result: Awaited<ReturnType<typeof x402FetchFlow>>): string {
+function truncateToolBody(text: string): string {
+  if (text.length <= TOOL_BODY_LIMIT_CHARS) return text;
+  return `${text.slice(0, TOOL_BODY_LIMIT_CHARS)}\n[truncated]`;
+}
+
+function responseBodyBlock(result: Awaited<ReturnType<typeof x402FetchFlow>>): string {
+  if (!('bodyJson' in result || 'bodyText' in result)) return '';
+
+  if ('bodyJson' in result && result.bodyJson !== undefined) {
+    return `\n\nResponse body:\n\`\`\`json\n${truncateToolBody(JSON.stringify(result.bodyJson, null, 2))}\n\`\`\``;
+  }
+  if ('bodyText' in result && result.bodyText !== undefined) {
+    const language = result.http?.contentType?.toLowerCase().includes('json') ? 'json' : 'text';
+    return `\n\nResponse body:\n\`\`\`${language}\n${truncateToolBody(result.bodyText)}\n\`\`\``;
+  }
+  return '';
+}
+
+export function describeX402Result(result: Awaited<ReturnType<typeof x402FetchFlow>>): string {
   if (result.status === 'paid') {
     const payment = result.selectedPayment
       ? ` Paid ${result.selectedPayment.amount} of ${result.selectedPayment.asset} on ${result.selectedPayment.network}.`
       : '';
-    return `x402 fetch succeeded with HTTP ${result.http.status}.${payment}`;
+    return `x402 fetch succeeded with HTTP ${result.http.status}.${payment}${responseBodyBlock(result)}`;
   }
   if (result.status === 'http_error') {
-    return `x402 fetch completed with HTTP ${result.http.status} ${result.http.statusText}.`;
+    return `x402 fetch completed with HTTP ${result.http.status} ${result.http.statusText}.${responseBodyBlock(result)}`;
   }
   if (result.status === 'payment_required') {
     const selected = result.selectedPayment
@@ -118,7 +138,7 @@ function describeX402Result(result: Awaited<ReturnType<typeof x402FetchFlow>>): 
     const responseStatus = result.paymentResponse?.paymentStatus
       ? ` x402 status: ${result.paymentResponse.paymentStatus}.`
       : '';
-    return `x402 fetch still requires payment: ${result.reason}${http}${responseStatus}${selected}`;
+    return `x402 fetch still requires payment: ${result.reason}${http}${responseStatus}${selected}${responseBodyBlock(result)}`;
   }
   if (result.status === 'rejected') {
     return `x402 payment rejected: ${result.reason}`;

--- a/packages/ac2-open-claw-reference/src/tools/index.ts
+++ b/packages/ac2-open-claw-reference/src/tools/index.ts
@@ -111,7 +111,14 @@ function describeX402Result(result: Awaited<ReturnType<typeof x402FetchFlow>>): 
     return `x402 fetch completed with HTTP ${result.http.status} ${result.http.statusText}.`;
   }
   if (result.status === 'payment_required') {
-    return `x402 fetch still requires payment: ${result.reason}`;
+    const selected = result.selectedPayment
+      ? ` Selected ${result.selectedPayment.amount} of ${result.selectedPayment.asset} on ${result.selectedPayment.network} to ${result.selectedPayment.payTo}.`
+      : '';
+    const http = result.http ? ` HTTP ${result.http.status} ${result.http.statusText}.` : '';
+    const responseStatus = result.paymentResponse?.paymentStatus
+      ? ` x402 status: ${result.paymentResponse.paymentStatus}.`
+      : '';
+    return `x402 fetch still requires payment: ${result.reason}${http}${responseStatus}${selected}`;
   }
   if (result.status === 'rejected') {
     return `x402 payment rejected: ${result.reason}`;

--- a/packages/ac2-open-claw-reference/src/tools/index.ts
+++ b/packages/ac2-open-claw-reference/src/tools/index.ts
@@ -8,6 +8,7 @@ import { getToolPluginMetadata } from '../session/contracts.js';
 import { NoActiveSessionError } from '../session/manager.js';
 import { capabilitiesFlow, signFlow, type SignParams } from '../session/flows.js';
 import type { SigningRequestBody } from '@algorandfoundation/ac2-sdk/schema';
+import { normalizeX402FetchParams, x402FetchFlow } from '../x402/fetch-flow.js';
 
 function manifestTools(): ReadonlyArray<{
   name: string;
@@ -48,6 +49,7 @@ export function buildSignTool(): AnyAgentTool {
       const signParams: SignParams = {
         description: String(params.description ?? ''),
         payload_base64: String(params.payload_base64 ?? ''),
+        ...(typeof params.schema === 'string' ? { schema: params.schema } : {}),
         ...(typeof params.sig_hint === 'string'
           ? { sig_hint: params.sig_hint as SigningRequestBody['sig_hint'] }
           : {}),
@@ -90,6 +92,61 @@ export function buildSignTool(): AnyAgentTool {
         const msg = err instanceof Error ? err.message : String(err);
         return {
           content: [textResult(`Sign error: ${msg}`)],
+          details: { status: 'error', error: msg },
+        };
+      }
+    },
+  };
+  return tool as unknown as AnyAgentTool;
+}
+
+function describeX402Result(result: Awaited<ReturnType<typeof x402FetchFlow>>): string {
+  if (result.status === 'paid') {
+    const payment = result.selectedPayment
+      ? ` Paid ${result.selectedPayment.amount} of ${result.selectedPayment.asset} on ${result.selectedPayment.network}.`
+      : '';
+    return `x402 fetch succeeded with HTTP ${result.http.status}.${payment}`;
+  }
+  if (result.status === 'http_error') {
+    return `x402 fetch completed with HTTP ${result.http.status} ${result.http.statusText}.`;
+  }
+  if (result.status === 'payment_required') {
+    return `x402 fetch still requires payment: ${result.reason}`;
+  }
+  if (result.status === 'rejected') {
+    return `x402 payment rejected: ${result.reason}`;
+  }
+  if (result.status === 'error') {
+    return `x402 fetch error: ${result.error}`;
+  }
+  return 'x402 fetch completed.';
+}
+
+export function buildX402FetchTool(): AnyAgentTool {
+  const tool = {
+    name: 'ac2_x402_fetch',
+    label: 'AC2 · x402 Fetch',
+    description: findToolDescription('ac2_x402_fetch'),
+    parameters: findToolParametersSchema('ac2_x402_fetch'),
+    async execute(
+      _toolCallId: string,
+      params: Record<string, unknown>,
+    ): Promise<{
+      content: Array<{ type: 'text'; text: string }>;
+      details: unknown;
+    }> {
+      const config = resolveConfig(getActiveApi() || ({} as any));
+      const fetchParams = normalizeX402FetchParams(params);
+      try {
+        const result = await x402FetchFlow(fetchParams, config);
+        return {
+          content: [textResult(describeX402Result(result))],
+          details: result,
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          content: [textResult(`x402 fetch error: ${msg}`)],
           details: { status: 'error', error: msg },
         };
       }

--- a/packages/ac2-open-claw-reference/src/tools/manifest.ts
+++ b/packages/ac2-open-claw-reference/src/tools/manifest.ts
@@ -1,4 +1,4 @@
-/** Tool-plugin manifest (`defineToolPlugin`): `ac2_sign` + `ac2_capabilities`. */
+/** Tool-plugin manifest (`defineToolPlugin`): AC2 signing, capabilities, and x402 fetch. */
 
 import { Type } from '@sinclair/typebox';
 import type { SigningRequestBody } from '@algorandfoundation/ac2-sdk/schema';
@@ -7,12 +7,13 @@ import type { SigningRequestBody } from '@algorandfoundation/ac2-sdk/schema';
 import { ConfigSchema, defineToolPlugin } from '../session/contracts.js';
 import { NoActiveSessionError } from '../session/manager.js';
 import { capabilitiesFlow, signFlow } from '../session/flows.js';
+import { normalizeX402FetchParams, x402FetchFlow } from '../x402/fetch-flow.js';
 
 const plugin = defineToolPlugin({
   id: 'ac2-open-claw-reference',
   name: 'AC2 Reference',
   description:
-    'Reference OpenClaw plugin for the AC2 protocol. The `ac2` channel owns pairing over Liquid Auth + WebRTC; the `ac2_sign` and `ac2_capabilities` tools route through that channel.',
+    'Reference OpenClaw plugin for the AC2 protocol. The `ac2` channel owns pairing over Liquid Auth + WebRTC; signing and x402 paid fetch tools route through that channel.',
   configSchema: ConfigSchema,
   tools: (tool) => [
     tool({
@@ -29,6 +30,12 @@ const plugin = defineToolPlugin({
           description:
             'Base64-encoded raw bytes the wallet will sign. The core reference signs these bytes as-is under the selected curve; downstream plugins may apply additional encodings based on `sig_hint`.',
         }),
+        schema: Type.Optional(
+          Type.String({
+            description:
+              'Optional schema identifier for the payload. Useful for wallet UX and domain-specific signing requests such as x402 Algorand payment bytes.',
+          }),
+        ),
         sig_hint: Type.Optional(
           Type.String({
             description:
@@ -61,6 +68,7 @@ const plugin = defineToolPlugin({
             {
               description: params.description ?? '',
               payload_base64: params.payload_base64 ?? '',
+              ...(params.schema !== undefined ? { schema: params.schema } : {}),
               ...(params.sig_hint !== undefined
                 ? { sig_hint: params.sig_hint as SigningRequestBody['sig_hint'] }
                 : {}),
@@ -106,6 +114,86 @@ const plugin = defineToolPlugin({
       }),
       async execute(_params, config, _context) {
         return capabilitiesFlow(config);
+      },
+    }),
+    tool({
+      name: 'ac2_x402_fetch',
+      label: 'AC2 x402 Fetch',
+      description:
+        'Fetch an HTTP(S) resource that may require x402 payment. When the server returns 402, this tool uses x402 exact payments on Algorand, asks the paired wallet to approve the required Algorand transaction signing over AC2, retries with PAYMENT-SIGNATURE, and returns the HTTP/payment result. Requires an active `ac2` channel.',
+      parameters: Type.Object({
+        url: Type.String({
+          description: 'Absolute HTTP(S) URL to fetch.',
+        }),
+        method: Type.Optional(
+          Type.Union(
+            [
+              Type.Literal('GET'),
+              Type.Literal('POST'),
+              Type.Literal('PUT'),
+              Type.Literal('PATCH'),
+              Type.Literal('DELETE'),
+            ],
+            {
+              description: 'HTTP method. Defaults to GET unless a body is supplied.',
+            },
+          ),
+        ),
+        headers: Type.Optional(
+          Type.Record(Type.String(), Type.String(), {
+            description: 'Optional HTTP headers for the request.',
+          }),
+        ),
+        body: Type.Optional(
+          Type.String({
+            description: 'Optional UTF-8 request body. Do not pass with body_base64.',
+          }),
+        ),
+        body_base64: Type.Optional(
+          Type.String({
+            description: 'Optional base64 request body for binary payloads. Do not pass with body.',
+          }),
+        ),
+        max_amount_atomic: Type.Optional(
+          Type.String({
+            description:
+              'Maximum payment amount in the asset atomic units. Defaults to plugin config x402MaxAmountAtomic or 1000000.',
+          }),
+        ),
+        allowed_networks: Type.Optional(
+          Type.Array(Type.String(), {
+            description:
+              'Per-call allow-list of x402 Algorand CAIP-2 networks. Defaults to plugin config or Algorand TestNet/MainNet.',
+          }),
+        ),
+        allowed_assets: Type.Optional(
+          Type.Array(Type.String(), {
+            description:
+              'Per-call allow-list of x402 assets. Defaults to plugin config or Algorand USDC.',
+          }),
+        ),
+        allowed_pay_to: Type.Optional(
+          Type.Array(Type.String(), {
+            description: 'Per-call allow-list of recipient Algorand addresses.',
+          }),
+        ),
+        network_preferences: Type.Optional(
+          Type.Array(Type.String(), {
+            description:
+              'Preferred x402 Algorand networks when a resource offers several accepted options.',
+          }),
+        ),
+        include_response_body: Type.Optional(
+          Type.Boolean({
+            description:
+              'Whether to include the response body text/JSON in the tool result. Defaults to true.',
+            default: true,
+          }),
+        ),
+      }),
+      async execute(params, config, context) {
+        context.signal?.throwIfAborted();
+        return x402FetchFlow(normalizeX402FetchParams(params), config, {}, context);
       },
     }),
   ],

--- a/packages/ac2-open-claw-reference/src/x402/ac2-avm-signer.ts
+++ b/packages/ac2-open-claw-reference/src/x402/ac2-avm-signer.ts
@@ -16,7 +16,12 @@ import type { PaymentRequirements, ResourceInfo } from '@x402/core/types';
 import { extractEd25519PublicKey } from '../identity/did.js';
 import type { PluginConfig, ToolContext } from '../session/contracts.js';
 import { signFlow, type SignDeps } from '../session/flows.js';
-import { NoActiveSessionError, sessionManager, type SessionManager } from '../session/manager.js';
+import {
+  NoActiveSessionError,
+  sessionManager,
+  type ActiveSession,
+  type SessionManager,
+} from '../session/manager.js';
 
 export const X402_ALGORAND_SIGNING_SCHEMA =
   'x402/exact/algorand/v2/transaction-signing-bytes';
@@ -63,6 +68,13 @@ export function controllerDidToAlgorandAddress(controllerDid: string): string | 
   if (!publicKey) return undefined;
   const address = encodeAddress(publicKey);
   return isValidAddress(address) ? address : undefined;
+}
+
+function sessionAlgorandAddress(active: ActiveSession): string | undefined {
+  if (active.walletAddress && isValidAddress(active.walletAddress)) {
+    return active.walletAddress;
+  }
+  return controllerDidToAlgorandAddress(active.controllerDid);
 }
 
 function decodeUnsignedTransaction(txnBytes: Uint8Array, index: number): Transaction {
@@ -163,7 +175,7 @@ function assertSignature(bytes: Uint8Array, index: number): void {
 export function createAc2AvmSigner(options: Ac2AvmSignerOptions): ClientAvmSigner {
   const manager = managerFromDeps(options.deps);
   const active = manager.requireActive();
-  const address = controllerDidToAlgorandAddress(active.controllerDid);
+  const address = sessionAlgorandAddress(active);
   if (!address) throw new X402ControllerAddressError(active.controllerDid);
 
   return {

--- a/packages/ac2-open-claw-reference/src/x402/ac2-avm-signer.ts
+++ b/packages/ac2-open-claw-reference/src/x402/ac2-avm-signer.ts
@@ -1,0 +1,260 @@
+/** AC2-backed Algorand signer adapter for x402's AVM client scheme. */
+
+import { Buffer } from 'node:buffer';
+
+import { encodeAddress, isValidAddress } from '@algorandfoundation/algokit-utils/common';
+import {
+  bytesForSigning,
+  decodeTransaction,
+  encodeSignedTransaction,
+  TransactionType,
+  type Transaction,
+} from '@algorandfoundation/algokit-utils/transact';
+import type { ClientAvmSigner } from '@x402/avm';
+import type { PaymentRequirements, ResourceInfo } from '@x402/core/types';
+
+import { extractEd25519PublicKey } from '../identity/did.js';
+import type { PluginConfig, ToolContext } from '../session/contracts.js';
+import { signFlow, type SignDeps } from '../session/flows.js';
+import { NoActiveSessionError, sessionManager, type SessionManager } from '../session/manager.js';
+
+export const X402_ALGORAND_SIGNING_SCHEMA =
+  'x402/exact/algorand/v2/transaction-signing-bytes';
+
+export interface X402PaymentContext {
+  readonly requirements?: PaymentRequirements;
+  readonly resource?: ResourceInfo;
+}
+
+export interface Ac2AvmSignerOptions {
+  readonly config: PluginConfig;
+  readonly deps?: SignDeps;
+  readonly context?: ToolContext;
+  readonly getPaymentContext?: () => X402PaymentContext | undefined;
+}
+
+export class X402SigningRejectedError extends Error {
+  readonly code = 'x402_signing_rejected' as const;
+  constructor(reason: string) {
+    super(`x402 payment signing rejected: ${reason}`);
+    this.name = 'X402SigningRejectedError';
+  }
+}
+
+export class X402ControllerAddressError extends Error {
+  readonly code = 'x402_controller_address_unavailable' as const;
+  constructor(controllerDid: string) {
+    super(`Active AC2 controller DID is not an Algorand account address: ${controllerDid}`);
+    this.name = 'X402ControllerAddressError';
+  }
+}
+
+function managerFromDeps(deps?: SignDeps): SessionManager {
+  return deps?.manager ?? sessionManager;
+}
+
+export function controllerDidToAlgorandAddress(controllerDid: string): string | undefined {
+  const raw = controllerDid.startsWith('did:key:')
+    ? controllerDid.slice('did:key:'.length)
+    : controllerDid;
+  if (isValidAddress(raw)) return raw;
+
+  const publicKey = extractEd25519PublicKey(controllerDid);
+  if (!publicKey) return undefined;
+  const address = encodeAddress(publicKey);
+  return isValidAddress(address) ? address : undefined;
+}
+
+function decodeUnsignedTransaction(txnBytes: Uint8Array, index: number): Transaction {
+  try {
+    return decodeTransaction(txnBytes);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Unable to decode x402 Algorand transaction at index ${index}: ${msg}`);
+  }
+}
+
+function formatAmount(amount: bigint | undefined): string {
+  return amount === undefined ? 'unknown amount' : amount.toString();
+}
+
+function summarizeTransaction(txn: Transaction): string {
+  if (txn.type === TransactionType.AssetTransfer && txn.assetTransfer) {
+    const xfer = txn.assetTransfer;
+    return [
+      'ASA transfer',
+      `asset ${xfer.assetId.toString()}`,
+      `amount ${formatAmount(xfer.amount)}`,
+      `to ${xfer.receiver.toString()}`,
+    ].join(' · ');
+  }
+
+  if (txn.type === TransactionType.Payment && txn.payment) {
+    const payment = txn.payment;
+    return [
+      'ALGO payment',
+      `${formatAmount(payment.amount)} microAlgos`,
+      `to ${payment.receiver.toString()}`,
+    ].join(' · ');
+  }
+
+  return `Algorand ${txn.type} transaction`;
+}
+
+function formatResource(resource?: ResourceInfo): string {
+  if (!resource) return '';
+  const parts = [
+    resource.description,
+    resource.serviceName,
+    resource.url,
+    resource.mimeType,
+  ].filter((v): v is string => typeof v === 'string' && v.trim().length > 0);
+  return parts.length > 0 ? `\nResource: ${parts.join(' · ')}` : '';
+}
+
+function buildSigningDescription(args: {
+  readonly txn: Transaction;
+  readonly txnIndex: number;
+  readonly groupSize: number;
+  readonly signerAddress: string;
+  readonly paymentContext?: X402PaymentContext;
+}): string {
+  const req = args.paymentContext?.requirements;
+  const requirementLine = req
+    ? [
+        `x402 exact payment`,
+        `network ${req.network}`,
+        `asset ${req.asset}`,
+        `amount ${req.amount}`,
+        `payTo ${req.payTo}`,
+      ].join(' · ')
+    : 'x402 exact Algorand payment';
+
+  return [
+    requirementLine,
+    `Sign transaction ${args.txnIndex + 1} of ${args.groupSize} as ${args.signerAddress}.`,
+    summarizeTransaction(args.txn),
+    `Sender: ${args.txn.sender.toString()}`,
+    formatResource(args.paymentContext?.resource),
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+function base64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64');
+}
+
+function normalizeIndexes(indexesToSign: number[] | undefined, groupSize: number): Set<number> {
+  if (indexesToSign === undefined) {
+    return new Set(Array.from({ length: groupSize }, (_v, i) => i));
+  }
+  return new Set(indexesToSign);
+}
+
+function assertSignature(bytes: Uint8Array, index: number): void {
+  if (bytes.length !== 64) {
+    throw new Error(
+      `Wallet returned ${bytes.length} bytes for x402 transaction ${index + 1}; expected a 64-byte Ed25519 signature.`,
+    );
+  }
+}
+
+export function createAc2AvmSigner(options: Ac2AvmSignerOptions): ClientAvmSigner {
+  const manager = managerFromDeps(options.deps);
+  const active = manager.requireActive();
+  const address = controllerDidToAlgorandAddress(active.controllerDid);
+  if (!address) throw new X402ControllerAddressError(active.controllerDid);
+
+  return {
+    address,
+    async signTransactions(
+      txns: Uint8Array[],
+      indexesToSign?: number[],
+    ): Promise<(Uint8Array | null)[]> {
+      const signerIndexes = normalizeIndexes(indexesToSign, txns.length);
+      const signed: (Uint8Array | null)[] = [];
+
+      for (let i = 0; i < txns.length; i++) {
+        options.context?.signal?.throwIfAborted();
+        if (!signerIndexes.has(i)) {
+          signed.push(null);
+          continue;
+        }
+
+        const unsignedBytes = txns[i];
+        if (!unsignedBytes) {
+          throw new Error(`Missing x402 Algorand transaction at index ${i}.`);
+        }
+
+        const txn = decodeUnsignedTransaction(unsignedBytes, i);
+        const sender = txn.sender.toString();
+        if (sender !== address) {
+          throw new Error(
+            `x402 transaction ${i + 1} has sender ${sender}, but the active AC2 wallet is ${address}.`,
+          );
+        }
+
+        const signingBytes = bytesForSigning.transaction(txn);
+        const paymentContext = options.getPaymentContext?.();
+        const result = await signFlow(
+          {
+            description: buildSigningDescription({
+              txn,
+              txnIndex: i,
+              groupSize: txns.length,
+              signerAddress: address,
+              ...(paymentContext !== undefined ? { paymentContext } : {}),
+            }),
+            payload_base64: base64(signingBytes),
+            schema: X402_ALGORAND_SIGNING_SCHEMA,
+            sig_hint: 'raw-ed25519',
+            display_hint: 'hex',
+            key_type: 'account',
+          },
+          options.config,
+          options.deps,
+          options.context,
+        );
+
+        if (result.status === 'rejected') {
+          throw new X402SigningRejectedError(result.reason);
+        }
+        if (result.address !== undefined && result.address !== address) {
+          throw new Error(
+            `Wallet signed x402 transaction with ${result.address}, expected ${address}.`,
+          );
+        }
+
+        const signature = new Uint8Array(Buffer.from(result.signature, 'base64'));
+        assertSignature(signature, i);
+        signed.push(encodeSignedTransaction({ txn, sig: signature }));
+      }
+
+      return signed;
+    },
+  };
+}
+
+export function classifyX402SigningError(err: unknown):
+  | { status: 'rejected'; reason: string }
+  | { status: 'error'; reason: string } {
+  if (err instanceof NoActiveSessionError) {
+    return { status: 'rejected', reason: err.code };
+  }
+  if (err instanceof X402SigningRejectedError) {
+    return { status: 'rejected', reason: err.message };
+  }
+  if (err instanceof X402ControllerAddressError) {
+    return { status: 'error', reason: err.message };
+  }
+
+  const message = err instanceof Error ? err.message : String(err);
+  if (message.includes('no_active_session')) {
+    return { status: 'rejected', reason: 'no_active_session' };
+  }
+  if (message.includes('x402 payment signing rejected')) {
+    return { status: 'rejected', reason: message };
+  }
+  return { status: 'error', reason: message };
+}

--- a/packages/ac2-open-claw-reference/src/x402/fetch-flow.ts
+++ b/packages/ac2-open-claw-reference/src/x402/fetch-flow.ts
@@ -14,6 +14,7 @@ import {
   wrapFetchWithPayment,
   x402Client,
   x402HTTPClient,
+  type HTTPResourceResponse,
   type PaymentPolicy,
   type PaymentRequired,
   type PaymentRequirements,
@@ -79,7 +80,18 @@ export type X402FetchResult =
   | {
       status: 'payment_required';
       url: string;
+      http?: {
+        status: number;
+        ok: boolean;
+        statusText: string;
+        contentType?: string;
+      };
       paymentRequired?: PaymentRequired;
+      paymentResponse?: HTTPResourceResponse;
+      selectedPayment?: X402PaymentSelection;
+      paymentPayload?: PaymentPayload;
+      bodyText?: string;
+      bodyJson?: unknown;
       reason: string;
     }
   | {
@@ -245,6 +257,30 @@ function paymentRequiredFromResponse(
   }
 }
 
+function paymentResultFromResponse(
+  httpClient: x402HTTPClient,
+  response: Response,
+  body: { bodyText?: string; bodyJson?: unknown },
+): HTTPResourceResponse | undefined {
+  try {
+    return httpClient.parsePaymentResult({
+      status: response.status,
+      getHeader: (name) => response.headers.get(name),
+      body: body.bodyJson ?? body.bodyText ?? null,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+function paymentRequiredReason(paymentRequired: PaymentRequired | undefined): string {
+  const serverError = paymentRequired?.error?.trim();
+  if (serverError) {
+    return `The resource returned 402 after x402 payment negotiation: ${serverError}`;
+  }
+  return 'The resource still returned 402 after x402 payment negotiation.';
+}
+
 export async function x402FetchFlow(
   params: X402FetchParams,
   config: PluginConfig,
@@ -317,11 +353,24 @@ export async function x402FetchFlow(
 
     if (isPaymentRequiredResponse(response)) {
       const paymentRequired = paymentRequiredFromResponse(httpClient, response, body.bodyJson);
+      const paymentResponse = paymentResultFromResponse(httpClient, response, body);
       return {
         status: 'payment_required',
         url,
+        http: {
+          status: response.status,
+          ok: response.ok,
+          statusText: response.statusText,
+          ...(response.headers.get('content-type') !== null
+            ? { contentType: response.headers.get('content-type') as string }
+            : {}),
+        },
         ...(paymentRequired !== undefined ? { paymentRequired } : {}),
-        reason: 'The resource still returned 402 after x402 payment negotiation.',
+        ...(paymentResponse !== undefined ? { paymentResponse } : {}),
+        ...(selectedPayment !== undefined ? { selectedPayment } : {}),
+        ...(paymentPayload !== undefined ? { paymentPayload } : {}),
+        ...body,
+        reason: paymentRequiredReason(paymentRequired),
       };
     }
 

--- a/packages/ac2-open-claw-reference/src/x402/fetch-flow.ts
+++ b/packages/ac2-open-claw-reference/src/x402/fetch-flow.ts
@@ -1,0 +1,380 @@
+/** Paid HTTP fetch flow for x402 exact payments on Algorand. */
+
+import { Buffer } from 'node:buffer';
+
+import {
+  ALGORAND_MAINNET_CAIP2,
+  ALGORAND_TESTNET_CAIP2,
+  isAlgorandNetwork,
+  USDC_MAINNET_ASA_ID,
+  USDC_TESTNET_ASA_ID,
+} from '@x402/avm';
+import { ExactAvmScheme } from '@x402/avm/exact/client';
+import {
+  wrapFetchWithPayment,
+  x402Client,
+  x402HTTPClient,
+  type PaymentPolicy,
+  type PaymentRequired,
+  type PaymentRequirements,
+  type SelectPaymentRequirements,
+} from '@x402/fetch';
+import type { PaymentPayload, ResourceInfo, SettleResponse } from '@x402/core/types';
+import type { Network } from '@x402/core/types';
+
+import type { PluginConfig, ToolContext } from '../session/contracts.js';
+import type { SignDeps } from '../session/flows.js';
+import { NoActiveSessionError } from '../session/manager.js';
+import {
+  classifyX402SigningError,
+  createAc2AvmSigner,
+  type X402PaymentContext,
+} from './ac2-avm-signer.js';
+
+const DEFAULT_MAX_AMOUNT_ATOMIC = '1000000';
+const DEFAULT_ALLOWED_NETWORKS = [ALGORAND_TESTNET_CAIP2, ALGORAND_MAINNET_CAIP2] as const;
+const DEFAULT_ALLOWED_ASSETS = [USDC_TESTNET_ASA_ID, USDC_MAINNET_ASA_ID, 'USDC'] as const;
+const RESPONSE_BODY_LIMIT_BYTES = 128 * 1024;
+
+export interface X402FetchParams {
+  url: string;
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+  body_base64?: string;
+  max_amount_atomic?: string;
+  allowed_networks?: string[];
+  allowed_assets?: string[];
+  allowed_pay_to?: string[];
+  network_preferences?: string[];
+  include_response_body?: boolean;
+}
+
+export interface X402PaymentSelection {
+  readonly x402Version: number;
+  readonly scheme: string;
+  readonly network: string;
+  readonly asset: string;
+  readonly amount: string;
+  readonly payTo: string;
+  readonly resource?: ResourceInfo;
+}
+
+export type X402FetchResult =
+  | {
+      status: 'paid' | 'http_error';
+      url: string;
+      http: {
+        status: number;
+        ok: boolean;
+        statusText: string;
+        contentType?: string;
+      };
+      selectedPayment?: X402PaymentSelection;
+      paymentPayload?: PaymentPayload;
+      settlement?: SettleResponse;
+      bodyText?: string;
+      bodyJson?: unknown;
+    }
+  | {
+      status: 'payment_required';
+      url: string;
+      paymentRequired?: PaymentRequired;
+      reason: string;
+    }
+  | {
+      status: 'rejected';
+      url: string;
+      reason: string;
+    }
+  | {
+      status: 'error';
+      url: string;
+      error: string;
+    };
+
+interface PolicyOptions {
+  readonly maxAmountAtomic: bigint;
+  readonly allowedNetworks: ReadonlySet<string>;
+  readonly allowedAssets: ReadonlySet<string>;
+  readonly allowedPayTo?: ReadonlySet<string>;
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  return Array.from(new Set(values.map((v) => v.trim()).filter(Boolean)));
+}
+
+function configStringArray(value: unknown): string[] | undefined {
+  return Array.isArray(value) && value.every((v) => typeof v === 'string') ? value : undefined;
+}
+
+function resolveAllowedNetworks(params: X402FetchParams, config: PluginConfig): string[] {
+  return uniqueStrings(
+    params.allowed_networks ??
+      config.x402AllowedNetworks ??
+      (DEFAULT_ALLOWED_NETWORKS as readonly string[]),
+  );
+}
+
+function resolveAllowedAssets(params: X402FetchParams, config: PluginConfig): string[] {
+  return uniqueStrings(
+    params.allowed_assets ?? config.x402AllowedAssets ?? (DEFAULT_ALLOWED_ASSETS as readonly string[]),
+  );
+}
+
+function resolveAllowedPayTo(params: X402FetchParams, config: PluginConfig): string[] | undefined {
+  const values = params.allowed_pay_to ?? config.x402AllowedPayTo;
+  return values ? uniqueStrings(values) : undefined;
+}
+
+function resolveMaxAmount(params: X402FetchParams, config: PluginConfig): bigint {
+  const raw = params.max_amount_atomic ?? config.x402MaxAmountAtomic ?? DEFAULT_MAX_AMOUNT_ATOMIC;
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`max_amount_atomic must be an unsigned integer string, got ${JSON.stringify(raw)}.`);
+  }
+  return BigInt(raw);
+}
+
+function buildPaymentPolicy(options: PolicyOptions): PaymentPolicy {
+  return (_version, requirements) =>
+    requirements.filter((req) => {
+      if (req.scheme !== 'exact') return false;
+      if (!isAlgorandNetwork(req.network)) return false;
+      if (!options.allowedNetworks.has(req.network)) return false;
+      if (!options.allowedAssets.has(req.asset)) return false;
+      try {
+        if (BigInt(req.amount) > options.maxAmountAtomic) return false;
+      } catch {
+        return false;
+      }
+      if (options.allowedPayTo && !options.allowedPayTo.has(req.payTo)) return false;
+      return true;
+    });
+}
+
+function buildSelector(preferences: readonly string[]): SelectPaymentRequirements {
+  const preferred = uniqueStrings(preferences);
+  return (_version, requirements) => {
+    for (const network of preferred) {
+      const match = requirements.find((req) => req.network === network);
+      if (match) return match;
+    }
+    return requirements[0] as PaymentRequirements;
+  };
+}
+
+function createRequestInit(params: X402FetchParams, context: ToolContext): RequestInit {
+  if (params.body !== undefined && params.body_base64 !== undefined) {
+    throw new Error('Pass either body or body_base64, not both.');
+  }
+
+  const method = (params.method ?? (params.body || params.body_base64 ? 'POST' : 'GET')).toUpperCase();
+  const init: RequestInit = { method };
+  if (params.headers !== undefined) init.headers = params.headers;
+  if (context.signal !== undefined) init.signal = context.signal;
+  if (params.body !== undefined) {
+    init.body = params.body;
+  } else if (params.body_base64 !== undefined) {
+    init.body = Buffer.from(params.body_base64, 'base64');
+  }
+  return init;
+}
+
+function selectedPaymentFromContext(
+  x402Version: number,
+  requirements: PaymentRequirements,
+  resource?: ResourceInfo,
+): X402PaymentSelection {
+  return {
+    x402Version,
+    scheme: requirements.scheme,
+    network: requirements.network,
+    asset: requirements.asset,
+    amount: requirements.amount,
+    payTo: requirements.payTo,
+    ...(resource !== undefined ? { resource } : {}),
+  };
+}
+
+function parseSettleResponse(httpClient: x402HTTPClient, response: Response): SettleResponse | undefined {
+  try {
+    return httpClient.getPaymentSettleResponse((name) => response.headers.get(name));
+  } catch {
+    return undefined;
+  }
+}
+
+async function readResponseBody(
+  response: Response,
+  includeBody: boolean,
+): Promise<{ bodyText?: string; bodyJson?: unknown }> {
+  if (!includeBody) return {};
+  const cloned = response.clone();
+  const bytes = new Uint8Array(await cloned.arrayBuffer());
+  const limited = bytes.subarray(0, RESPONSE_BODY_LIMIT_BYTES);
+  const suffix = bytes.length > RESPONSE_BODY_LIMIT_BYTES ? '\n[truncated]' : '';
+  const bodyText = Buffer.from(limited).toString('utf8') + suffix;
+  const contentType = response.headers.get('content-type') ?? '';
+
+  if (contentType.toLowerCase().includes('json') && bodyText.length > 0 && !suffix) {
+    try {
+      return { bodyText, bodyJson: JSON.parse(bodyText) };
+    } catch {
+      return { bodyText };
+    }
+  }
+  return { bodyText };
+}
+
+function isPaymentRequiredResponse(response: Response): boolean {
+  return response.status === 402;
+}
+
+function paymentRequiredFromResponse(
+  httpClient: x402HTTPClient,
+  response: Response,
+  bodyJson: unknown,
+): PaymentRequired | undefined {
+  try {
+    return httpClient.getPaymentRequiredResponse(
+      (name) => response.headers.get(name),
+      bodyJson,
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+export async function x402FetchFlow(
+  params: X402FetchParams,
+  config: PluginConfig,
+  deps: SignDeps = {},
+  context: ToolContext = {},
+): Promise<X402FetchResult> {
+  context.signal?.throwIfAborted();
+  const url = params.url.trim();
+  if (!/^https?:\/\//i.test(url)) {
+    return { status: 'error', url, error: 'url must be an absolute HTTP(S) URL.' };
+  }
+
+  let paymentContext: X402PaymentContext = {};
+  let selectedPayment: X402PaymentSelection | undefined;
+  let paymentPayload: PaymentPayload | undefined;
+
+  try {
+    const signer = createAc2AvmSigner({
+      config,
+      deps,
+      context,
+      getPaymentContext: () => paymentContext,
+    });
+
+    const allowedNetworks = resolveAllowedNetworks(params, config);
+    const allowedAssets = resolveAllowedAssets(params, config);
+    const allowedPayTo = resolveAllowedPayTo(params, config);
+    const maxAmountAtomic = resolveMaxAmount(params, config);
+    const networkPreferences = uniqueStrings(
+      params.network_preferences ?? config.x402NetworkPreferences ?? allowedNetworks,
+    );
+
+    const client = new x402Client(buildSelector(networkPreferences));
+    const schemeConfig: ConstructorParameters<typeof ExactAvmScheme>[1] = {
+      ...(config.x402AlgodUrl !== undefined ? { algodUrl: config.x402AlgodUrl } : {}),
+      ...(config.x402AlgodToken !== undefined ? { algodToken: config.x402AlgodToken } : {}),
+    };
+    for (const network of allowedNetworks) {
+      client.register(network as Network, new ExactAvmScheme(signer, schemeConfig));
+    }
+
+    client.registerPolicy(
+      buildPaymentPolicy({
+        maxAmountAtomic,
+        allowedNetworks: new Set(allowedNetworks),
+        allowedAssets: new Set(allowedAssets),
+        ...(allowedPayTo !== undefined ? { allowedPayTo: new Set(allowedPayTo) } : {}),
+      }),
+    );
+    client.onBeforePaymentCreation(async (ctx) => {
+      paymentContext = {
+        requirements: ctx.selectedRequirements,
+        resource: ctx.paymentRequired.resource,
+      };
+      selectedPayment = selectedPaymentFromContext(
+        ctx.paymentRequired.x402Version,
+        ctx.selectedRequirements,
+        ctx.paymentRequired.resource,
+      );
+    });
+    client.onAfterPaymentCreation(async (ctx) => {
+      paymentPayload = ctx.paymentPayload;
+    });
+
+    const httpClient = new x402HTTPClient(client);
+    const fetchWithPayment = wrapFetchWithPayment(globalThis.fetch, httpClient);
+    const response = await fetchWithPayment(url, createRequestInit(params, context));
+    const includeBody = params.include_response_body !== false;
+    const body = await readResponseBody(response, includeBody);
+
+    if (isPaymentRequiredResponse(response)) {
+      const paymentRequired = paymentRequiredFromResponse(httpClient, response, body.bodyJson);
+      return {
+        status: 'payment_required',
+        url,
+        ...(paymentRequired !== undefined ? { paymentRequired } : {}),
+        reason: 'The resource still returned 402 after x402 payment negotiation.',
+      };
+    }
+
+    const settlement = parseSettleResponse(httpClient, response);
+    return {
+      status: response.ok ? 'paid' : 'http_error',
+      url,
+      http: {
+        status: response.status,
+        ok: response.ok,
+        statusText: response.statusText,
+        ...(response.headers.get('content-type') !== null
+          ? { contentType: response.headers.get('content-type') as string }
+          : {}),
+      },
+      ...(selectedPayment !== undefined ? { selectedPayment } : {}),
+      ...(paymentPayload !== undefined ? { paymentPayload } : {}),
+      ...(settlement !== undefined ? { settlement } : {}),
+      ...body,
+    };
+  } catch (err) {
+    if (err instanceof NoActiveSessionError) {
+      return { status: 'rejected', url, reason: err.code };
+    }
+    const classified = classifyX402SigningError(err);
+    if (classified.status === 'rejected') {
+      return { status: 'rejected', url, reason: classified.reason };
+    }
+    return { status: 'error', url, error: classified.reason };
+  }
+}
+
+export function normalizeX402FetchParams(params: Record<string, unknown>): X402FetchParams {
+  const out: X402FetchParams = { url: String(params.url ?? '') };
+  if (typeof params.method === 'string') out.method = params.method;
+  if (params.headers !== null && typeof params.headers === 'object' && !Array.isArray(params.headers)) {
+    out.headers = params.headers as Record<string, string>;
+  }
+  if (typeof params.body === 'string') out.body = params.body;
+  if (typeof params.body_base64 === 'string') out.body_base64 = params.body_base64;
+  if (typeof params.max_amount_atomic === 'string') {
+    out.max_amount_atomic = params.max_amount_atomic;
+  }
+  const allowedNetworks = configStringArray(params.allowed_networks);
+  if (allowedNetworks !== undefined) out.allowed_networks = allowedNetworks;
+  const allowedAssets = configStringArray(params.allowed_assets);
+  if (allowedAssets !== undefined) out.allowed_assets = allowedAssets;
+  const allowedPayTo = configStringArray(params.allowed_pay_to);
+  if (allowedPayTo !== undefined) out.allowed_pay_to = allowedPayTo;
+  const networkPreferences = configStringArray(params.network_preferences);
+  if (networkPreferences !== undefined) out.network_preferences = networkPreferences;
+  if (typeof params.include_response_body === 'boolean') {
+    out.include_response_body = params.include_response_body;
+  }
+  return out;
+}

--- a/packages/ac2-open-claw-reference/src/x402/index.ts
+++ b/packages/ac2-open-claw-reference/src/x402/index.ts
@@ -1,0 +1,19 @@
+/** x402 integration helpers for the AC2 OpenClaw reference plugin. */
+
+export {
+  X402_ALGORAND_SIGNING_SCHEMA,
+  X402ControllerAddressError,
+  X402SigningRejectedError,
+  classifyX402SigningError,
+  controllerDidToAlgorandAddress,
+  createAc2AvmSigner,
+  type Ac2AvmSignerOptions,
+  type X402PaymentContext,
+} from './ac2-avm-signer.js';
+export {
+  normalizeX402FetchParams,
+  x402FetchFlow,
+  type X402FetchParams,
+  type X402FetchResult,
+  type X402PaymentSelection,
+} from './fetch-flow.js';

--- a/packages/ac2-open-claw-reference/tests/plugin.test.ts
+++ b/packages/ac2-open-claw-reference/tests/plugin.test.ts
@@ -10,8 +10,17 @@ import {
   isSigningRequest,
   type AC2BaseMessage as Ac2Message,
   type AC2KeyRequest as KeyRequestMessage,
+  type AC2SigningRequest as SigningRequestMessage,
 } from '@algorandfoundation/ac2-sdk/schema';
 import type { Ac2Transport } from '@algorandfoundation/ac2-sdk/transport';
+import { Address } from '@algorandfoundation/algokit-utils/common';
+import {
+  bytesForSigning,
+  decodeSignedTransaction,
+  encodeTransactionRaw,
+  Transaction,
+  TransactionType,
+} from '@algorandfoundation/algokit-utils/transact';
 import {
   signFlow,
   capabilitiesFlow,
@@ -26,7 +35,10 @@ import {
   AC2_MEDIA_SOURCE_PARAMS,
   getToolPluginMetadata,
   pluginManifest as plugin,
+  createAc2AvmSigner,
+  X402_ALGORAND_SIGNING_SCHEMA,
 } from '../src/index.js';
+import { publicKeyToDidKey } from '../src/identity/did.js';
 
 /**
  * Stub controller DID used by the in-memory provider — the wallet's
@@ -133,6 +145,7 @@ describe('ac2-open-claw-reference plugin', () => {
     const names = (metadata?.tools ?? []).map((t) => t.name);
     expect(names).toContain('ac2_sign');
     expect(names).toContain('ac2_capabilities');
+    expect(names).toContain('ac2_x402_fetch');
   });
 
   it('exposes the ac2 channel via the channel object', () => {
@@ -199,7 +212,9 @@ describe('ac2-open-claw-reference plugin', () => {
 
   describe('signFlow through an active channel', () => {
     it('round-trips a SigningRequest/Response across the channel session', async () => {
+      let observedSchema: string | undefined;
       const provider = makeClient((req, peer) => {
+        observedSchema = (req as SigningRequestMessage).body.schema;
         peer.send(
           JSON.stringify(
             buildSigningResponse({
@@ -221,6 +236,7 @@ describe('ac2-open-claw-reference plugin', () => {
           {
             description: 'Sign test payload',
             payload_base64: Buffer.from('hello').toString('base64'),
+            schema: 'test/schema',
             sig_hint: 'raw-ed25519',
           },
           { defaultTimeoutMs: 2_000 },
@@ -232,6 +248,7 @@ describe('ac2-open-claw-reference plugin', () => {
           expect(outcome.public_key).toBe(Buffer.from('pk').toString('base64'));
           expect(outcome.key_type).toBe('account');
         }
+        expect(observedSchema).toBe('test/schema');
       } finally {
         await teardown();
       }
@@ -292,6 +309,90 @@ describe('ac2-open-claw-reference plugin', () => {
       } finally {
         await teardown();
       }
+    });
+  });
+
+  describe('x402 Algorand signing adapter', () => {
+    it('wraps wallet-approved Ed25519 signatures into signed Algorand transactions', async () => {
+      const sender = new Address(new Uint8Array(32).fill(1));
+      const receiver = new Address(new Uint8Array(32).fill(2));
+      const txn = new Transaction({
+        type: TransactionType.AssetTransfer,
+        sender,
+        fee: 1_000n,
+        firstValid: 1n,
+        lastValid: 1_000n,
+        genesisHash: new Uint8Array(32).fill(3),
+        genesisId: 'testnet-v1.0',
+        assetTransfer: {
+          assetId: 10_458_941n,
+          amount: 123n,
+          receiver,
+        },
+      });
+      const unsignedTxn = encodeTransactionRaw(txn);
+      const expectedPayload = Buffer.from(bytesForSigning.transaction(txn)).toString('base64');
+      const rawUnsignedPayload = Buffer.from(unsignedTxn).toString('base64');
+      const signature = new Uint8Array(64).fill(7);
+      let observedRequest: any;
+
+      const manager = new SessionManager();
+      manager.setActive({
+        transport: {} as never,
+        client: {
+          requestSignature: async (args: any) => {
+            observedRequest = args;
+            return {
+              kind: 'response',
+              message: {
+                thid: 'x402-thread',
+                body: {
+                  signature: Buffer.from(signature).toString('base64'),
+                  public_key: Buffer.from(sender.publicKey).toString('base64'),
+                  address: sender.toString(),
+                  key_type: 'account',
+                },
+              },
+            };
+          },
+        } as never,
+        controllerDid: publicKeyToDidKey(sender.publicKey),
+        agentDid: STUB_AGENT_DID,
+      });
+
+      const signer = createAc2AvmSigner({
+        config: { defaultTimeoutMs: 2_000 },
+        deps: { manager },
+        getPaymentContext: () => ({
+          requirements: {
+            scheme: 'exact',
+            network: 'algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
+            asset: '10458941',
+            amount: '123',
+            payTo: receiver.toString(),
+            maxTimeoutSeconds: 60,
+            extra: {},
+          },
+        }),
+      });
+
+      expect(signer.address).toBe(sender.toString());
+      const signed = await signer.signTransactions([unsignedTxn], [0]);
+      expect(signed).toHaveLength(1);
+      expect(signed[0]).toBeInstanceOf(Uint8Array);
+
+      const decoded = decodeSignedTransaction(signed[0]!);
+      expect(decoded.txn.txId()).toBe(txn.txId());
+      expect(Buffer.from(decoded.sig ?? new Uint8Array()).toString('base64')).toBe(
+        Buffer.from(signature).toString('base64'),
+      );
+      expect(observedRequest.body.schema).toBe(X402_ALGORAND_SIGNING_SCHEMA);
+      expect(observedRequest.body.sig_hint).toBe('raw-ed25519');
+      expect(observedRequest.body.key_type).toBe('account');
+      expect(observedRequest.body.payload).toBe(expectedPayload);
+      expect(observedRequest.body.payload).not.toBe(rawUnsignedPayload);
+      expect(observedRequest.body.description).toContain('x402 exact payment');
+      expect(observedRequest.body.description).toContain(receiver.toString());
     });
   });
 

--- a/packages/ac2-open-claw-reference/tests/plugin.test.ts
+++ b/packages/ac2-open-claw-reference/tests/plugin.test.ts
@@ -38,6 +38,7 @@ import {
   createAc2AvmSigner,
   X402_ALGORAND_SIGNING_SCHEMA,
 } from '../src/index.js';
+import { describeX402Result } from '../src/tools/index.js';
 import { publicKeyToDidKey } from '../src/identity/did.js';
 
 /**
@@ -450,6 +451,44 @@ describe('ac2-open-claw-reference plugin', () => {
       expect(signed[0]).toBeInstanceOf(Uint8Array);
       expect(observedRequest.body.description).toContain(`as ${sender.toString()}`);
       expect(observedRequest.body.description).toContain(`Sender: ${sender.toString()}`);
+    });
+  });
+
+  describe('x402 fetch tool response rendering', () => {
+    it('includes successful JSON response bodies in visible tool content', () => {
+      const text = describeX402Result({
+        status: 'paid',
+        url: 'https://example.test/weather',
+        http: {
+          status: 200,
+          ok: true,
+          statusText: 'OK',
+          contentType: 'application/json',
+        },
+        bodyText: '{"temperature":72}',
+        bodyJson: { temperature: 72 },
+      });
+
+      expect(text).toContain('x402 fetch succeeded with HTTP 200');
+      expect(text).toContain('Response body');
+      expect(text).toContain('"temperature": 72');
+    });
+
+    it('includes successful text response bodies in visible tool content', () => {
+      const text = describeX402Result({
+        status: 'paid',
+        url: 'https://example.test/plain',
+        http: {
+          status: 200,
+          ok: true,
+          statusText: 'OK',
+          contentType: 'text/plain',
+        },
+        bodyText: 'paid response body',
+      });
+
+      expect(text).toContain('```text');
+      expect(text).toContain('paid response body');
     });
   });
 

--- a/packages/ac2-open-claw-reference/tests/plugin.test.ts
+++ b/packages/ac2-open-claw-reference/tests/plugin.test.ts
@@ -394,6 +394,63 @@ describe('ac2-open-claw-reference plugin', () => {
       expect(observedRequest.body.description).toContain('x402 exact payment');
       expect(observedRequest.body.description).toContain(receiver.toString());
     });
+
+    it('uses the linked AC2 wallet address as the x402 payment sender', async () => {
+      const sender = new Address(new Uint8Array(32).fill(4));
+      const receiver = new Address(new Uint8Array(32).fill(5));
+      const txn = new Transaction({
+        type: TransactionType.AssetTransfer,
+        sender,
+        fee: 1_000n,
+        firstValid: 1n,
+        lastValid: 1_000n,
+        genesisHash: new Uint8Array(32).fill(3),
+        genesisId: 'testnet-v1.0',
+        assetTransfer: {
+          assetId: 10_458_941n,
+          amount: 1_000n,
+          receiver,
+        },
+      });
+      const signature = new Uint8Array(64).fill(8);
+      let observedRequest: any;
+
+      const manager = new SessionManager();
+      manager.setActive({
+        transport: {} as never,
+        client: {
+          requestSignature: async (args: any) => {
+            observedRequest = args;
+            return {
+              kind: 'response',
+              message: {
+                thid: 'x402-wallet-address-thread',
+                body: {
+                  signature: Buffer.from(signature).toString('base64'),
+                  public_key: Buffer.from(sender.publicKey).toString('base64'),
+                  address: sender.toString(),
+                  key_type: 'account',
+                },
+              },
+            };
+          },
+        } as never,
+        controllerDid: STUB_CONTROLLER_DID,
+        walletAddress: sender.toString(),
+        agentDid: STUB_AGENT_DID,
+      });
+
+      const signer = createAc2AvmSigner({
+        config: { defaultTimeoutMs: 2_000 },
+        deps: { manager },
+      });
+
+      expect(signer.address).toBe(sender.toString());
+      const signed = await signer.signTransactions([encodeTransactionRaw(txn)], [0]);
+      expect(signed[0]).toBeInstanceOf(Uint8Array);
+      expect(observedRequest.body.description).toContain(`as ${sender.toString()}`);
+      expect(observedRequest.body.description).toContain(`Sender: ${sender.toString()}`);
+    });
   });
 
   describe('identity bootstrap', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,11 +22,6 @@ catalogs:
       specifier: ~5.8.3
       version: 5.8.3
 
-patchedDependencies:
-  '@semantic-release/npm@13.1.5':
-    hash: f8fb36b515bbe8990c2498aa928100d1676d2af288ea16a4656a8827c9458e76
-    path: patches/@semantic-release__npm@13.1.5.patch
-
 importers:
 
   .:
@@ -77,6 +72,9 @@ importers:
       '@algorandfoundation/ac2-sdk':
         specifier: 1.0.0-canary.1
         version: 1.0.0-canary.1
+      '@algorandfoundation/algokit-utils':
+        specifier: 10.0.0-beta.4
+        version: 10.0.0-beta.4
       '@algorandfoundation/keystore':
         specifier: 1.0.0-canary.16
         version: 1.0.0-canary.16(@tanstack/store@0.9.3)(before-after-hook@4.0.0)
@@ -92,6 +90,15 @@ importers:
       '@tanstack/store':
         specifier: ^0.9.1
         version: 0.9.3
+      '@x402/avm':
+        specifier: ^2.11.0
+        version: 2.17.0
+      '@x402/core':
+        specifier: ^2.11.0
+        version: 2.17.0
+      '@x402/fetch':
+        specifier: ^2.11.0
+        version: 2.17.0
       node-datachannel:
         specifier: ^0.32.3
         version: 0.32.3
@@ -170,6 +177,10 @@ packages:
 
   '@algorandfoundation/ac2-sdk@1.0.0-canary.1':
     resolution: {integrity: sha512-OYP/TpCWTLpcjWtG9+RLxMhCKFb7mQwmF2KgI/Kv/7F5vILZoSoE8jAnrbkRfjo4zylvhmI7bb4G92AGzlZM1A==}
+
+  '@algorandfoundation/algokit-utils@10.0.0-alpha.46':
+    resolution: {integrity: sha512-Lx56ET6RmrDCFGwx6qyIr7YRX3Q3MyKgqkNeumLkFHXVkqMnXnK1aLeEbV59EOK8UHQ5UPJofSj1zvRMm9Du7w==}
+    engines: {node: '>=20.0'}
 
   '@algorandfoundation/algokit-utils@10.0.0-beta.4':
     resolution: {integrity: sha512-+X06PW7w2zWJWPp91pHoLMQizrq7E33Y1Mj/Hz/hkLiASXWwMKVX5QsQCbvsMYk+guqayCwB6782VngLR8d1RA==}
@@ -680,35 +691,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/keyring-linux-arm64-musl@1.3.0':
     resolution: {integrity: sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
     resolution: {integrity: sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/keyring-linux-x64-gnu@1.3.0':
     resolution: {integrity: sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/keyring-linux-x64-musl@1.3.0':
     resolution: {integrity: sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
     resolution: {integrity: sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw==}
@@ -918,79 +924,66 @@ packages:
     resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.61.1':
     resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.61.1':
     resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.61.1':
     resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.61.1':
     resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.61.1':
     resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.61.1':
     resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.61.1':
     resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.61.1':
     resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.61.1':
     resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.61.1':
     resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.61.1':
     resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.61.1':
     resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.61.1':
     resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
@@ -1189,6 +1182,15 @@ packages:
   '@vitest/utils@3.2.6':
     resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
 
+  '@x402/avm@2.17.0':
+    resolution: {integrity: sha512-NSsnVOVGT89ufsqllEJX5fLosW5nVUec+Y4VA4H5qtwjdxAHVdEE/xS5Vmg7FzKBsIwUB9pLLqncewXTX5rkPg==}
+
+  '@x402/core@2.17.0':
+    resolution: {integrity: sha512-BBooe9Kewl5KLaKadElFwhZzZ+n/X/m2djzGtc7OY51D8fk2vHTVvDZtBFEJYdJxtQoUZMKX73hew0ss81FENQ==}
+
+  '@x402/fetch@2.17.0':
+    resolution: {integrity: sha512-iy6ar1JTgs4gzdlc2q2Z7nuL5keBkQhoD4v5niVlTwLoivVvHnAA0p/wK5WTWRrJ1b+el8pthkjFS0Jc3nMIIg==}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -1275,6 +1277,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1306,6 +1311,9 @@ packages:
 
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
+
+  brace-expansion@2.1.1:
+    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -1562,8 +1570,8 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  diff@9.0.0:
-    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
 
   dijkstrajs@1.0.3:
@@ -2328,6 +2336,10 @@ packages:
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -3303,9 +3315,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   validate-npm-package-license@3.0.4:
@@ -3536,6 +3547,9 @@ packages:
     peerDependencies:
       zod: ^3.25.28 || ^4
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -3564,6 +3578,20 @@ snapshots:
   '@algorandfoundation/ac2-sdk@1.0.0-canary.1':
     dependencies:
       ajv: 8.20.0
+
+  '@algorandfoundation/algokit-utils@10.0.0-alpha.46':
+    dependencies:
+      '@algorandfoundation/xhd-wallet-api': 2.0.0-canary.1
+      '@noble/curves': 2.2.0
+      '@noble/ed25519': 3.1.0
+      '@noble/hashes': 2.2.0
+      algorand-msgpack: 1.1.0
+      buffer: 6.0.3
+      dotenv: 16.6.1
+      hi-base32: 0.5.1
+      json-bigint: 1.0.0
+      tweetnacl: 1.0.3
+      vlq: 2.0.4
 
   '@algorandfoundation/algokit-utils@10.0.0-beta.4':
     dependencies:
@@ -3601,7 +3629,7 @@ snapshots:
     dependencies:
       '@algorandfoundation/algokit-utils': 10.0.0-beta.4
       eventemitter3: 5.0.4
-      uuid: 10.0.0
+      uuid: 11.1.1
     optionalDependencies:
       socket.io-client: 4.8.3
 
@@ -3611,7 +3639,7 @@ snapshots:
     dependencies:
       '@noble/ciphers': 2.2.0
       '@noble/curves': 2.2.0
-      '@noble/hashes': 2.0.1
+      '@noble/hashes': 2.2.0
       ajv: 8.20.0
       algo-msgpack-with-bigint: 2.1.1
       bn.js: 5.2.3
@@ -4274,7 +4302,7 @@ snapshots:
       - kerberos
       - supports-color
 
-  '@semantic-release/npm@13.1.5(patch_hash=f8fb36b515bbe8990c2498aa928100d1676d2af288ea16a4656a8827c9458e76)(semantic-release@25.0.3(typescript@5.8.3))':
+  '@semantic-release/npm@13.1.5(semantic-release@25.0.3(typescript@5.8.3))':
     dependencies:
       '@actions/core': 3.0.1
       '@semantic-release/error': 4.0.0
@@ -4419,6 +4447,19 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  '@x402/avm@2.17.0':
+    dependencies:
+      '@algorandfoundation/algokit-utils': 10.0.0-alpha.46
+      '@x402/core': 2.17.0
+
+  '@x402/core@2.17.0':
+    dependencies:
+      zod: 3.25.76
+
+  '@x402/fetch@2.17.0':
+    dependencies:
+      '@x402/core': 2.17.0
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -4492,6 +4533,8 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -4527,6 +4570,10 @@ snapshots:
   boolbase@1.0.0: {}
 
   bottleneck@2.19.5: {}
+
+  brace-expansion@2.1.1:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.6:
     dependencies:
@@ -4763,7 +4810,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  diff@9.0.0: {}
+  diff@8.0.4: {}
 
   dijkstrajs@1.0.3: {}
 
@@ -5578,6 +5625,10 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.6
 
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.1
+
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
@@ -5728,7 +5779,7 @@ snapshots:
       commander: 14.0.3
       croner: 10.0.1
       cross-spawn: 7.0.6
-      diff: 9.0.0
+      diff: 8.0.4
       dotenv: 17.4.2
       express: 5.2.1
       file-type: 22.0.1
@@ -5742,7 +5793,7 @@ snapshots:
       jszip: 3.10.1
       kysely: 0.29.2
       linkedom: 0.18.12
-      minimatch: 10.2.5
+      minimatch: 9.0.9
       node-edge-tts: 1.2.10
       openai: 6.39.1(ws@8.21.0)(zod@4.4.3)
       partial-json: 0.1.7
@@ -6105,7 +6156,7 @@ snapshots:
       '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.3(typescript@5.8.3))
       '@semantic-release/error': 4.0.0
       '@semantic-release/github': 12.0.8(semantic-release@25.0.3(typescript@5.8.3))
-      '@semantic-release/npm': 13.1.5(patch_hash=f8fb36b515bbe8990c2498aa928100d1676d2af288ea16a4656a8827c9458e76)(semantic-release@25.0.3(typescript@5.8.3))
+      '@semantic-release/npm': 13.1.5(semantic-release@25.0.3(typescript@5.8.3))
       '@semantic-release/release-notes-generator': 14.1.1(semantic-release@25.0.3(typescript@5.8.3))
       aggregate-error: 5.0.0
       cosmiconfig: 9.0.2(typescript@5.8.3)
@@ -6558,7 +6609,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@10.0.0: {}
+  uuid@11.1.1: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:
@@ -6779,5 +6830,7 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
+
+  zod@3.25.76: {}
 
   zod@4.4.3: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,11 @@ catalogs:
       specifier: ~5.8.3
       version: 5.8.3
 
+patchedDependencies:
+  '@semantic-release/npm@13.1.5':
+    hash: f8fb36b515bbe8990c2498aa928100d1676d2af288ea16a4656a8827c9458e76
+    path: patches/@semantic-release__npm@13.1.5.patch
+
 importers:
 
   .:
@@ -691,30 +696,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/keyring-linux-arm64-musl@1.3.0':
     resolution: {integrity: sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
     resolution: {integrity: sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/keyring-linux-x64-gnu@1.3.0':
     resolution: {integrity: sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/keyring-linux-x64-musl@1.3.0':
     resolution: {integrity: sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
     resolution: {integrity: sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw==}
@@ -924,66 +934,79 @@ packages:
     resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.61.1':
     resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.61.1':
     resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.61.1':
     resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.61.1':
     resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.61.1':
     resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.61.1':
     resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.61.1':
     resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.61.1':
     resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.61.1':
     resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.61.1':
     resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.61.1':
     resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.61.1':
     resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.61.1':
     resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
@@ -1277,9 +1300,6 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1311,9 +1331,6 @@ packages:
 
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
-
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -1570,8 +1587,8 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  diff@8.0.4:
-    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
   dijkstrajs@1.0.3:
@@ -2336,10 +2353,6 @@ packages:
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
-
-  minimatch@9.0.9:
-    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
-    engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -3315,8 +3328,9 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@11.1.1:
-    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   validate-npm-package-license@3.0.4:
@@ -3629,7 +3643,7 @@ snapshots:
     dependencies:
       '@algorandfoundation/algokit-utils': 10.0.0-beta.4
       eventemitter3: 5.0.4
-      uuid: 11.1.1
+      uuid: 10.0.0
     optionalDependencies:
       socket.io-client: 4.8.3
 
@@ -4302,7 +4316,7 @@ snapshots:
       - kerberos
       - supports-color
 
-  '@semantic-release/npm@13.1.5(semantic-release@25.0.3(typescript@5.8.3))':
+  '@semantic-release/npm@13.1.5(patch_hash=f8fb36b515bbe8990c2498aa928100d1676d2af288ea16a4656a8827c9458e76)(semantic-release@25.0.3(typescript@5.8.3))':
     dependencies:
       '@actions/core': 3.0.1
       '@semantic-release/error': 4.0.0
@@ -4533,8 +4547,6 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -4570,10 +4582,6 @@ snapshots:
   boolbase@1.0.0: {}
 
   bottleneck@2.19.5: {}
-
-  brace-expansion@2.1.1:
-    dependencies:
-      balanced-match: 1.0.2
 
   brace-expansion@5.0.6:
     dependencies:
@@ -4810,7 +4818,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  diff@8.0.4: {}
+  diff@9.0.0: {}
 
   dijkstrajs@1.0.3: {}
 
@@ -5625,10 +5633,6 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.6
 
-  minimatch@9.0.9:
-    dependencies:
-      brace-expansion: 2.1.1
-
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
@@ -5779,7 +5783,7 @@ snapshots:
       commander: 14.0.3
       croner: 10.0.1
       cross-spawn: 7.0.6
-      diff: 8.0.4
+      diff: 9.0.0
       dotenv: 17.4.2
       express: 5.2.1
       file-type: 22.0.1
@@ -5793,7 +5797,7 @@ snapshots:
       jszip: 3.10.1
       kysely: 0.29.2
       linkedom: 0.18.12
-      minimatch: 9.0.9
+      minimatch: 10.2.5
       node-edge-tts: 1.2.10
       openai: 6.39.1(ws@8.21.0)(zod@4.4.3)
       partial-json: 0.1.7
@@ -6156,7 +6160,7 @@ snapshots:
       '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.3(typescript@5.8.3))
       '@semantic-release/error': 4.0.0
       '@semantic-release/github': 12.0.8(semantic-release@25.0.3(typescript@5.8.3))
-      '@semantic-release/npm': 13.1.5(semantic-release@25.0.3(typescript@5.8.3))
+      '@semantic-release/npm': 13.1.5(patch_hash=f8fb36b515bbe8990c2498aa928100d1676d2af288ea16a4656a8827c9458e76)(semantic-release@25.0.3(typescript@5.8.3))
       '@semantic-release/release-notes-generator': 14.1.1(semantic-release@25.0.3(typescript@5.8.3))
       aggregate-error: 5.0.0
       cosmiconfig: 9.0.2(typescript@5.8.3)
@@ -6609,7 +6613,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@11.1.1: {}
+  uuid@10.0.0: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:


### PR DESCRIPTION
## Summary
- add `ac2_x402_fetch` to the OpenClaw reference plugin for x402 exact Algorand paid HTTP resources
- add an AC2-backed AVM signer that asks the paired wallet to approve Algorand transaction signing bytes and packages signed transaction blobs for x402
- wire plugin metadata, setup grants, config policy knobs, docs, and tests for the combined AC2 + x402 install

## Verification
- `pnpm --filter @algorandfoundation/ac2-open-claw-reference type-check`
- `pnpm --filter @algorandfoundation/ac2-open-claw-reference test`
- `pnpm --filter @algorandfoundation/ac2-open-claw-reference build`

## Notes
- AC2 protocol messages remain unchanged; x402 is layered as an OpenClaw tool over the existing signing flow.
- Local tests required rebuilding `node-datachannel` after dependency install.