### PR TITLE
fix: avoid native import during AC2 command registration

### DIFF
--- a/packages/CONTRIBUTING.md
+++ b/packages/CONTRIBUTING.md
@@ -125,7 +125,7 @@ pnpm build               # bundle + tsc + flatten d.ts
 pnpm test                # vitest, loads sources from src/
 pnpm dev:link            # rebuild natives, build, install into local openclaw
 pnpm dev:relink          # rebuild + `openclaw plugins update`
-pnpm dev:unlink          # `openclaw plugins uninstall ac2-open-claw-reference`
+pnpm dev:unlink          # `openclaw plugins uninstall ac2`
 ```
 
 ### Releasing the plugin

--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -47,7 +47,7 @@ agent never touches the user's account keys or passkeys.
 #### From the npm registry (canary)
 
 ```bash
-openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.6
+openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.7
 
 # openclaw plugins install runs `npm install --ignore-scripts`, so native
 # addons are not built automatically. Rebuild them from the plugin project dir:
@@ -65,7 +65,7 @@ NDC="$PLUGIN_DIR/node_modules/node-datachannel"
   && npx cmake-js configure --CDUSE_NICE=1 \
   && npx cmake-js build)
 
-openclaw plugins enable ac2-open-claw-reference
+openclaw plugins enable ac2
 openclaw ac2 setup                                    # wire channel + tools into openclaw.json
 openclaw gateway restart
 ```
@@ -91,7 +91,7 @@ openclaw gateway restart
 
 `pnpm install:plugin` builds the flat tree-shakeable `dist/`, packs a
 tarball with workspace-only devDependencies stripped, installs it into
-`${OPENCLAW_HOME:-~/.openclaw}/extensions/ac2-open-claw-reference`, rebuilds
+`${OPENCLAW_HOME:-~/.openclaw}/extensions/ac2`, rebuilds
 `@napi-rs/keyring` via `npm rebuild`, then compiles `node-datachannel` from
 source against libnice (`USE_NICE=1`) via `pnpm rebuild:node-datachannel`.
 You can also run `pnpm rebuild:node-datachannel` on its own to re-compile the
@@ -100,7 +100,7 @@ native ICE layer without repeating the full install cycle.
 To uninstall (either install path):
 
 ```bash
