### PR TITLE
Fix x402 demo prompt and signing copy

### DIFF
--- a/packages/ac2-open-claw-reference/openclaw.plugin.json
+++ b/packages/ac2-open-claw-reference/openclaw.plugin.json
@@ -130,13 +130,13 @@
     },
     "ac2_x402_fetch": {
       "label": "AC2 x402 Fetch",
-      "description": "Fetch an HTTP(S) resource that may require x402 payment. When the server returns 402, this tool uses x402 exact payments on Algorand, asks the paired wallet to approve the required Algorand transaction signing over AC2, retries with PAYMENT-SIGNATURE, and returns the HTTP/payment result. Requires an active `ac2` channel.",
+      "description": "Fetch an HTTP(S) resource that may require x402 payment. Use this tool for weather requests, including ordinary questions like \"what is the weather like today?\"; if no weather URL is provided, use https://example.x402.goplausible.xyz/avm/weather. When the server returns 402, this tool uses x402 exact payments on Algorand, asks the paired wallet to approve the required Algorand transaction signing over AC2, retries with PAYMENT-SIGNATURE, and returns the HTTP/payment result. Requires an active `ac2` channel.",
       "parameters": {
         "type": "object",
         "properties": {
           "url": {
             "type": "string",
-            "description": "Absolute HTTP(S) URL to fetch."
+            "description": "Absolute HTTP(S) URL to fetch. For weather requests without a user-provided URL, use https://example.x402.goplausible.xyz/avm/weather."
           },
           "method": {
             "type": "string",

--- a/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
@@ -96,9 +96,9 @@ Concretely:
 
 ## Paid HTTP with x402 on Algorand
 
-Use **`ac2_x402_fetch`** when the user asks you to call a paid API/resource that uses x402, or when a normal fetch returns an x402 `402 Payment Required` response.
+Use **`ac2_x402_fetch`** when the user asks you to call a paid API/resource that uses x402, when a normal fetch returns an x402 `402 Payment Required` response, or when the user asks an ordinary weather question such as "what's the weather like today?"
 
-If the user asks you to fetch the weather and does not provide a URL, use `https://example.x402.goplausible.xyz/avm/weather`.
+If the user asks about weather and does not provide a URL, use `https://example.x402.goplausible.xyz/avm/weather`. Do not fall back to regular web search for weather first; the weather demo is intentionally routed through the x402 endpoint.
 
 The tool:
 

--- a/packages/ac2-open-claw-reference/src/tools/manifest.ts
+++ b/packages/ac2-open-claw-reference/src/tools/manifest.ts
@@ -120,10 +120,11 @@ const plugin = defineToolPlugin({
       name: 'ac2_x402_fetch',
       label: 'AC2 x402 Fetch',
       description:
-        'Fetch an HTTP(S) resource that may require x402 payment. When the server returns 402, this tool uses x402 exact payments on Algorand, asks the paired wallet to approve the required Algorand transaction signing over AC2, retries with PAYMENT-SIGNATURE, and returns the HTTP/payment result. Requires an active `ac2` channel.',
+        'Fetch an HTTP(S) resource that may require x402 payment. Use this tool for weather requests, including ordinary questions like "what is the weather like today?"; if no weather URL is provided, use https://example.x402.goplausible.xyz/avm/weather. When the server returns 402, this tool uses x402 exact payments on Algorand, asks the paired wallet to approve the required Algorand transaction signing over AC2, retries with PAYMENT-SIGNATURE, and returns the HTTP/payment result. Requires an active `ac2` channel.',
       parameters: Type.Object({
         url: Type.String({
-          description: 'Absolute HTTP(S) URL to fetch.',
+          description:
+            'Absolute HTTP(S) URL to fetch. For weather requests without a user-provided URL, use https://example.x402.goplausible.xyz/avm/weather.',
         }),
         method: Type.Optional(
           Type.Union(

--- a/packages/ac2-open-claw-reference/src/x402/ac2-avm-signer.ts
+++ b/packages/ac2-open-claw-reference/src/x402/ac2-avm-signer.ts
@@ -90,6 +90,21 @@ function formatAmount(amount: bigint | undefined): string {
   return amount === undefined ? 'unknown amount' : amount.toString();
 }
 
+function compactAddress(address: string): string {
+  return address.length > 16 ? `${address.slice(0, 8)}...${address.slice(-6)}` : address;
+}
+
+function formatNetwork(network: string | undefined): string {
+  if (!network) return 'Algorand';
+  if (network.includes('SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=')) {
+    return 'Algorand TestNet';
+  }
+  if (network.includes('wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=')) {
+    return 'Algorand MainNet';
+  }
+  return network.startsWith('algorand:') ? 'Algorand' : network;
+}
+
 function summarizeTransaction(txn: Transaction): string {
   if (txn.type === TransactionType.AssetTransfer && txn.assetTransfer) {
     const xfer = txn.assetTransfer;
@@ -97,7 +112,7 @@ function summarizeTransaction(txn: Transaction): string {
       'ASA transfer',
       `asset ${xfer.assetId.toString()}`,
       `amount ${formatAmount(xfer.amount)}`,
-      `to ${xfer.receiver.toString()}`,
+      `to ${compactAddress(xfer.receiver.toString())}`,
     ].join(' · ');
   }
 
@@ -106,22 +121,24 @@ function summarizeTransaction(txn: Transaction): string {
     return [
       'ALGO payment',
       `${formatAmount(payment.amount)} microAlgos`,
-      `to ${payment.receiver.toString()}`,
+      `to ${compactAddress(payment.receiver.toString())}`,
     ].join(' · ');
   }
 
   return `Algorand ${txn.type} transaction`;
 }
 
-function formatResource(resource?: ResourceInfo): string {
+function resourceName(resource?: ResourceInfo): string {
+  const name = resource?.description ?? resource?.serviceName;
+  return typeof name === 'string' && name.trim().length > 0 ? name.trim() : 'paid resource';
+}
+
+function resourceDetails(resource?: ResourceInfo): string {
   if (!resource) return '';
-  const parts = [
-    resource.description,
-    resource.serviceName,
-    resource.url,
-    resource.mimeType,
-  ].filter((v): v is string => typeof v === 'string' && v.trim().length > 0);
-  return parts.length > 0 ? `\nResource: ${parts.join(' · ')}` : '';
+  const parts = [resource.url, resource.mimeType].filter(
+    (v): v is string => typeof v === 'string' && v.trim().length > 0,
+  );
+  return parts.length > 0 ? `Resource: ${parts.join(' · ')}` : '';
 }
 
 function buildSigningDescription(args: {
@@ -132,22 +149,25 @@ function buildSigningDescription(args: {
   readonly paymentContext?: X402PaymentContext;
 }): string {
   const req = args.paymentContext?.requirements;
-  const requirementLine = req
-    ? [
-        `x402 exact payment`,
-        `network ${req.network}`,
-        `asset ${req.asset}`,
-        `amount ${req.amount}`,
-        `payTo ${req.payTo}`,
-      ].join(' · ')
-    : 'x402 exact Algorand payment';
+  const resource = args.paymentContext?.resource;
+  const title = `Approve x402 payment for ${resourceName(resource)}.`;
+  const paymentLine = req
+    ? `Payment: ${req.amount} of asset ${req.asset} to ${compactAddress(req.payTo)}.`
+    : 'Payment: exact Algorand payment.';
+  const networkLine = `Network: ${formatNetwork(req?.network)}.`;
+  const signingLine = `Sign transaction ${args.txnIndex + 1} of ${args.groupSize} as ${compactAddress(
+    args.signerAddress,
+  )}.`;
+  const senderLine = `Sender: ${compactAddress(args.txn.sender.toString())}.`;
 
   return [
-    requirementLine,
-    `Sign transaction ${args.txnIndex + 1} of ${args.groupSize} as ${args.signerAddress}.`,
+    title,
+    paymentLine,
+    networkLine,
+    signingLine,
     summarizeTransaction(args.txn),
-    `Sender: ${args.txn.sender.toString()}`,
-    formatResource(args.paymentContext?.resource),
+    senderLine,
+    resourceDetails(resource),
   ]
     .filter(Boolean)
     .join('\n');

--- a/packages/ac2-open-claw-reference/tests/plugin.test.ts
+++ b/packages/ac2-open-claw-reference/tests/plugin.test.ts
@@ -429,6 +429,11 @@ describe('ac2 plugin', () => {
             maxTimeoutSeconds: 60,
             extra: {},
           },
+          resource: {
+            description: 'Weather data',
+            url: 'https://example.x402.goplausible.xyz/avm/weather',
+            mimeType: 'application/json',
+          },
         }),
       });
 
@@ -447,8 +452,13 @@ describe('ac2 plugin', () => {
       expect(observedRequest.body.key_type).toBe('account');
       expect(observedRequest.body.payload).toBe(expectedPayload);
       expect(observedRequest.body.payload).not.toBe(rawUnsignedPayload);
-      expect(observedRequest.body.description).toContain('x402 exact payment');
-      expect(observedRequest.body.description).toContain(receiver.toString());
+      expect(observedRequest.body.description).toContain('Approve x402 payment for Weather data.');
+      expect(observedRequest.body.description).toContain('Payment: 123 of asset 10458941');
+      expect(observedRequest.body.description).toContain('Network: Algorand TestNet.');
+      expect(observedRequest.body.description).toContain(
+        `${receiver.toString().slice(0, 8)}...${receiver.toString().slice(-6)}`,
+      );
+      expect(observedRequest.body.description).not.toContain(receiver.toString());
     });
 
     it('uses the linked AC2 wallet address as the x402 payment sender', async () => {
@@ -504,8 +514,12 @@ describe('ac2 plugin', () => {
       expect(signer.address).toBe(sender.toString());
       const signed = await signer.signTransactions([encodeTransactionRaw(txn)], [0]);
       expect(signed[0]).toBeInstanceOf(Uint8Array);
-      expect(observedRequest.body.description).toContain(`as ${sender.toString()}`);
-      expect(observedRequest.body.description).toContain(`Sender: ${sender.toString()}`);
+      expect(observedRequest.body.description).toContain(
+        `as ${sender.toString().slice(0, 8)}...${sender.toString().slice(-6)}`,
+      );
+      expect(observedRequest.body.description).toContain(
+        `Sender: ${sender.toString().slice(0, 8)}...${sender.toString().slice(-6)}`,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- make x402 signing descriptions wallet-friendly while preserving raw Ed25519 transaction signing bytes
- route ordinary weather questions toward the x402 weather demo endpoint in tool metadata and skill guidance
- update plugin tests for the new signing copy and weather resource context

## Tests
- ./node_modules/.bin/vitest run
- ./node_modules/.bin/tsc --noEmit