### PR TITLE
fix(openclaw): allow AC2 reconnect after heartbeat close

### DIFF
--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -109,6 +109,8 @@ Once installed, `openclaw.json` will contain an entry like:
 ```
 
 `AC2_LIQUID_AUTH_SERVER` overrides `liquidAuthServer` at runtime.
+`AC2_HEARTBEAT_TIMEOUT_MS` overrides the WebRTC heartbeat liveness timeout;
+it defaults to `50000`.
 
 ### Using it
 

--- a/packages/ac2-open-claw-reference/openclaw.plugin.json
+++ b/packages/ac2-open-claw-reference/openclaw.plugin.json
@@ -9,6 +9,11 @@
       "name": "AC2_LIQUID_AUTH_SERVER",
       "description": "Liquid Auth signaling server origin. Overrides the `liquidAuthServer` channel config at runtime. Defaults to https://debug.liquidauth.com when neither is set.",
       "required": false
+    },
+    {
+      "name": "AC2_HEARTBEAT_TIMEOUT_MS",
+      "description": "Milliseconds without inbound ac2-heartbeat traffic before the plugin closes the channel. Defaults to 50000.",
+      "required": false
     }
   ],
   "skills": ["./skills"],

--- a/packages/ac2-open-claw-reference/package.json
+++ b/packages/ac2-open-claw-reference/package.json
@@ -93,6 +93,11 @@
         "name": "AC2_LIQUID_AUTH_SERVER",
         "description": "Liquid Auth signaling server origin. Overrides the `liquidAuthServer` channel config at runtime. Defaults to https://debug.liquidauth.com when neither is set.",
         "required": false
+      },
+      {
+        "name": "AC2_HEARTBEAT_TIMEOUT_MS",
+        "description": "Milliseconds without inbound ac2-heartbeat traffic before the plugin closes the channel. Defaults to 50000.",
+        "required": false
       }
     ],
     "contracts": {

--- a/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
+++ b/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
@@ -105,13 +105,36 @@ const AC2_HEARTBEAT_MS = 20000;
  * Treat the peer as gone if we receive no `ac2-heartbeat` traffic for this
  * long. 2.5× the send interval tolerates one missed round-trip plus jitter.
  */
-const AC2_HEARTBEAT_TIMEOUT_MS = AC2_HEARTBEAT_MS * 2.5;
+const AC2_DEFAULT_HEARTBEAT_TIMEOUT_MS = AC2_HEARTBEAT_MS * 2.5;
 const AC2_CONTROL_LABEL = 'ac2-v1' as const;
 const AC2_STREAM_LABEL = 'ac2-stream' as const;
 /** Dedicated liveness channel — keeps keepalive off the control plane. */
 const AC2_HEARTBEAT_LABEL = 'ac2-heartbeat' as const;
 const AC2_HEARTBEAT_PING = 'ping' as const;
 const AC2_HEARTBEAT_PONG = 'pong' as const;
+
+export function closeRtcDataChannel(channel: unknown): void {
+  if (
+    channel &&
+    typeof (channel as { close?: unknown }).close === 'function' &&
+    (channel as { readyState?: unknown }).readyState !== 'closed'
+  ) {
+    try {
+      (channel as { close: () => void }).close();
+    } catch {
+      // Already closing/closed; ignore.
+    }
+  }
+}
+
+export function resolveHeartbeatTimeoutMs(value?: string): number {
+  if (value === undefined || value.trim().length === 0) return AC2_DEFAULT_HEARTBEAT_TIMEOUT_MS;
+  const parsed = Number(value);
+  const minimum = AC2_HEARTBEAT_MS * 2;
+  return Number.isFinite(parsed) && parsed >= minimum
+    ? parsed
+    : AC2_DEFAULT_HEARTBEAT_TIMEOUT_MS;
+}
 
 export interface LiquidAuthChannelProviderOptions {
   /** Liquid Auth signaling server origin. */
@@ -120,6 +143,8 @@ export interface LiquidAuthChannelProviderOptions {
   requestId?: string;
   /** Request the optional `ac2-stream` channel (default `true`). */
   includeStreamChannel?: boolean;
+  /** Milliseconds without inbound heartbeat traffic before closing. */
+  heartbeatTimeoutMs?: number;
 }
 
 export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
@@ -131,6 +156,9 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
     const origin = this.defaults.origin ?? 'https://debug.liquidauth.com';
     const requestId = this.defaults.requestId ?? SignalClient.generateRequestId();
     const includeStream = this.defaults.includeStreamChannel ?? true;
+    const heartbeatTimeoutMs =
+      this.defaults.heartbeatTimeoutMs ??
+      resolveHeartbeatTimeoutMs(process.env['AC2_HEARTBEAT_TIMEOUT_MS']);
 
     // Build the signaling socket from the Node-native `socket.io-client` and
     // pass it to `SignalClient` via its `{ socket }` option.
@@ -265,8 +293,13 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
       // Bidirectional keep-alive: each side pings on its own timer AND replies
       // PONG to the peer's pings. `lastInboundAt` is updated on any inbound
       // frame (PING or PONG); the interval below declares the peer dead if no
-      // inbound traffic arrives within AC2_HEARTBEAT_TIMEOUT_MS and triggers
+      // inbound traffic arrives within `heartbeatTimeoutMs` and triggers
       // `close()` so the control transport's `onClose` propagates upstream.
+      //
+      // The heartbeat channel is optional and mobile controllers can suspend
+      // it while backgrounded. Only enforce the timeout when the heartbeat
+      // channel is present and open; the WebRTC/control close handlers remain
+      // authoritative for peers that really go away.
       let lastInboundAt = Date.now();
 
       if (heartbeatChannel) {
@@ -283,10 +316,12 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
       }
 
       heartbeat = setInterval(() => {
-        if (Date.now() - lastInboundAt > AC2_HEARTBEAT_TIMEOUT_MS) {
+        if (!heartbeatChannel || heartbeatChannel.readyState !== 'open') return;
+
+        if (Date.now() - lastInboundAt > heartbeatTimeoutMs) {
           // eslint-disable-next-line no-console
           console.warn(
-            `[ac2] Heartbeat timeout (${AC2_HEARTBEAT_TIMEOUT_MS}ms with no inbound) — closing channel.`,
+            `[ac2] Heartbeat timeout (${heartbeatTimeoutMs}ms with no inbound) — closing channel.`,
           );
           void close();
           return;
@@ -307,6 +342,9 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
           clearInterval(heartbeat);
           heartbeat = undefined;
         }
+        closeRtcDataChannel(heartbeatChannel);
+        closeRtcDataChannel(streamChannel);
+        closeRtcDataChannel(controlChannel);
         try {
           client.close(true);
         } catch {

--- a/packages/ac2-open-claw-reference/tests/liquid-auth-provider.test.ts
+++ b/packages/ac2-open-claw-reference/tests/liquid-auth-provider.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { closeRtcDataChannel, resolveHeartbeatTimeoutMs } from '../src/providers/liquid-auth.js';
+
+describe('LiquidAuthChannelProvider heartbeat timeout', () => {
+  it('defaults to the standard heartbeat timeout', () => {
+    expect(resolveHeartbeatTimeoutMs()).toBe(50_000);
+    expect(resolveHeartbeatTimeoutMs('')).toBe(50_000);
+  });
+
+  it('accepts timeout overrides at or above two heartbeat intervals', () => {
+    expect(resolveHeartbeatTimeoutMs('40000')).toBe(40_000);
+    expect(resolveHeartbeatTimeoutMs('900000')).toBe(900_000);
+  });
+
+  it('falls back for invalid or too-small overrides', () => {
+    expect(resolveHeartbeatTimeoutMs('not-a-number')).toBe(50_000);
+    expect(resolveHeartbeatTimeoutMs('39999')).toBe(50_000);
+  });
+});
+
+describe('closeRtcDataChannel', () => {
+  it('closes non-closed DataChannels', () => {
+    let closed = false;
+    closeRtcDataChannel({
+      readyState: 'open',
+      close: () => {
+        closed = true;
+      },
+    });
+    expect(closed).toBe(true);
+  });
+
+  it('ignores absent, already closed, or throwing channels', () => {
+    expect(() => closeRtcDataChannel(undefined)).not.toThrow();
+    expect(() =>
+      closeRtcDataChannel({
+        readyState: 'closed',
+        close: () => {
+          throw new Error('should not be called');
+        },
+      }),
+    ).not.toThrow();
+    expect(() =>
+      closeRtcDataChannel({
+        readyState: 'closing',
+        close: () => {
+          throw new Error('already closing');
+        },
+      }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- close the negotiated AC2 WebRTC DataChannels when heartbeat liveness forces a Liquid Auth close
- avoid enforcing heartbeat timeouts when the optional heartbeat channel is absent/closed
- expose AC2_HEARTBEAT_TIMEOUT_MS as a documented override and add provider tests

## Testing
- pnpm --filter @algorandfoundation/ac2-open-claw-reference test
- pnpm --filter @algorandfoundation/ac2-open-claw-reference type-check
- pnpm --filter @algorandfoundation/ac2-open-claw-reference build