### PR TITLE
fix: document AC2 sign tool signature output

### DIFF
--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -11,7 +11,7 @@ Liquid Auth + WebRTC via [`@algorandfoundation/ac2-sdk`](../ac2-sdk).
 | ----------------------- | -------------------------------------------------------------------------- |
 | Channel `ac2`           | Owns Liquid Auth + WebRTC pairing and the active session.                  |
 | Tool `ac2_capabilities` | Agent DID + `sig_hint` catalog.                                            |
-| Tool `ac2_sign`         | Routes a `SigningRequest` to the wallet over the active channel.           |
+| Tool `ac2_sign`         | Routes a `SigningRequest` and returns signature details to the agent.      |
 | Tool `ac2_x402_fetch`   | Pays x402 exact Algorand resources using wallet-approved AC2 signing.      |
 | Setup entry             | `openclaw ac2 setup` writes the channel/tools wiring into `openclaw.json`. |
 


### PR DESCRIPTION
## Summary
- update the OpenClaw reference README to document that ac2_sign returns signature details to the agent
- use a conventional fix commit so the next canary release includes the merged sign-tool output fix

## Notes
The runtime fix is already on master via #9. This tiny docs change intentionally triggers semantic-release for the package.