### PR TITLE
fix(openclaw): reconnect after forced heartbeat close

### DIFF
--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -39,7 +39,7 @@ agent never touches the user's account keys or passkeys.
 #### From the npm registry (canary)
 
 ```bash
-openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.16
+openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.17
 
 # openclaw plugins install runs `npm install --ignore-scripts`, so the
 # @napi-rs/keyring native addon is not built automatically. Rebuild it from

--- a/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
+++ b/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
@@ -13,7 +13,7 @@ import type {
   Ac2PairingInfo,
   Ac2StartPairingOptions,
 } from '@algorandfoundation/ac2-sdk/signaling';
-import { rtcDataChannelTransport } from '@algorandfoundation/ac2-sdk/transport';
+import { rtcDataChannelTransport, type Ac2Transport } from '@algorandfoundation/ac2-sdk/transport';
 import qrcode from 'qrcode-terminal';
 import { normalizeDidKey } from '../identity/did.js';
 
@@ -125,6 +125,57 @@ export function closeRtcDataChannel(channel: unknown): void {
       // Already closing/closed; ignore.
     }
   }
+}
+
+export function closeAwareTransport(base: Ac2Transport): {
+  transport: Ac2Transport;
+  emitClose: () => void;
+} {
+  const closeHandlers = new Set<() => void>();
+  let closeEmitted = false;
+
+  const emitClose = (): void => {
+    if (closeEmitted) return;
+    closeEmitted = true;
+    for (const handler of closeHandlers) {
+      try {
+        handler();
+      } catch {
+        // Close notifications are best-effort; keep notifying the rest.
+      }
+    }
+    closeHandlers.clear();
+  };
+
+  base.onClose(emitClose);
+
+  const transport: Ac2Transport = {
+    send: (payload) => base.send(payload),
+    onMessage: (handler) => base.onMessage(handler),
+    onRawMessage: (handler) => base.onRawMessage?.(handler),
+    onBinaryMessage: (handler) => base.onBinaryMessage?.(handler),
+    onError: (handler) => base.onError(handler),
+    onOpen: (handler) => base.onOpen(handler),
+    onClose: (handler) => {
+      if (closeEmitted) {
+        handler();
+        return;
+      }
+      closeHandlers.add(handler);
+    },
+    close: () => {
+      try {
+        base.close();
+      } finally {
+        emitClose();
+      }
+    },
+    get isOpen() {
+      return base.isOpen;
+    },
+  };
+
+  return { transport, emitClose };
 }
 
 export function resolveHeartbeatTimeoutMs(value?: string): number {
@@ -271,7 +322,7 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
       // Brief grace period so the app attaches handlers before resolve.
       await new Promise((resolve) => setTimeout(resolve, 500));
 
-      const transport = rtcDataChannelTransport(controlChannel);
+      const { transport, emitClose } = closeAwareTransport(rtcDataChannelTransport(controlChannel));
 
       if (!transport.isOpen) {
         await new Promise<void>((resolve, reject) => {
@@ -345,6 +396,7 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
         closeRtcDataChannel(heartbeatChannel);
         closeRtcDataChannel(streamChannel);
         closeRtcDataChannel(controlChannel);
+        emitClose();
         try {
           client.close(true);
         } catch {

--- a/packages/ac2-open-claw-reference/tests/liquid-auth-provider.test.ts
+++ b/packages/ac2-open-claw-reference/tests/liquid-auth-provider.test.ts
@@ -1,6 +1,33 @@
 import { describe, expect, it } from 'vitest';
+import type { Ac2Transport } from '@algorandfoundation/ac2-sdk/transport';
 
-import { closeRtcDataChannel, resolveHeartbeatTimeoutMs } from '../src/providers/liquid-auth.js';
+import {
+  closeAwareTransport,
+  closeRtcDataChannel,
+  resolveHeartbeatTimeoutMs,
+} from '../src/providers/liquid-auth.js';
+
+function makeBaseTransport(): Ac2Transport & { emitBaseClose: () => void; closes: () => number } {
+  let closeHandler: (() => void) | undefined;
+  let closes = 0;
+  return {
+    send: () => {},
+    onMessage: () => {},
+    onError: () => {},
+    onOpen: () => {},
+    onClose: (handler) => {
+      closeHandler = handler;
+    },
+    close: () => {
+      closes += 1;
+    },
+    get isOpen() {
+      return true;
+    },
+    emitBaseClose: () => closeHandler?.(),
+    closes: () => closes,
+  };
+}
 
 describe('LiquidAuthChannelProvider heartbeat timeout', () => {
   it('defaults to the standard heartbeat timeout', () => {
@@ -49,5 +76,58 @@ describe('closeRtcDataChannel', () => {
         },
       }),
     ).not.toThrow();
+  });
+});
+
+describe('closeAwareTransport', () => {
+  it('notifies every close listener when the base transport closes', () => {
+    const base = makeBaseTransport();
+    const { transport } = closeAwareTransport(base);
+    const seen: string[] = [];
+
+    transport.onClose(() => seen.push('client'));
+    transport.onClose(() => seen.push('session-loop'));
+    base.emitBaseClose();
+
+    expect(seen).toEqual(['client', 'session-loop']);
+  });
+
+  it('emits close when the provider closes the transport even if the base does not', () => {
+    const base = makeBaseTransport();
+    const { transport, emitClose } = closeAwareTransport(base);
+    const seen: string[] = [];
+
+    transport.onClose(() => seen.push('session-loop'));
+    emitClose();
+    emitClose();
+
+    expect(seen).toEqual(['session-loop']);
+  });
+
+  it('emits close from transport.close for native transports that do not emit onclose', () => {
+    const base = makeBaseTransport();
+    const { transport } = closeAwareTransport(base);
+    let closed = 0;
+
+    transport.onClose(() => {
+      closed += 1;
+    });
+    transport.close();
+
+    expect(base.closes()).toBe(1);
+    expect(closed).toBe(1);
+  });
+
+  it('immediately calls listeners registered after close emission', () => {
+    const base = makeBaseTransport();
+    const { transport, emitClose } = closeAwareTransport(base);
+    let closed = 0;
+
+    emitClose();
+    transport.onClose(() => {
+      closed += 1;
+    });
+
+    expect(closed).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- wrap the Liquid Auth control transport so multiple close listeners are notified
- emit a provider-level close notification when heartbeat liveness forces a disconnect, even if native WebRTC DataChannel onclose does not fire
- update the README install snippet to the expected next canary version

## Testing
- pnpm exec vitest run tests/liquid-auth-provider.test.ts
- pnpm --filter @algorandfoundation/ac2-open-claw-reference type-check
- pnpm --filter @algorandfoundation/ac2-open-claw-reference test
- pnpm --filter @algorandfoundation/ac2-open-claw-reference build