### PR TITLE
docs: update OpenClaw canary install version

### DIFF
--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -38,7 +38,7 @@ agent never touches the user's account keys or passkeys.
 #### From the npm registry (canary)
 
 ```bash
-openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.10
+openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.11
 
 # openclaw plugins install runs `npm install --ignore-scripts`, so native
 # addons are not built automatically. Rebuild them from the plugin project dir:


### PR DESCRIPTION
## Summary
- update the OpenClaw registry install command to use @algorandfoundation/ac2-open-claw-reference@1.0.0-canary.11

## Testing
- Not run; README-only change.