-openclaw plugins uninstall ac2-open-claw-reference
+openclaw plugins uninstall ac2
 # or, from the monorepo:
 pnpm uninstall:plugin
 ```
@@ -111,12 +111,16 @@ Once installed, `openclaw.json` will contain an entry like:
 
 ```json5
 {
-  'ac2-open-claw-reference': {
-    enabled: true,
-    config: {
+  plugins: {
+    entries: {
+      ac2: {
+        enabled: true,
+      },
+    },
+  },
+  channels: {
+    ac2: {
       liquidAuthServer: 'https://debug.liquidauth.com',
-      defaultTimeoutMs: 120000,
-      x402MaxAmountAtomic: '1000000',
     },
   },
 }

--- a/packages/ac2-open-claw-reference/openclaw.plugin.json
+++ b/packages/ac2-open-claw-reference/openclaw.plugin.json
@@ -1,5 +1,5 @@
 {
-  "id": "ac2-open-claw-reference",
+  "id": "ac2",
   "name": "AC2 Reference",
   "description": "Reference OpenClaw plugin for the AC2 protocol. The `ac2` channel owns pairing over Liquid Auth + WebRTC; signing, capabilities, and x402 paid fetch tools route through the active channel session.",
   "version": "0.1.0",

--- a/packages/ac2-open-claw-reference/package.json
+++ b/packages/ac2-open-claw-reference/package.json
@@ -53,9 +53,9 @@
     "test:watch": "vitest",
     "release": "package-releaser",
     "release:dry-run": "package-releaser --dry-run",
-    "rebuild:node-datachannel": "NDC=\"${OPENCLAW_HOME:-$HOME/.openclaw}/extensions/ac2-open-claw-reference/node_modules/node-datachannel\" && (cd \"$NDC\" && npm install --ignore-scripts --production=false && npx cmake-js clean && npx cmake-js configure --CDUSE_NICE=1 && npx cmake-js build)",
-    "install:plugin": "node scripts/bundle.mjs && tsc -p tsconfig.build.json && node scripts/bundle.mjs --flatten-dts && TGZ=\"$(node scripts/pack-plugin.mjs --pack-destination /tmp | tail -n1)\" && openclaw plugins install \"file:$TGZ\" --dangerously-force-unsafe-install --force && npm rebuild --prefix \"${OPENCLAW_HOME:-$HOME/.openclaw}/extensions/ac2-open-claw-reference\" @napi-rs/keyring && pnpm rebuild:node-datachannel && openclaw plugins enable ac2-open-claw-reference",
-    "uninstall:plugin": "openclaw plugins uninstall ac2-open-claw-reference"
+    "rebuild:node-datachannel": "NDC=\"${OPENCLAW_HOME:-$HOME/.openclaw}/extensions/ac2/node_modules/node-datachannel\" && (cd \"$NDC\" && npm install --ignore-scripts --production=false && npx cmake-js clean && npx cmake-js configure --CDUSE_NICE=1 && npx cmake-js build)",
+    "install:plugin": "node scripts/bundle.mjs && tsc -p tsconfig.build.json && node scripts/bundle.mjs --flatten-dts && TGZ=\"$(node scripts/pack-plugin.mjs --pack-destination /tmp | tail -n1)\" && openclaw plugins install \"file:$TGZ\" --dangerously-force-unsafe-install --force && npm rebuild --prefix \"${OPENCLAW_HOME:-$HOME/.openclaw}/extensions/ac2\" @napi-rs/keyring && pnpm rebuild:node-datachannel && openclaw plugins enable ac2",
+    "uninstall:plugin": "openclaw plugins uninstall ac2"
   },
   "release": null,
   "dependencies": {

--- a/packages/ac2-open-claw-reference/skills/ac2/AGENTS.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/AGENTS.md
@@ -6,7 +6,7 @@ metadata:
     'openclaw':
       {
         'emoji': '📜',
-        'requires': { 'config': ['plugins.entries.ac2-open-claw-reference.enabled'] },
+        'requires': { 'config': ['plugins.entries.ac2.enabled'] },
       },
   }
 ---

--- a/packages/ac2-open-claw-reference/skills/ac2/CLAUDE.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/CLAUDE.md
@@ -6,7 +6,7 @@ metadata:
     'openclaw':
       {
         'emoji': '🤖',
-        'requires': { 'config': ['plugins.entries.ac2-open-claw-reference.enabled'] },
+        'requires': { 'config': ['plugins.entries.ac2.enabled'] },
       },
   }
 ---

--- a/packages/ac2-open-claw-reference/skills/ac2/IDENTITY.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/IDENTITY.md
@@ -6,7 +6,7 @@ metadata:
     'openclaw':
       {
         'emoji': '🪪',
-        'requires': { 'config': ['plugins.entries.ac2-open-claw-reference.enabled'] },
+        'requires': { 'config': ['plugins.entries.ac2.enabled'] },
       },
   }
 ---
@@ -29,7 +29,7 @@ The agent presents itself via these fields, populated at runtime by
 | Field           | Source                                   | Meaning                                                                                                                 |
 | --------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `did`           | `ac2_capabilities.agent.did`             | The agent's own `did:key`, issued by the Controller's wallet during pairing. The agent signs its envelopes as this DID. |
-| `name`          | `ac2_capabilities.agent.plugin.id`       | Human-readable plugin identifier (`ac2-open-claw-reference`).                                                           |
+| `name`          | `ac2_capabilities.agent.plugin.id`       | Human-readable plugin identifier (`ac2`).                                                           |
 | `version`       | `ac2_capabilities.agent.plugin.version`  | Plugin semver.                                                                                                          |
 | `controllerDid` | `ac2_capabilities.session.controllerDid` | The Controller account currently paired (NOT part of the agent's identity — it identifies the _peer_).                  |
 

--- a/packages/ac2-open-claw-reference/skills/ac2/MEMORY.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/MEMORY.md
@@ -6,7 +6,7 @@ metadata:
     'openclaw':
       {
         'emoji': '🧠',
-        'requires': { 'config': ['plugins.entries.ac2-open-claw-reference.enabled'] },
+        'requires': { 'config': ['plugins.entries.ac2.enabled'] },
       },
   }
 ---

--- a/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
@@ -6,7 +6,7 @@ metadata:
     'openclaw':
       {
         'emoji': '🔐',
-        'requires': { 'config': ['plugins.entries.ac2-open-claw-reference.enabled'] },
+        'requires': { 'config': ['plugins.entries.ac2.enabled'] },
       },
   }
 ---

