### PR TITLE
docs: update OpenClaw plugin canary install reference

### DIFF
--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -47,7 +47,7 @@ agent never touches the user's account keys or passkeys.
 #### From the npm registry (canary)
 
 ```bash
-openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.4
+openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.6
 
 # openclaw plugins install runs `npm install --ignore-scripts`, so native
 # addons are not built automatically. Rebuild them from the plugin project dir:


### PR DESCRIPTION
## Summary
- update the OpenClaw plugin README install command from canary.4 to canary.6

## Notes
canary.6 is the release that includes the ac2_sign tool output fix from #9/#10.