### PR TITLE
fix: report missing AC2 native pairing dependency

### DIFF
--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -67,6 +67,7 @@ NDC="$PLUGIN_DIR/node_modules/node-datachannel"
 
 openclaw plugins enable ac2
 openclaw ac2 setup                                    # wire channel + tools into openclaw.json
+openclaw ac2 status                                   # works before pairing; pair requires the native rebuild above
 openclaw gateway restart
 ```
 

--- a/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
+++ b/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
@@ -44,13 +44,39 @@ const NO_IDENTITY_NOTICE =
   'actions. When you are ready, approve the identity request in your wallet to ' +
   'continue.';
 
+function isMissingNodeDataChannelError(err: unknown): boolean {
+  const message = err instanceof Error ? `${err.message}\n${err.stack ?? ''}` : String(err);
+  return message.includes('node_datachannel.node') || message.includes('node-datachannel');
+}
+
+function nativeRebuildInstructions(): string {
+  return [
+    'AC2 pairing needs the native node-datachannel module, but it is not built yet.',
+    '',
+    'Rebuild the native dependencies from the installed plugin project root:',
+    '',
+    '```bash',
+    'PLUGIN_ROOT="$(ls -d "${OPENCLAW_HOME:-$HOME/.openclaw}"/npm/projects/algorandfoundation-ac2-open-claw-reference-* | head -n1)"',
+    'npm rebuild --prefix "$PLUGIN_ROOT" @napi-rs/keyring',
+    'NDC="$PLUGIN_ROOT/node_modules/node-datachannel"',
+    'cd "$NDC"',
+    'npm install --ignore-scripts --production=false',
+    'npx cmake-js clean',
+    'npx cmake-js configure --CDUSE_NICE=1',
+    'npx cmake-js build',
+    '```',
+    '',
+    'Then run `openclaw ac2 pair` again.',
+  ].join('\n');
+}
+
 export function buildAc2Command(api: OpenClawApi): unknown {
   return {
     name: 'ac2',
     description: 'AC2 channel control (pair, status, forget).',
     acceptsArgs: true,
     requireAuth: false,
-    async handler(ctx: any): Promise<{ text: string }> {
+    async handler(ctx: any): Promise<{ text: string; keepAlive?: boolean }> {
       const args = (ctx.args ?? '').trim();
       const tokens = args.split(/\s+/).filter(Boolean);
       const sub = tokens[0] ?? 'pair';
@@ -155,7 +181,15 @@ export function buildAc2Command(api: OpenClawApi): unknown {
             'Scan the QR code with your AC2 Controller. The channel will activate once paired.',
           ].join('\n');
 
-        const firstCycle = await startPairingCycle();
+        let firstCycle: Awaited<ReturnType<typeof startPairingCycle>>;
+        try {
+          firstCycle = await startPairingCycle();
+        } catch (err) {
+          if (isMissingNodeDataChannelError(err)) {
+            return { text: nativeRebuildInstructions() };
+          }
+          throw err;
+        }
 
         const context: ChannelContext = {
           logger: {
@@ -410,6 +444,7 @@ export function buildAc2Command(api: OpenClawApi): unknown {
 
         return {
           text: buildInvitationText(firstCycle.pairing, firstCycle.qrString),
+          keepAlive: true,
         };
       }
 

--- a/packages/ac2-open-claw-reference/src/entry.ts
+++ b/packages/ac2-open-claw-reference/src/entry.ts
@@ -29,10 +29,10 @@ let cliMetadataRegistered = false;
 async function runAc2CommandHandler(
   api: OpenClawApi,
   ctx: { args?: string; isCli?: boolean },
-): Promise<{ text: string }> {
+): Promise<{ text: string; keepAlive?: boolean }> {
   const { buildAc2Command } = await import('./cli/index.js');
   const command = buildAc2Command(api) as {
-    handler: (c: { args?: string; isCli?: boolean }) => Promise<{ text: string }>;
+    handler: (c: { args?: string; isCli?: boolean }) => Promise<{ text: string; keepAlive?: boolean }>;
   };
   return command.handler(ctx);
 }
@@ -124,8 +124,7 @@ function registerCliMetadata(api: OpenClawApi): void {
               });
               console.log(result.text);
 
-              const isPair = !sub || sub === 'pair';
-              if (isPair) {
+              if (result.keepAlive === true) {
                 console.log('\n[ac2] Waiting for controller to pair... (Ctrl+C to stop)');
                 const keepAlive = setInterval(() => {}, 60000);
 


### PR DESCRIPTION
## Summary
- catch missing node-datachannel native binary during ac2 pair
- print rebuild instructions instead of letting OpenClaw report Could not start the CLI
- only keep the CLI alive when pairing actually starts
- clarify in install docs that status works before pairing, but pair requires the native rebuild

## Tests
- pnpm --filter @algorandfoundation/ac2-open-claw-reference type-check
- pnpm --filter @algorandfoundation/ac2-open-claw-reference test
- pnpm --filter @algorandfoundation/ac2-open-claw-reference build
- packed-plugin smoke: openclaw ac2 pair without native rebuild prints rebuild instructions and exits 0