--- a/packages/ac2-open-claw-reference/skills/ac2/SOUL.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/SOUL.md
@@ -6,7 +6,7 @@ metadata:
     'openclaw':
       {
         'emoji': '🫀',
-        'requires': { 'config': ['plugins.entries.ac2-open-claw-reference.enabled'] },
+        'requires': { 'config': ['plugins.entries.ac2.enabled'] },
       },
   }
 ---

--- a/packages/ac2-open-claw-reference/skills/ac2/USER.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/USER.md
@@ -6,7 +6,7 @@ metadata:
     'openclaw':
       {
         'emoji': '🧑',
-        'requires': { 'config': ['plugins.entries.ac2-open-claw-reference.enabled'] },
+        'requires': { 'config': ['plugins.entries.ac2.enabled'] },
       },
   }
 ---

--- a/packages/ac2-open-claw-reference/src/channel/channel-object.ts
+++ b/packages/ac2-open-claw-reference/src/channel/channel-object.ts
@@ -3,7 +3,7 @@
 import type { ChannelPlugin } from 'openclaw/plugin-sdk';
 
 import { CHANNEL_ID } from '../runtime.js';
-import { sessionManager } from '../session/index.js';
+import { sessionManager } from '../session/manager.js';
 import { AC2_CHANNEL_ENV_VARS } from '../setup/config.js';
 import {
   AC2_DEFAULT_ACK_POLICY,

--- a/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
+++ b/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
@@ -4,13 +4,9 @@ import qrcode from 'qrcode-terminal';
 import { Ac2Client } from '@algorandfoundation/ac2-sdk';
 import { isValidAddress } from '@algorandfoundation/algokit-utils/common';
 import { resolveConfig, safeLog, type OpenClawApi } from '../runtime.js';
-import {
-  BootstrapError,
-  bootstrapAgentIdentity,
-  sessionManager,
-  type ChannelContext,
-} from '../session/index.js';
-import { LiquidAuthChannelProvider } from '../providers/liquid-auth.js';
+import { BootstrapError, bootstrapAgentIdentity } from '../session/bootstrap.js';
+import type { ChannelContext } from '../session/contracts.js';
+import { sessionManager } from '../session/manager.js';
 import {
   clearAc2State,
   ensureConversation,
@@ -124,6 +120,7 @@ export function buildAc2Command(api: OpenClawApi): unknown {
         }> => {
           // Reuse a persisted requestId so the wallet reconnects to the same connection.
           const persistedRequestId = loadAc2State().requestId;
+          const { LiquidAuthChannelProvider } = await import('../providers/liquid-auth.js');
           const provider: import('@algorandfoundation/ac2-sdk/signaling').Ac2ChannelProvider =
             new LiquidAuthChannelProvider({
               origin,

--- a/packages/ac2-open-claw-reference/src/runtime.ts
+++ b/packages/ac2-open-claw-reference/src/runtime.ts
@@ -2,7 +2,7 @@
 
 import type { OpenClawPluginApi } from 'openclaw/plugin-sdk';
 
-export const PLUGIN_ID = 'ac2-open-claw-reference';
+export const PLUGIN_ID = 'ac2';
 export const CHANNEL_ID = 'ac2';
 
 /** Host API injected into `register(api)` (SDK `OpenClawPluginApi`). */

--- a/packages/ac2-open-claw-reference/src/session/channel-runtime.ts
+++ b/packages/ac2-open-claw-reference/src/session/channel-runtime.ts
@@ -3,7 +3,7 @@
 import { Ac2Client } from '@algorandfoundation/ac2-sdk';
 import { isValidAddress } from '@algorandfoundation/algokit-utils/common';
 import type { Ac2ChannelProvider, Ac2PairedChannel } from '@algorandfoundation/ac2-sdk/signaling';
-import { LiquidAuthChannelProvider, renderPairingQr } from '../providers/liquid-auth.js';
+import qrcode from 'qrcode-terminal';
 import type { ChannelContext, PluginConfig } from './contracts.js';
 import { SessionManager, sessionManager } from './manager.js';
 import { bootstrapAgentIdentity } from './bootstrap.js';
@@ -26,6 +26,14 @@ function resolveLiquidAuthServer(config: PluginConfig): string | undefined {
   return fromEnv ?? config.liquidAuthServer ?? undefined;
 }
 
+/** Render a pairing payload to the terminal (QR + raw string). */
+export function renderPairingQr(pairing: { qrPayload: string }): void {
+  const isTty = typeof process !== 'undefined' && Boolean(process.stdout?.isTTY);
+  if (isTty) qrcode.generate(pairing.qrPayload, { small: true });
+  // eslint-disable-next-line no-console
+  console.log(`[ac2-open-claw] Pair with Controller: ${pairing.qrPayload}`);
+}
+
 export interface ChannelDeps {
   /** Channel bringup provider; defaults to `LiquidAuthChannelProvider`. */
   provider?: Ac2ChannelProvider;
@@ -41,7 +49,9 @@ export async function runAc2Channel(
   context: ChannelContext,
 ): Promise<void> {
   const origin = resolveLiquidAuthServer(config) ?? DEFAULT_LIQUID_AUTH_SERVER;
-  const provider: Ac2ChannelProvider = deps.provider ?? new LiquidAuthChannelProvider({ origin });
+  const provider: Ac2ChannelProvider =
+    deps.provider ??
+    new (await import('../providers/liquid-auth.js')).LiquidAuthChannelProvider({ origin });
   const renderQr = deps.renderQr ?? renderPairingQr;
   const manager = deps.manager ?? sessionManager;
 

--- a/packages/ac2-open-claw-reference/src/session/flows.ts
+++ b/packages/ac2-open-claw-reference/src/session/flows.ts
@@ -128,7 +128,7 @@ export function capabilitiesFlow(_config: PluginConfig, deps: SignDeps = {}): Ca
     status: active ? 'ok' : 'no_active_session',
     agent: {
       did: hasIdentity ? active.agentDid : null,
-      plugin: { id: 'ac2-open-claw-reference', version: '0.1.0' },
+      plugin: { id: 'ac2', version: '0.1.0' },
       sigHintsCatalog: SIG_HINTS_CATALOG as unknown as ReadonlyArray<
         SigningRequestBody['sig_hint']
       >,

--- a/packages/ac2-open-claw-reference/src/setup/config.ts
+++ b/packages/ac2-open-claw-reference/src/setup/config.ts
@@ -8,7 +8,7 @@ import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
-export const PLUGIN_ID = 'ac2-open-claw-reference';
+export const PLUGIN_ID = 'ac2';
 export const CHANNEL_ID = 'ac2';
 export const DEFAULT_LIQUID_AUTH_SERVER = 'https://debug.liquidauth.com';
 
@@ -35,6 +35,8 @@ export function resolveOpenClawConfigPath(): string {
   if (stateDirEnv) return join(stateDirEnv, 'openclaw.json');
   const configPathEnv = process.env['OPENCLAW_CONFIG_PATH']?.trim();
   if (configPathEnv) return configPathEnv;
+  const homeEnv = process.env['OPENCLAW_HOME']?.trim();
+  if (homeEnv) return join(homeEnv, 'openclaw.json');
   return join(homedir(), '.openclaw', 'openclaw.json');
 }
 

--- a/packages/ac2-open-claw-reference/src/tools/manifest.ts
+++ b/packages/ac2-open-claw-reference/src/tools/manifest.ts
@@ -10,7 +10,7 @@ import { capabilitiesFlow, signFlow } from '../session/flows.js';
 import { normalizeX402FetchParams, x402FetchFlow } from '../x402/fetch-flow.js';
 
 const plugin = defineToolPlugin({
-  id: 'ac2-open-claw-reference',
+  id: 'ac2',
   name: 'AC2 Reference',
   description:
     'Reference OpenClaw plugin for the AC2 protocol. The `ac2` channel owns pairing over Liquid Auth + WebRTC; signing and x402 paid fetch tools route through that channel.',

--- a/packages/ac2-open-claw-reference/tests/plugin.test.ts
+++ b/packages/ac2-open-claw-reference/tests/plugin.test.ts
@@ -139,12 +139,12 @@ async function bootChannel(
   };
 }
 
-describe('ac2-open-claw-reference plugin', () => {
+describe('ac2 plugin', () => {
   it('exposes the expected plugin manifest shape', () => {
     // The manifest is a genuine SDK `defineToolPlugin` entry; its catalog is
     // re-read through the supported `getToolPluginMetadata` accessor.
     const metadata = getToolPluginMetadata(plugin);
-    expect(metadata?.id).toBe('ac2-open-claw-reference');
+    expect(metadata?.id).toBe('ac2');
     const names = (metadata?.tools ?? []).map((t) => t.name);
     expect(names).toContain('ac2_sign');
     expect(names).toContain('ac2_capabilities');

--- a/packages/ac2-open-claw-reference/tests/setup.test.ts
+++ b/packages/ac2-open-claw-reference/tests/setup.test.ts
@@ -3,7 +3,12 @@ import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { AC2_CHANNEL_ENV_VARS, readChannelStatus, cmdSetup } from '../src/setup/config.js';
+import {
+  AC2_CHANNEL_ENV_VARS,
+  readChannelStatus,
+  cmdSetup,
+  resolveOpenClawConfigPath,
+} from '../src/setup/config.js';
 import { setupEntry } from '../src/setup/index.js';
 import { buildChannelObject } from '../src/index.js';
 
@@ -15,20 +20,30 @@ import { buildChannelObject } from '../src/index.js';
  */
 describe('setup entry + channel env vars (OpenClaw setup-entry contract)', () => {
   let prevStateDir: string | undefined;
+  let prevConfigPath: string | undefined;
+  let prevOpenClawHome: string | undefined;
   let prevServer: string | undefined;
   let dir: string;
 
   beforeEach(() => {
     prevStateDir = process.env['OPENCLAW_STATE_DIR'];
+    prevConfigPath = process.env['OPENCLAW_CONFIG_PATH'];
+    prevOpenClawHome = process.env['OPENCLAW_HOME'];
     prevServer = process.env['AC2_LIQUID_AUTH_SERVER'];
     dir = mkdtempSync(join(tmpdir(), 'ac2-setup-'));
     process.env['OPENCLAW_STATE_DIR'] = dir;
+    delete process.env['OPENCLAW_CONFIG_PATH'];
+    delete process.env['OPENCLAW_HOME'];
     delete process.env['AC2_LIQUID_AUTH_SERVER'];
   });
 
   afterEach(() => {
     if (prevStateDir === undefined) delete process.env['OPENCLAW_STATE_DIR'];
     else process.env['OPENCLAW_STATE_DIR'] = prevStateDir;
+    if (prevConfigPath === undefined) delete process.env['OPENCLAW_CONFIG_PATH'];
+    else process.env['OPENCLAW_CONFIG_PATH'] = prevConfigPath;
+    if (prevOpenClawHome === undefined) delete process.env['OPENCLAW_HOME'];
+    else process.env['OPENCLAW_HOME'] = prevOpenClawHome;
     if (prevServer === undefined) delete process.env['AC2_LIQUID_AUTH_SERVER'];
     else process.env['AC2_LIQUID_AUTH_SERVER'] = prevServer;
     rmSync(dir, { recursive: true, force: true });
@@ -56,7 +71,7 @@ describe('setup entry + channel env vars (OpenClaw setup-entry contract)', () =>
       status?: () => unknown;
       setup?: () => string;
     };
-    expect(entry.id).toBe('ac2-open-claw-reference');
+    expect(entry.id).toBe('ac2');
     expect(entry.channels).toContain('ac2');
     expect(entry.channelEnvVars?.length).toBeGreaterThan(0);
     expect(typeof entry.status).toBe('function');
@@ -79,6 +94,13 @@ describe('setup entry + channel env vars (OpenClaw setup-entry contract)', () =>
     const status = readChannelStatus();
     expect(status.liquidAuthServer).toBe('https://example.test');
     expect(status.liquidAuthServerSource).toBe('env');
+  });
+
+  it('uses OPENCLAW_HOME when no explicit state/config path is set', () => {
+    delete process.env['OPENCLAW_STATE_DIR'];
+    delete process.env['OPENCLAW_CONFIG_PATH'];
+    process.env['OPENCLAW_HOME'] = dir;
+    expect(resolveOpenClawConfigPath()).toBe(join(dir, 'openclaw.json'));
   });
 
   it('cmdSetup makes the channel ready and is idempotent', () => {


### PR DESCRIPTION
## Summary
- avoid importing the session barrel from AC2 channel/CLI cold paths
- lazy-load the Liquid Auth/node-datachannel provider only when pairing starts
- make AC2 setup config resolution honor OPENCLAW_HOME

## Why
A fresh OpenClaw install can load the plugin before node-datachannel has been rebuilt. The plugin registration then fails, so OpenClaw never learns the ac2 command and reports: "OpenClaw does not know the command 'ac2'."

## Tests
- pnpm --filter @algorandfoundation/ac2-open-claw-reference type-check
- pnpm --filter @algorandfoundation/ac2-open-claw-reference test
- pnpm --filter @algorandfoundation/ac2-open-claw-reference build
- local packed-plugin smoke test: install + enable + openclaw ac2 status + openclaw ac2 setup in an isolated OPENCLAW_HOME