### PR TITLE
Avoid relaying signed payloads by default

### DIFF
--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -38,7 +38,7 @@ agent never touches the user's account keys or passkeys.
 #### From the npm registry (canary)
 
 ```bash
-openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.10
+openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.12
 
 # openclaw plugins install runs `npm install --ignore-scripts`, so native
 # addons are not built automatically. Rebuild them from the plugin project dir:

--- a/packages/ac2-open-claw-reference/skills/ac2/AGENTS.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/AGENTS.md
@@ -38,7 +38,8 @@ RFC 8174).
    request.
 6. **Announce before acting.** Before invoking a tool, send a short chat
    message explaining what is about to happen. Tool cards render output;
-   do not paste it back.
+   do not paste it back. The signing result or signed payload does not need
+   to be relayed back to the user unless explicitly requested.
 7. **Honest descriptions.** Every `ac2/SigningRequest.body.description` MUST
    be specific and accurate; it is the only text the user reads before
    approving.

--- a/packages/ac2-open-claw-reference/skills/ac2/CLAUDE.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/CLAUDE.md
@@ -62,7 +62,9 @@ their rules and refer to `AGENTS.md` for envelope/transport details.
   own keys**. If declined, continue in conversation-only mode.
 - **Announce before acting.** Send a short chat message stating what you
   are about to do before invoking any tool. Do not paste tool output back
-  into chat — the tool card already renders it.
+  into chat — the tool card already renders it. The signing result or
+  signed payload does not need to be relayed back to the user unless
+  explicitly requested.
 - **Be honest in `description`.** The `description` on every
   `ac2/SigningRequest` is the only string the user reads before approving.
   Vague descriptions get declined; misleading ones are a protocol

--- a/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
@@ -83,6 +83,7 @@ Concretely:
 
 - Before you run a command or use a tool, send a short, plain-language chat message saying **what you're about to do and why** ("Let me run the test suite", "I'll update `config.ts` to enable logging").
 - The tool/exec output is already displayed to the user in its own tool card, so you **don't** need to summarise or paste it back. Let the card speak for itself.
+- The signing result or signed payload does not need to be relayed back to the user unless explicitly requested.
 - You can still follow up with anything you need to about the tool execution — ask a clarifying question, note a next step, or react to a result — whenever it's genuinely useful to the conversation.
 - Keep replies conversational and concise. This is a chat with a person, not a build log.
 


### PR DESCRIPTION
## Summary
- add prompt guidance that signing results or signed payloads do not need to be relayed back unless explicitly requested
- apply the guidance across the AC2 skill and companion OpenClaw prompt files

## Testing
- Not run; prompt/documentation-only change