### PR TITLE
fix(ac2-open-claw-reference): bundle libnice node-datachannel artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,37 @@ concurrency:
   group: Release
   cancel-in-progress: true
 jobs:
+  prebuild-node-datachannel:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-13, macos-14]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v5 # Honors the packageManager field
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24.x"
+          cache: "pnpm"
+      - name: Install libnice build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake libnice-dev patchelf
+      - name: Install libnice build dependencies
+        if: runner.os == 'macOS'
+        run: brew install cmake libnice
+      - run: pnpm install
+      - run: pnpm --filter @algorandfoundation/ac2-open-claw-reference build:node-datachannel-vendor
+      - uses: actions/upload-artifact@v4
+        with:
+          name: node-datachannel-${{ runner.os }}-${{ runner.arch }}
+          path: packages/ac2-open-claw-reference/vendor/node-datachannel
+          if-no-files-found: error
+
   release:
+    needs: prebuild-node-datachannel
     runs-on: ubuntu-latest
     # TODO: add support for environment
     #environment: Production
@@ -28,6 +58,11 @@ jobs:
       - run: pnpm install
       - run: pnpm run --if-present build
       - run: pnpm install # fix broken workspace for binaries
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: node-datachannel-*
+          path: packages/ac2-open-claw-reference/vendor/node-datachannel
+          merge-multiple: true
       - name: Release
         id: release
         run: pnpm run release

--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -30,52 +30,23 @@ agent never touches the user's account keys or passkeys.
 - Node.js ≥ 22, pnpm ≥ 10
 - `openclaw` CLI on `PATH`
 - `openclaw` already set up with an agent
-- A C/C++ toolchain (the plugin pulls in native addons —
-  `node-datachannel`, `@napi-rs/keyring` — that are rebuilt against your
-  Node version at install time)
-- **`cmake` and `libnice`** (with its development headers) — required to
-  build `node-datachannel` against the libnice ICE backend, which supports
-  TURN over TCP and TURNs (TURN over TLS). On macOS:
-  ```bash
-  brew install cmake libnice
-  ```
-  On Debian/Ubuntu: `apt install cmake libnice-dev`. Other platforms: see
-  your package manager for an equivalent `libnice` development package.
 
 ### Install the plugin into OpenClaw
 
 #### From the npm registry (canary)
 
 ```bash
-openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.10
-
-# openclaw plugins install runs `npm install --ignore-scripts`, so native
-# addons are not built automatically. Rebuild them from the plugin project dir:
-PLUGIN_DIR="$(ls -d "${OPENCLAW_HOME:-$HOME/.openclaw}"/npm/projects/algorandfoundation-ac2-open-claw-reference-* | head -n1)"
-
-# @napi-rs/keyring — standard prebuild-install path:
-npm rebuild --prefix "$PLUGIN_DIR" @napi-rs/keyring
-
-# node-datachannel — must be built from source against libnice (USE_NICE=1)
-# so that TURN over TCP and TURNs are supported (the prebuilt binary uses
-# libjuice which is UDP-only for TURN):
-NDC="$PLUGIN_DIR/node_modules/node-datachannel"
-(cd "$NDC" && npm install --ignore-scripts --production=false \
-  && npx cmake-js clean \
-  && npx cmake-js configure --CDUSE_NICE=1 \
-  && npx cmake-js build)
-
+openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.11
 openclaw plugins enable ac2
 openclaw ac2 setup                                    # wire channel + tools into openclaw.json
-openclaw ac2 status                                   # works before pairing; pair requires the native rebuild above
+openclaw ac2 status
 openclaw gateway restart
 ```
 
-The npm-registry install lays the plugin out at
-`${OPENCLAW_HOME:-~/.openclaw}/npm/projects/algorandfoundation-ac2-open-claw-reference-<hash>/node_modules/@algorandfoundation/ac2-open-claw-reference`,
-so `npm rebuild --prefix` must point at the **project root** (the
-`npm/projects/<slug>/` directory), not at the inner package — that's
-where the rebuildable `node_modules/` tree lives.
+The registry package includes AC2-built libnice-backed `node-datachannel`
+artifacts for supported platforms. `openclaw ac2 pair` installs the matching
+artifact into the dependency tree before loading WebRTC, so users do not need
+`cmake`, `libnice`, or a local native rebuild.
 
 #### From this monorepo (pre-release / development)
 
@@ -85,18 +56,16 @@ cd ac2
 pnpm install                                          # once, at the repo root
 
 cd packages/ac2-open-claw-reference
