### PR TITLE
feat(openclaw): expose Algorand wallet address to agents

### DIFF
--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -39,7 +39,7 @@ agent never touches the user's account keys or passkeys.
 #### From the npm registry (canary)
 
 ```bash
-openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.17
+openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.18
 
 # openclaw plugins install runs `npm install --ignore-scripts`, so the
 # @napi-rs/keyring native addon is not built automatically. Rebuild it from

--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -10,7 +10,7 @@ Liquid Auth + WebRTC via [`@algorandfoundation/ac2-sdk`](../ac2-sdk).
 | OpenClaw surface        | AC2 contribution                                                           |
 | ----------------------- | -------------------------------------------------------------------------- |
 | Channel `ac2`           | Owns Liquid Auth + WebRTC pairing and the active session.                  |
-| Tool `ac2_capabilities` | Agent DID + `sig_hint` catalog.                                            |
+| Tool `ac2_capabilities` | Agent DID, connected wallet address, and `sig_hint` catalog.              |
 | Tool `ac2_sign`         | Routes a `SigningRequest` and returns signature details to the agent.      |
 | Tool `ac2_x402_fetch`   | Pays x402 exact Algorand resources using wallet-approved AC2 signing.      |
 | Setup entry             | `openclaw ac2 setup` writes the channel/tools wiring into `openclaw.json`. |

--- a/packages/ac2-open-claw-reference/openclaw.plugin.json
+++ b/packages/ac2-open-claw-reference/openclaw.plugin.json
@@ -121,7 +121,7 @@
     },
     "ac2_capabilities": {
       "label": "AC2 Capabilities",
-      "description": "Return the agent's AC2 descriptor and the protocol catalog of sig_hints. Reports whether an `ac2` channel session is currently active. Downstream wallet-specific plugins extend this with live wallet identities/accounts.",
+      "description": "Return the agent's AC2 descriptor, the protocol catalog of sig_hints, and the connected wallet's public Algorand address. Reports whether an `ac2` channel session is currently active. Downstream wallet-specific plugins may extend this with additional live wallet identities/accounts.",
       "parameters": {
         "type": "object",
         "properties": {

--- a/packages/ac2-open-claw-reference/skills/ac2/CLAUDE.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/CLAUDE.md
@@ -49,11 +49,14 @@ their rules and refer to `AGENTS.md` for envelope/transport details.
 - MUST NOT bypass the `ac2-v1` DataChannel for any AC2 message.
 - MUST NOT report a placeholder identity (e.g. `did:key:zAc2Controller`);
   always answer from `ac2_capabilities`.
+- MUST NOT guess or infer an Algorand sender in the model; use
+  `ac2_capabilities.session.walletAddress`.
 
 ## Operating Posture
 
 - **Call `ac2_capabilities` at most once per turn** to ground identity,
-  connection status, and the `sig_hint` catalog. Cache for the turn only.
+  connection status, the public Algorand wallet address, and the `sig_hint`
+  catalog. Cache for the turn only.
 - **Connection first.** If `status: "no_active_session"`, ask the user to
   open and connect their AC2 Controller / wallet on the `ac2` channel and
   stop. Do not retry in a loop.

--- a/packages/ac2-open-claw-reference/skills/ac2/IDENTITY.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/IDENTITY.md
@@ -32,6 +32,7 @@ The agent presents itself via these fields, populated at runtime by
 | `name`          | `ac2_capabilities.agent.plugin.id`       | Human-readable plugin identifier (`ac2`).                                                           |
 | `version`       | `ac2_capabilities.agent.plugin.version`  | Plugin semver.                                                                                                          |
 | `controllerDid` | `ac2_capabilities.session.controllerDid` | The Controller account currently paired (NOT part of the agent's identity — it identifies the _peer_).                  |
+| `walletAddress` | `ac2_capabilities.session.walletAddress` | The Controller's validated public Algorand account address, suitable for manually constructing transactions.            |
 
 The agent MUST NOT report a hard-coded placeholder DID (e.g. the legacy
 `did:key:zAc2Controller`). If `agent.did` is `null`, the agent MUST report

--- a/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
@@ -41,6 +41,7 @@ The tool returns:
 - `agent.sigHintsCatalog` — the protocol catalog of sig_hints AC2 defines. This is **not** a list of what the connected wallet actually supports; it's the universe of valid `sig_hint` strings. Pick from this list when calling `ac2_sign`.
 - `session.connected` — boolean mirror of `status`.
 - `session.controllerDid` — the **connected account**: the `did:key` of the wallet account that paired with you (taken from the Liquid Auth link response, not a hard-coded placeholder). This is who is on the other end; use it when the user asks which account/wallet is connected.
+- `session.walletAddress` — the connected wallet's validated, public Algorand account address. Use this value when the user asks for their address or when you need to construct an Algorand transaction manually. It is `null` when no address can be resolved; never guess or derive a replacement in the model.
 
 ## Knowing your identity
 
@@ -48,6 +49,7 @@ You have two distinct `did:key` identities in every session, both surfaced by `a
 
 - **Your identity** (`agent.did`) — the DID bound to the identity key the user's wallet issued you. It is _yours_; you sign and present yourself as this DID. You never hold its private key — the wallet does — but this DID is who you are on the AC2 channel.
 - **The connected account** (`session.controllerDid`) — the user's wallet account that is paired with you right now.
