### PR TITLE
docs: update AC2 install reference to canary.10

### DIFF
--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -47,7 +47,7 @@ agent never touches the user's account keys or passkeys.
 #### From the npm registry (canary)
 
 ```bash
-openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.9
+openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.10
 
 # openclaw plugins install runs `npm install --ignore-scripts`, so native
 # addons are not built automatically. Rebuild them from the plugin project dir:


### PR DESCRIPTION
## Summary
- update the AC2 OpenClaw install command from canary.9 to canary.10

## Notes
canary.10 has already been published from #15. This is docs-only and should not trigger another release.