-pnpm install:plugin                                   # build → pack → openclaw plugins install → rebuild natives → enable
+pnpm install:plugin                                   # build → pack with local libnice artifact → install → enable
 openclaw ac2 setup                                    # wire channel + tools into openclaw.json
 openclaw gateway restart
 ```
 
 `pnpm install:plugin` builds the flat tree-shakeable `dist/`, packs a
 tarball with workspace-only devDependencies stripped, installs it into
-`${OPENCLAW_HOME:-~/.openclaw}/extensions/ac2`, rebuilds
-`@napi-rs/keyring` via `npm rebuild`, then compiles `node-datachannel` from
-source against libnice (`USE_NICE=1`) via `pnpm rebuild:node-datachannel`.
-You can also run `pnpm rebuild:node-datachannel` on its own to re-compile the
-native ICE layer without repeating the full install cycle.
+OpenClaw, and enables the plugin. The local pack step builds the current
+platform's libnice-backed `node-datachannel` artifact and includes it in the
+tarball.
 
 To uninstall (either install path):
 
@@ -145,4 +114,4 @@ Algorand payment transaction signing over AC2, retries with
   channel-owned sessions, wallet-issued agent identity, x402 exact Algorand
   paid fetch via wallet-approved signing.
 - ❌ Chain-specific verifiers, wallet introspection, holding user keys,
-  a bundled Node WebRTC stack — these belong in downstream plugins.
+  wallet UI — these belong in downstream plugins.

--- a/packages/ac2-open-claw-reference/package.json
+++ b/packages/ac2-open-claw-reference/package.json
@@ -27,6 +27,7 @@
   },
   "files": [
     "dist",
+    "vendor",
     "openclaw.plugin.json",
     "skills",
     "README.md",
@@ -51,10 +52,10 @@
     "type-check": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "build:node-datachannel-vendor": "node scripts/build-node-datachannel-vendor.mjs",
     "release": "package-releaser",
     "release:dry-run": "package-releaser --dry-run",
-    "rebuild:node-datachannel": "NDC=\"${OPENCLAW_HOME:-$HOME/.openclaw}/extensions/ac2/node_modules/node-datachannel\" && (cd \"$NDC\" && npm install --ignore-scripts --production=false && npx cmake-js clean && npx cmake-js configure --CDUSE_NICE=1 && npx cmake-js build)",
-    "install:plugin": "node scripts/bundle.mjs && tsc -p tsconfig.build.json && node scripts/bundle.mjs --flatten-dts && TGZ=\"$(node scripts/pack-plugin.mjs --pack-destination /tmp | tail -n1)\" && openclaw plugins install \"file:$TGZ\" --dangerously-force-unsafe-install --force && npm rebuild --prefix \"${OPENCLAW_HOME:-$HOME/.openclaw}/extensions/ac2\" @napi-rs/keyring && pnpm rebuild:node-datachannel && openclaw plugins enable ac2",
+    "install:plugin": "node scripts/bundle.mjs && tsc -p tsconfig.build.json && node scripts/bundle.mjs --flatten-dts && TGZ=\"$(node scripts/pack-plugin.mjs --pack-destination /tmp | tail -n1)\" && openclaw plugins install \"file:$TGZ\" --dangerously-force-unsafe-install --force && openclaw plugins enable ac2",
     "uninstall:plugin": "openclaw plugins uninstall ac2"
   },
   "release": null,

--- a/packages/ac2-open-claw-reference/scripts/build-node-datachannel-vendor.mjs
+++ b/packages/ac2-open-claw-reference/scripts/build-node-datachannel-vendor.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, parse, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = resolve(here, '..');
+const require = createRequire(import.meta.url);
+const ifMissing = process.argv.includes('--if-missing');
+
+function findPackageRoot(entrypoint) {
+  let dir = dirname(realpathSync(entrypoint));
+  const root = parse(dir).root;
+  while (dir !== root) {
+    if (existsSync(resolve(dir, 'package.json'))) return dir;
+    dir = dirname(dir);
+  }
+  throw new Error(`Could not locate package root for ${entrypoint}`);
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? pkgRoot,
+    env: { ...process.env, ...(options.env ?? {}) },
+    stdio: 'inherit',
+  });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+function check(command, args) {
+  const result = spawnSync(command, args, { stdio: 'ignore' });
+  return result.status === 0;
+}
+
+function commandOutput(command, args) {
+  const result = spawnSync(command, args, { encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} failed:\n${result.stderr}`);
+  }
+  return result.stdout;
+}
+
+function macDependencies(binary) {
+  const output = commandOutput('otool', ['-L', binary]);
+  return output
+    .split(/\r?\n/)
+    .slice(1)
+    .map((line) => line.trim().split(/\s+/)[0])
+    .filter(
+      (dep) =>
+        dep &&
+        dep !== binary &&
+        !dep.startsWith('/usr/lib/') &&
+        !dep.startsWith('/System/Library/') &&
+        !dep.startsWith('@'),
+    );
+}
+
+function vendorMacDylibs(vendorDir, rootBinary) {
+  const copied = new Map();
+  const queue = macDependencies(rootBinary);
+
+  while (queue.length > 0) {
+    const dep = queue.shift();
+    if (!dep || copied.has(dep)) continue;
+
+    const basename = dep.split('/').pop();
+    const target = resolve(vendorDir, basename);
+    if (!existsSync(target)) {
+      copyFileSync(dep, target);
+    }
+    copied.set(dep, basename);
+
+    for (const child of macDependencies(dep)) {
+      if (!copied.has(child)) queue.push(child);
+    }
+  }
+
+  const patchable = [
+    resolve(vendorDir, 'node_datachannel.node'),
+    ...readdirSync(vendorDir)
+      .filter((name) => name.endsWith('.dylib'))
+      .map((name) => resolve(vendorDir, name)),
+  ].filter((file) => statSync(file).isFile());
+
+  for (const file of patchable) {
+    if (file.endsWith('.dylib')) {
+      run('install_name_tool', ['-id', `@loader_path/${file.split('/').pop()}`, file]);
+    }
+    for (const [original, basename] of copied) {
+      run('install_name_tool', ['-change', original, `@loader_path/${basename}`, file]);
+    }
+    run('codesign', ['--force', '--sign', '-', file]);
+  }
+}
+
+function linuxDependencies(binary) {
+  const output = commandOutput('ldd', [binary]);
+  return output
+    .split(/\r?\n/)
+    .map((line) => {
+      const resolved = line.match(/=>\s+(\/\S+)\s+\(/)?.[1];
+      if (resolved) return resolved;
+      return line.trim().match(/^(\/\S+)\s+\(/)?.[1];
+    })
+    .filter(Boolean)
+    .filter((dep) => !dep.includes('linux-vdso') && !dep.includes('ld-linux'));
+}
+
+function shouldBundleLinuxLibrary(dep) {
+  const name = dep.split('/').pop();
+  return ![
+    /^libc\.so/,
+    /^libm\.so/,
+    /^libpthread\.so/,
+    /^libdl\.so/,
+    /^librt\.so/,
+    /^libgcc_s\.so/,
+    /^libstdc\+\+\.so/,
+  ].some((pattern) => pattern.test(name));
+}
+
+function vendorLinuxSharedLibraries(vendorDir, rootBinary) {
+  if (!check('patchelf', ['--version'])) {
+    console.error('[ac2] patchelf is required to vendor Linux node-datachannel libraries.');
+    process.exit(1);
+  }
+
+  const copied = new Set();
+  const queue = linuxDependencies(rootBinary).filter(shouldBundleLinuxLibrary);
+
+  while (queue.length > 0) {
+    const dep = queue.shift();
+    if (!dep) continue;
+    const basename = dep.split('/').pop();
+    if (copied.has(basename)) continue;
+    copyFileSync(dep, resolve(vendorDir, basename));
+    copied.add(basename);
+
+    for (const child of linuxDependencies(dep)) {
+      if (shouldBundleLinuxLibrary(child)) queue.push(child);
+    }
+  }
+
+  for (const file of [
+    resolve(vendorDir, 'node_datachannel.node'),
+    ...readdirSync(vendorDir)
+      .filter((name) => name.endsWith('.so') || name.includes('.so.'))
+      .map((name) => resolve(vendorDir, name)),
+  ]) {
+    if (statSync(file).isFile()) {
+      run('patchelf', ['--set-rpath', '$ORIGIN', file]);
+    }
+  }
+}
+
+const nodeDataChannelRoot = findPackageRoot(require.resolve('node-datachannel'));
+const nodeDataChannelPackage = JSON.parse(
+  readFileSync(resolve(nodeDataChannelRoot, 'package.json'), 'utf8'),
+);
+const platformKey = `${process.platform}-${process.arch}`;
+const vendorDir = resolve(pkgRoot, 'vendor', 'node-datachannel', platformKey);
+const vendorBinary = resolve(vendorDir, 'node_datachannel.node');
+
+if (ifMissing && existsSync(vendorBinary)) {
+  console.log(`[ac2] using existing libnice node-datachannel artifact for ${platformKey}`);
+  process.exit(0);
+}
+
+if (!check('cmake', ['--version'])) {
+  console.error(
+    '[ac2] cmake is required to build the libnice node-datachannel vendor artifact.',
+  );
+  process.exit(1);
+}
+if (!check('pkg-config', ['--exists', 'nice'])) {
+  console.error(
+    '[ac2] libnice development files are required to build the AC2 node-datachannel artifact.',
+  );
+  console.error('[ac2] macOS: brew install libnice');
+  console.error('[ac2] Debian/Ubuntu: sudo apt-get install libnice-dev');
+  process.exit(1);
+}
+
+run('npm', ['install', '--ignore-scripts', '--production=false'], {
+  cwd: nodeDataChannelRoot,
+  env: { npm_config_fund: 'false', npm_config_audit: 'false' },
+});
+run('npx', ['cmake-js', 'clean'], { cwd: nodeDataChannelRoot });
+run('npx', ['cmake-js', 'configure', '--CDUSE_NICE=1'], { cwd: nodeDataChannelRoot });
+run('npx', ['cmake-js', 'build'], { cwd: nodeDataChannelRoot });
+
+const sourceBinary = resolve(nodeDataChannelRoot, 'build', 'Release', 'node_datachannel.node');
+rmSync(vendorDir, { recursive: true, force: true });
+mkdirSync(vendorDir, { recursive: true });
+copyFileSync(sourceBinary, resolve(vendorDir, 'node_datachannel.node'));
+if (process.platform === 'darwin') {
+  vendorMacDylibs(vendorDir, resolve(vendorDir, 'node_datachannel.node'));
+} else if (process.platform === 'linux') {
+  vendorLinuxSharedLibraries(vendorDir, resolve(vendorDir, 'node_datachannel.node'));
+}
+writeFileSync(
+  resolve(vendorDir, 'manifest.json'),
+  `${JSON.stringify(
+    {
+      nodeDataChannel: nodeDataChannelPackage.version,
+      platform: process.platform,
+      arch: process.arch,
+      backend: 'libnice',
+      binary: 'node_datachannel.node',
+    },
+    null,
+    2,
+  )}\n`,
+);
+
+console.log(`[ac2] staged libnice node-datachannel artifact for ${platformKey}`);

--- a/packages/ac2-open-claw-reference/scripts/pack-plugin.mjs
+++ b/packages/ac2-open-claw-reference/scripts/pack-plugin.mjs
@@ -33,6 +33,15 @@ const dest = destArgIdx >= 0 ? process.argv[destArgIdx + 1] : '/tmp';
 const original = readFileSync(pkgJsonPath, 'utf8');
 const pkg = JSON.parse(original);
 
+const vendorResult = spawnSync('node', ['scripts/build-node-datachannel-vendor.mjs', '--if-missing'], {
+  cwd: pkgRoot,
+  encoding: 'utf8',
+  stdio: 'inherit',
+});
+if (vendorResult.status !== 0) {
+  process.exit(vendorResult.status ?? 1);
+}
+
 // Build the consumer-facing package.json: drop dev-only fields.
 const stripped = { ...pkg };
 delete stripped.devDependencies;
@@ -45,10 +54,10 @@ const SCRIPTS_TO_DROP = new Set([
   'type-check',
   'test',
   'test:watch',
+  'build:node-datachannel-vendor',
   'release',
   'release:dry-run',
   'dist:pack',
-  'rebuild:node-datachannel',
   'install:plugin',
   'uninstall:plugin',
   'dev:natives',

--- a/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
+++ b/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
@@ -51,22 +51,16 @@ function isMissingNodeDataChannelError(err: unknown): boolean {
 
 function nativeRebuildInstructions(): string {
   return [
-    'AC2 pairing needs the native node-datachannel module, but it is not built yet.',
+    'AC2 pairing could not load its bundled libnice node-datachannel WebRTC artifact.',
     '',
-    'Rebuild the native dependencies from the installed plugin project root:',
+    'This should not require a local rebuild. Reinstall the latest canary:',
     '',
     '```bash',
-    'PLUGIN_ROOT="$(ls -d "${OPENCLAW_HOME:-$HOME/.openclaw}"/npm/projects/algorandfoundation-ac2-open-claw-reference-* | head -n1)"',
-    'npm rebuild --prefix "$PLUGIN_ROOT" @napi-rs/keyring',
-    'NDC="$PLUGIN_ROOT/node_modules/node-datachannel"',
-    'cd "$NDC"',
-    'npm install --ignore-scripts --production=false',
-    'npx cmake-js clean',
-    'npx cmake-js configure --CDUSE_NICE=1',
-    'npx cmake-js build',
+    'openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@next --force',
+    'openclaw plugins enable ac2',
     '```',
     '',
-    'Then run `openclaw ac2 pair` again.',
+    'If this still fails, the published package is missing an AC2 WebRTC artifact for your platform.',
   ].join('\n');
 }
 

--- a/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
+++ b/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
@@ -14,6 +14,10 @@ import type {
   Ac2StartPairingOptions,
 } from '@algorandfoundation/ac2-sdk/signaling';
 import { rtcDataChannelTransport } from '@algorandfoundation/ac2-sdk/transport';
+import { copyFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, parse, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import qrcode from 'qrcode-terminal';
 import { normalizeDidKey } from '../identity/did.js';
 
@@ -23,11 +27,74 @@ import { io as createSocketIoClient } from 'socket.io-client';
 
 let webRtcPolyfillReady: Promise<void> | undefined;
 
+const require = createRequire(import.meta.url);
+
+function findPackageRoot(entrypoint: string): string {
+  let dir = dirname(entrypoint);
+  const root = parse(dir).root;
+  while (dir !== root) {
+    if (existsSync(resolve(dir, 'package.json'))) return dir;
+    dir = dirname(dir);
+  }
+  throw new Error(`Could not locate package root for ${entrypoint}`);
+}
+
+function findVendorBinary(platformKey: string): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  const root = parse(dir).root;
+  while (dir !== root) {
+    const candidate = resolve(
+      dir,
+      'vendor',
+      'node-datachannel',
+      platformKey,
+      'node_datachannel.node',
+    );
+    if (existsSync(candidate)) return candidate;
+    dir = dirname(dir);
+  }
+  return resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    'vendor',
+    'node-datachannel',
+    platformKey,
+    'node_datachannel.node',
+  );
+}
+
+function ensureBundledNodeDataChannelBinary(): void {
+  const platformKey = `${process.platform}-${process.arch}`;
+  const vendorBinary = findVendorBinary(platformKey);
+  const vendorDir = dirname(vendorBinary);
+  const nodeDataChannelRoot = findPackageRoot(require.resolve('node-datachannel'));
+  const targetBinary = resolve(
+    nodeDataChannelRoot,
+    'build',
+    'Release',
+    'node_datachannel.node',
+  );
+
+  if (!existsSync(vendorBinary)) {
+    if (existsSync(targetBinary)) return;
+    throw new Error(
+      `AC2 does not include a libnice node-datachannel binary for ${platformKey}. ` +
+        'Install the latest ac2 OpenClaw plugin canary; if this persists, this platform needs a published AC2 WebRTC artifact.',
+    );
+  }
+
+  mkdirSync(dirname(targetBinary), { recursive: true });
+  for (const entry of readdirSync(vendorDir, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+    copyFileSync(resolve(vendorDir, entry.name), resolve(dirname(targetBinary), entry.name));
+  }
+}
+
 async function ensureWebRtcPolyfill(): Promise<void> {
   if (typeof (globalThis as any).RTCPeerConnection !== 'undefined') return;
   webRtcPolyfillReady ??= (async () => {
     // libdatachannel: modern SCTP/DTLS Node WebRTC backend, interops with react-native-webrtc.
     // Import lazily so plugin discovery/CLI startup does not require the native binary.
+    ensureBundledNodeDataChannelBinary();
     const ndc = await import('node-datachannel/polyfill');
 
     // Subclass node-datachannel's RTCPeerConnection to queue remote ICE candidates


### PR DESCRIPTION
## Summary
- keep the existing node-datachannel WebRTC backend for Liquid Auth compatibility
- add release prebuild jobs that build libnice-backed node-datachannel artifacts for Linux and macOS
- vendor native library dependencies alongside the addon and rewrite runtime load paths
- copy the matching vendored artifact into node-datachannel/build/Release before loading the polyfill
- update install docs to the next expected canary: 1.0.0-canary.11

## Verification
- cd packages/ac2-open-claw-reference && ./node_modules/.bin/tsc --noEmit
- cd packages/ac2-open-claw-reference && ./node_modules/.bin/vitest run
- cd packages/ac2-open-claw-reference && node scripts/bundle.mjs && ./node_modules/.bin/tsc -p tsconfig.build.json && node scripts/bundle.mjs --flatten-dts
- built local darwin-arm64 libnice artifact with vendored dylib closure
- verified no Homebrew load paths remain in node_datachannel.node
- packed plugin tarball includes vendor/node-datachannel/darwin-arm64
- clean OpenClaw install from packed tarball had no node-datachannel build/Release binary before pairing
- openclaw ac2 pair copied the vendored artifact into node_modules/node-datachannel/build/Release and reached the pairing QR without native rebuild instructions