### PR TITLE
fix: lazy load AC2 native provider from package root

### DIFF
--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -47,7 +47,7 @@ agent never touches the user's account keys or passkeys.
 #### From the npm registry (canary)
 
 ```bash
-openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.7
+openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.8
 
 # openclaw plugins install runs `npm install --ignore-scripts`, so native
 # addons are not built automatically. Rebuild them from the plugin project dir:

--- a/packages/ac2-open-claw-reference/src/index.ts
+++ b/packages/ac2-open-claw-reference/src/index.ts
@@ -8,6 +8,8 @@ export {
   signFlow,
   capabilitiesFlow,
   runAc2Channel,
+  renderPairingQr,
+  renderPairingQr as renderQr,
   defineToolPlugin,
   getToolPluginMetadata,
   SessionManager,
@@ -59,12 +61,12 @@ export {
   type X402PaymentContext,
   type X402PaymentSelection,
 } from './x402/index.js';
-export {
-  LiquidAuthChannelProvider,
-  renderPairingQr,
-  renderPairingQr as renderQr,
-  type LiquidAuthChannelProviderOptions,
-} from './providers/liquid-auth.js';
+export type { LiquidAuthChannelProviderOptions } from './providers/liquid-auth.js';
+export async function loadLiquidAuthChannelProvider(): Promise<
+  typeof import('./providers/liquid-auth.js')
+> {
+  return import('./providers/liquid-auth.js');
+}
 export {
   InMemoryChannelProvider,
   type InMemoryChannelProviderOptions,

--- a/packages/ac2-open-claw-reference/src/session/index.ts
+++ b/packages/ac2-open-claw-reference/src/session/index.ts
@@ -33,4 +33,4 @@ export {
   type SignDeps,
   type CapabilitiesResult,
 } from './flows.js';
-export { runAc2Channel, type ChannelDeps } from './channel-runtime.js';
+export { runAc2Channel, renderPairingQr, type ChannelDeps } from './channel-runtime.js';


### PR DESCRIPTION
## Summary
- remove the package root's static re-export of LiquidAuthChannelProvider
- keep renderPairingQr available from the non-native channel runtime
- add a lazy loadLiquidAuthChannelProvider helper for consumers that need the native provider
- update install docs to the expected canary.8 release

## Why
canary.7 still lets OpenClaw hit node-datachannel during CLI startup if discovery imports the package root. That produces:

```
Cannot find module '../../../build/Release/node_datachannel.node'
```

## Tests
- pnpm --filter @algorandfoundation/ac2-open-claw-reference type-check
- pnpm --filter @algorandfoundation/ac2-open-claw-reference test
- pnpm --filter @algorandfoundation/ac2-open-claw-reference build
- packed-plugin smoke: verify dist/index.js has no static providers.liquid-auth import, then install/enable and run openclaw ac2 status without native rebuild