+- **The connected Algorand address** (`session.walletAddress`) — the public account to use as the sender when manually constructing Algorand transactions for this session.
 
 When the user asks about "your identity", "your DID", "your did:key", or "who am I connected to", call `ac2_capabilities` (if you haven't already this turn) and answer from these fields rather than guessing or inventing a value. Never report a placeholder like `did:key:zAc2Controller` — that was a legacy hard-coded value; the real connected account is in `session.controllerDid`.
 

--- a/packages/ac2-open-claw-reference/skills/ac2/SOUL.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/SOUL.md
@@ -107,8 +107,14 @@ Before answering any of the following, you MUST call `ac2_capabilities`
 
 - "What is your DID / did:key / identity?" → `agent.did`.
 - "Who am I connected as?" / "Which account is paired?" → `session.controllerDid`.
+- "What is my Algorand/wallet address?" → `session.walletAddress`.
 - "What can you sign?" → entries from `agent.sigHintsCatalog`, with the
   caveat that the connected wallet may not support every catalog entry.
+
+When manually constructing an Algorand transaction, use
+`session.walletAddress` as the connected account. If it is `null`, stop and
+explain that no Algorand address is available for the active session; never
+guess one.
 
 Never report the legacy placeholder `did:key:zAc2Controller`.
 

--- a/packages/ac2-open-claw-reference/src/session/flows.ts
+++ b/packages/ac2-open-claw-reference/src/session/flows.ts
@@ -4,6 +4,7 @@ import type { BuildSigningRequestArgs, SigningOutcome } from '@algorandfoundatio
 import type { SigningRequestBody } from '@algorandfoundation/ac2-sdk/schema';
 import type { PluginConfig, ToolContext } from './contracts.js';
 import { SessionManager, sessionManager } from './manager.js';
+import { sessionAlgorandAddress } from './wallet-address.js';
 
 const STREAM_CONTROL_PREFIX = '\u0002';
 
@@ -115,6 +116,8 @@ export interface CapabilitiesResult {
     connected: boolean;
     /** Connected controller account, populated once a session is active. */
     controllerDid: string | null;
+    /** Public Algorand account bound to the connected controller. */
+    walletAddress: string | null;
   };
 }
 
@@ -133,6 +136,10 @@ export function capabilitiesFlow(_config: PluginConfig, deps: SignDeps = {}): Ca
         SigningRequestBody['sig_hint']
       >,
     },
