### PR TITLE
docs(openclaw): update canary install version

### DIFF
--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -39,7 +39,7 @@ agent never touches the user's account keys or passkeys.
 #### From the npm registry (canary)
 
 ```bash
-openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.15
+openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.16
 
 # openclaw plugins install runs `npm install --ignore-scripts`, so the
 # @napi-rs/keyring native addon is not built automatically. Rebuild it from


### PR DESCRIPTION
## Summary
- update the OpenClaw plugin README install command to use ac2-open-claw-reference@1.0.0-canary.16

## Testing
- not run; README-only change