### PR TITLE
fix: defer AC2 node-datachannel polyfill import

### DIFF
--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -47,7 +47,7 @@ agent never touches the user's account keys or passkeys.
 #### From the npm registry (canary)
 
 ```bash
-openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.8
+openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.9
 
 # openclaw plugins install runs `npm install --ignore-scripts`, so native
 # addons are not built automatically. Rebuild them from the plugin project dir:

--- a/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
+++ b/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
@@ -20,49 +20,56 @@ import { normalizeDidKey } from '../identity/did.js';
 // @ts-ignore - compiled JS in node_modules
 import { SignalClient } from '@algorandfoundation/liquid-client/signal';
 import { io as createSocketIoClient } from 'socket.io-client';
-// libdatachannel: modern SCTP/DTLS Node WebRTC backend, interops with react-native-webrtc.
-// @ts-ignore - polyfill ships its own types
-import * as ndc from 'node-datachannel/polyfill';
 
-// Subclass node-datachannel's RTCPeerConnection to queue remote ICE candidates
-// that arrive via trickle before setRemoteDescription completes. The Liquid Auth
-// SignalClient can race between trickling candidates and the offer/answer exchange;
-// node-datachannel is stricter than browser WebRTC and throws immediately
-// ("Got a remote candidate without ICE transport") instead of buffering silently.
-class _Ac2RTCPeerConnection extends (ndc as any).RTCPeerConnection {
-  private _ac2PendingCandidates: any[] = [];
-  private _ac2RemoteDescReady = false;
+let webRtcPolyfillReady: Promise<void> | undefined;
 
-  async setRemoteDescription(desc: any): Promise<void> {
-    this._ac2RemoteDescReady = false;
-    await super.setRemoteDescription(desc);
-    this._ac2RemoteDescReady = true;
-    const queued = this._ac2PendingCandidates.splice(0);
-    for (const c of queued) {
-      try {
-        await super.addIceCandidate(c);
-      } catch {
-        // Stale or invalid candidate after drain — safe to ignore.
+async function ensureWebRtcPolyfill(): Promise<void> {
+  if (typeof (globalThis as any).RTCPeerConnection !== 'undefined') return;
+  webRtcPolyfillReady ??= (async () => {
+    // libdatachannel: modern SCTP/DTLS Node WebRTC backend, interops with react-native-webrtc.
+    // Import lazily so plugin discovery/CLI startup does not require the native binary.
+    const ndc = await import('node-datachannel/polyfill');
+
+    // Subclass node-datachannel's RTCPeerConnection to queue remote ICE candidates
+    // that arrive via trickle before setRemoteDescription completes. The Liquid Auth
+    // SignalClient can race between trickling candidates and the offer/answer exchange;
+    // node-datachannel is stricter than browser WebRTC and throws immediately
+    // ("Got a remote candidate without ICE transport") instead of buffering silently.
+    class Ac2RTCPeerConnection extends (ndc as any).RTCPeerConnection {
+      private _ac2PendingCandidates: any[] = [];
+      private _ac2RemoteDescReady = false;
+
+      async setRemoteDescription(desc: any): Promise<void> {
+        this._ac2RemoteDescReady = false;
+        await super.setRemoteDescription(desc);
+        this._ac2RemoteDescReady = true;
+        const queued = this._ac2PendingCandidates.splice(0);
+        for (const c of queued) {
+          try {
+            await super.addIceCandidate(c);
+          } catch {
+            // Stale or invalid candidate after drain — safe to ignore.
+          }
+        }
+      }
+
+      async addIceCandidate(candidate: any): Promise<void> {
+        if (!this._ac2RemoteDescReady) {
+          this._ac2PendingCandidates.push(candidate);
+          return;
+        }
+        return super.addIceCandidate(candidate);
       }
     }
-  }
 
-  async addIceCandidate(candidate: any): Promise<void> {
-    if (!this._ac2RemoteDescReady) {
-      this._ac2PendingCandidates.push(candidate);
-      return;
+    (globalThis as any).RTCPeerConnection = Ac2RTCPeerConnection;
+    (globalThis as any).RTCIceCandidate = (ndc as any).RTCIceCandidate;
+    (globalThis as any).RTCSessionDescription = (ndc as any).RTCSessionDescription;
+    if ((ndc as any).RTCDataChannel) {
+      (globalThis as any).RTCDataChannel = (ndc as any).RTCDataChannel;
     }
-    return super.addIceCandidate(candidate);
-  }
-}
-
-if (typeof (globalThis as any).RTCPeerConnection === 'undefined') {
-  (globalThis as any).RTCPeerConnection = _Ac2RTCPeerConnection;
-  (globalThis as any).RTCIceCandidate = (ndc as any).RTCIceCandidate;
-  (globalThis as any).RTCSessionDescription = (ndc as any).RTCSessionDescription;
-  if ((ndc as any).RTCDataChannel) {
-    (globalThis as any).RTCDataChannel = (ndc as any).RTCDataChannel;
-  }
+  })();
+  await webRtcPolyfillReady;
 }
 
 /** Render a pairing payload to the terminal (QR + raw string). */
@@ -117,6 +124,8 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
   constructor(private readonly defaults: LiquidAuthChannelProviderOptions = {}) {}
 
   async startPairing(_opts: Ac2StartPairingOptions = {}): Promise<Ac2PairingHandle> {
+    await ensureWebRtcPolyfill();
+
     const origin = this.defaults.origin ?? 'https://debug.liquidauth.com';
     const requestId = this.defaults.requestId ?? SignalClient.generateRequestId();
     const includeStream = this.defaults.includeStreamChannel ?? true;


### PR DESCRIPTION
## Summary
- defer importing node-datachannel/polyfill until LiquidAuthChannelProvider.startPairing()
- make providers.liquid-auth safe to import during OpenClaw CLI/plugin discovery
- update install docs to expected canary.9

## Why
canary.8 still fails if any OpenClaw discovery path imports the Liquid Auth provider module. The provider module itself had a top-level node-datachannel/polyfill import, so startup could still crash before pairing.

## Tests
- pnpm --filter @algorandfoundation/ac2-open-claw-reference type-check
- pnpm --filter @algorandfoundation/ac2-open-claw-reference test
- pnpm --filter @algorandfoundation/ac2-open-claw-reference build
- packed-plugin smoke: provider module contains only dynamic node-datachannel import; install/enable and openclaw ac2 status work before native rebuild