-    session: { connected: active !== null, controllerDid: active?.controllerDid ?? null },
+    session: {
+      connected: active !== null,
+      controllerDid: active?.controllerDid ?? null,
+      walletAddress: active ? (sessionAlgorandAddress(active) ?? null) : null,
+    },
   };
 }

--- a/packages/ac2-open-claw-reference/src/session/index.ts
+++ b/packages/ac2-open-claw-reference/src/session/index.ts
@@ -20,6 +20,10 @@ export {
   type ActiveSession,
 } from './manager.js';
 export {
+  controllerDidToAlgorandAddress,
+  sessionAlgorandAddress,
+} from './wallet-address.js';
+export {
   BootstrapError,
   bootstrapAgentIdentity,
   deriveAgentDidFromKeyResponse,

--- a/packages/ac2-open-claw-reference/src/session/wallet-address.ts
+++ b/packages/ac2-open-claw-reference/src/session/wallet-address.ts
@@ -1,0 +1,27 @@
+/** Resolve the public Algorand account bound to an active AC2 session. */
+
+import { encodeAddress, isValidAddress } from '@algorandfoundation/algokit-utils/common';
+
+import { extractEd25519PublicKey } from '../identity/did.js';
+import type { ActiveSession } from './manager.js';
+
+/** Recover an Algorand account from a controller DID when no linked address is available. */
+export function controllerDidToAlgorandAddress(controllerDid: string): string | undefined {
+  const raw = controllerDid.startsWith('did:key:')
+    ? controllerDid.slice('did:key:'.length)
+    : controllerDid;
+  if (isValidAddress(raw)) return raw;
+
+  const publicKey = extractEd25519PublicKey(controllerDid);
+  if (!publicKey) return undefined;
+  const address = encodeAddress(publicKey);
+  return isValidAddress(address) ? address : undefined;
+}
+
+/** Return the validated public Algorand account associated with an active session. */
+export function sessionAlgorandAddress(active: ActiveSession): string | undefined {
+  if (active.walletAddress && isValidAddress(active.walletAddress)) {
+    return active.walletAddress;
+  }
+  return controllerDidToAlgorandAddress(active.controllerDid);
+}

--- a/packages/ac2-open-claw-reference/src/tools/manifest.ts
+++ b/packages/ac2-open-claw-reference/src/tools/manifest.ts
@@ -103,7 +103,7 @@ const plugin = defineToolPlugin({
       name: 'ac2_capabilities',
       label: 'AC2 Capabilities',
       description:
-        "Return the agent's AC2 descriptor and the protocol catalog of sig_hints. Reports whether an `ac2` channel session is currently active. Downstream wallet-specific plugins extend this with live wallet identities/accounts.",
+        "Return the agent's AC2 descriptor, the protocol catalog of sig_hints, and the connected wallet's public Algorand address. Reports whether an `ac2` channel session is currently active. Downstream wallet-specific plugins may extend this with additional live wallet identities/accounts.",
       parameters: Type.Object({
         refresh: Type.Optional(
           Type.Boolean({

--- a/packages/ac2-open-claw-reference/src/x402/ac2-avm-signer.ts
+++ b/packages/ac2-open-claw-reference/src/x402/ac2-avm-signer.ts
@@ -2,7 +2,6 @@
 
 import { Buffer } from 'node:buffer';
 
-import { encodeAddress, isValidAddress } from '@algorandfoundation/algokit-utils/common';
 import {
   bytesForSigning,
   decodeTransaction,
@@ -13,15 +12,16 @@ import {
 import type { ClientAvmSigner } from '@x402/avm';
 import type { PaymentRequirements, ResourceInfo } from '@x402/core/types';
 
-import { extractEd25519PublicKey } from '../identity/did.js';
 import type { PluginConfig, ToolContext } from '../session/contracts.js';
 import { signFlow, type SignDeps } from '../session/flows.js';
 import {
   NoActiveSessionError,
   sessionManager,
-  type ActiveSession,
   type SessionManager,
 } from '../session/manager.js';
+import { sessionAlgorandAddress } from '../session/wallet-address.js';
+
+export { controllerDidToAlgorandAddress } from '../session/wallet-address.js';
 
 export const X402_ALGORAND_SIGNING_SCHEMA =
   'x402/exact/algorand/v2/transaction-signing-bytes';
@@ -56,25 +56,6 @@ export class X402ControllerAddressError extends Error {
 
 function managerFromDeps(deps?: SignDeps): SessionManager {
   return deps?.manager ?? sessionManager;
-}
-
-export function controllerDidToAlgorandAddress(controllerDid: string): string | undefined {
-  const raw = controllerDid.startsWith('did:key:')
-    ? controllerDid.slice('did:key:'.length)
-    : controllerDid;
-  if (isValidAddress(raw)) return raw;
-
-  const publicKey = extractEd25519PublicKey(controllerDid);
-  if (!publicKey) return undefined;
-  const address = encodeAddress(publicKey);
-  return isValidAddress(address) ? address : undefined;
-}
-
-function sessionAlgorandAddress(active: ActiveSession): string | undefined {
-  if (active.walletAddress && isValidAddress(active.walletAddress)) {
-    return active.walletAddress;
-  }
-  return controllerDidToAlgorandAddress(active.controllerDid);
 }
 
 function decodeUnsignedTransaction(txnBytes: Uint8Array, index: number): Transaction {

--- a/packages/ac2-open-claw-reference/tests/plugin.test.ts
+++ b/packages/ac2-open-claw-reference/tests/plugin.test.ts
@@ -179,6 +179,7 @@ describe('ac2 plugin', () => {
       const caps = capabilitiesFlow({}, { manager });
       expect(caps.status).toBe('no_active_session');
       expect(caps.session.connected).toBe(false);
+      expect(caps.session.walletAddress).toBeNull();
     });
 
     it('an active-but-identity-less session locks signing and reports no DID', async () => {
@@ -438,6 +439,7 @@ describe('ac2 plugin', () => {
       });
 
       expect(signer.address).toBe(sender.toString());
+      expect(capabilitiesFlow({}, { manager }).session.walletAddress).toBe(sender.toString());
       const signed = await signer.signTransactions([unsignedTxn], [0]);
       expect(signed).toHaveLength(1);
       expect(signed[0]).toBeInstanceOf(Uint8Array);
@@ -512,6 +514,7 @@ describe('ac2 plugin', () => {
       });
 
       expect(signer.address).toBe(sender.toString());
+      expect(capabilitiesFlow({}, { manager }).session.walletAddress).toBe(sender.toString());
       const signed = await signer.signTransactions([encodeTransactionRaw(txn)], [0]);
       expect(signed[0]).toBeInstanceOf(Uint8Array);
       expect(observedRequest.body.description).toContain(


### PR DESCRIPTION
## Summary

- expose the connected public Algorand account as `session.walletAddress` from `ac2_capabilities`
- share the validated address-resolution path between capabilities and x402 signing
- teach the bundled agent instructions to use the capability value for manual Algorand transaction construction and never guess an address
- document and test linked-address, DID fallback, and disconnected-session behavior

## Why

The x402 runtime already had access to the connected wallet address, but the model-facing capabilities response did not expose it directly. That prevented agents from reliably constructing Algorand transactions or other account-specific payloads outside the x402 helper.

## Impact

Agents can now retrieve the public sender address through `ac2_capabilities` without receiving private key material. Automatic x402 behavior remains unchanged and uses the same resolver as manual workflows.

## Validation

- `pnpm --filter @algorandfoundation/ac2-open-claw-reference type-check`
- `pnpm --filter @algorandfoundation/ac2-open-claw-reference test` (86 tests)
- `pnpm --filter @algorandfoundation/ac2-open-claw-reference build`
- `git diff --check`
