### PR TITLE
fix: enhance LiquidAuthChannelProvider with ICE candidate handling

### DIFF
--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -46,7 +46,7 @@ agent never touches the user's account keys or passkeys.
 #### From the npm registry (canary)
 
 ```bash
-openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.3
+openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.4
 
 # openclaw plugins install runs `npm install --ignore-scripts`, so native
 # addons are not built automatically. Rebuild them from the plugin project dir:

--- a/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
+++ b/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
@@ -114,7 +114,7 @@ export interface LiquidAuthChannelProviderOptions {
 }
 
 export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
-  constructor(private readonly defaults: LiquidAuthChannelProviderOptions = {}) { }
+  constructor(private readonly defaults: LiquidAuthChannelProviderOptions = {}) {}
 
   async startPairing(_opts: Ac2StartPairingOptions = {}): Promise<Ac2PairingHandle> {
     const origin = this.defaults.origin ?? 'https://debug.liquidauth.com';

--- a/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
+++ b/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
@@ -24,8 +24,39 @@ import { io as createSocketIoClient } from 'socket.io-client';
 // @ts-ignore - polyfill ships its own types
 import * as ndc from 'node-datachannel/polyfill';
 
+// Subclass node-datachannel's RTCPeerConnection to queue remote ICE candidates
+// that arrive via trickle before setRemoteDescription completes. The Liquid Auth
+// SignalClient can race between trickling candidates and the offer/answer exchange;
+// node-datachannel is stricter than browser WebRTC and throws immediately
+// ("Got a remote candidate without ICE transport") instead of buffering silently.
+class _Ac2RTCPeerConnection extends (ndc as any).RTCPeerConnection {
+  private _ac2PendingCandidates: any[] = [];
+  private _ac2RemoteDescReady = false;
+
+  async setRemoteDescription(desc: any): Promise<void> {
+    await super.setRemoteDescription(desc);
+    this._ac2RemoteDescReady = true;
+    const queued = this._ac2PendingCandidates.splice(0);
+    for (const c of queued) {
+      try {
+        await super.addIceCandidate(c);
+      } catch {
+        // Stale or invalid candidate after drain — safe to ignore.
+      }
+    }
+  }
+
+  async addIceCandidate(candidate: any): Promise<void> {
+    if (!this._ac2RemoteDescReady) {
+      this._ac2PendingCandidates.push(candidate);
+      return;
+    }
+    return super.addIceCandidate(candidate);
+  }
+}
+
 if (typeof (globalThis as any).RTCPeerConnection === 'undefined') {
-  (globalThis as any).RTCPeerConnection = (ndc as any).RTCPeerConnection;
+  (globalThis as any).RTCPeerConnection = _Ac2RTCPeerConnection;
   (globalThis as any).RTCIceCandidate = (ndc as any).RTCIceCandidate;
   (globalThis as any).RTCSessionDescription = (ndc as any).RTCSessionDescription;
   if ((ndc as any).RTCDataChannel) {
@@ -82,7 +113,7 @@ export interface LiquidAuthChannelProviderOptions {
 }
 
 export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
-  constructor(private readonly defaults: LiquidAuthChannelProviderOptions = {}) {}
+  constructor(private readonly defaults: LiquidAuthChannelProviderOptions = {}) { }
 
   async startPairing(_opts: Ac2StartPairingOptions = {}): Promise<Ac2PairingHandle> {
     const origin = this.defaults.origin ?? 'https://debug.liquidauth.com';
@@ -193,7 +224,7 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
       if (controlChannel.label !== AC2_CONTROL_LABEL) {
         throw new Error(
           `[ac2-open-claw] Expected control channel labeled "${AC2_CONTROL_LABEL}", got "${controlChannel.label}". ` +
-            `The Controller app must use the latest liquid-auth-js with ac2-v1 support.`,
+          `The Controller app must use the latest liquid-auth-js with ac2-v1 support.`,
         );
       }
 
@@ -285,11 +316,11 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
         // Bind the real connected wallet (normalized to canonical `did:key:z…`).
         ...(linkedWallet !== undefined
           ? {
-              peer: {
-                did: normalizeDidKey(`did:key:${linkedWallet}`),
-                wallet: linkedWallet,
-              },
-            }
+            peer: {
+              did: normalizeDidKey(`did:key:${linkedWallet}`),
+              wallet: linkedWallet,
+            },
+          }
           : {}),
         close,
       };

--- a/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
+++ b/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
@@ -34,6 +34,7 @@ class _Ac2RTCPeerConnection extends (ndc as any).RTCPeerConnection {
   private _ac2RemoteDescReady = false;
 
   async setRemoteDescription(desc: any): Promise<void> {
+    this._ac2RemoteDescReady = false;
     await super.setRemoteDescription(desc);
     this._ac2RemoteDescReady = true;
     const queued = this._ac2PendingCandidates.splice(0);


### PR DESCRIPTION
- fixes a race condition with the wallet side with ICE candidates
- node-datachannel is stricter than browser WebRTC/react-native-webrtc and throws immediately instead of silently buffering.