### PR TITLE
fix: ac2 plugin pairing timeout

### DIFF
--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -39,7 +39,7 @@ agent never touches the user's account keys or passkeys.
 #### From the npm registry (canary)
 
 ```bash
-openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.19
+openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference@1.0.0-canary.20
 
 # openclaw plugins install runs `npm install --ignore-scripts`, so the
 # @napi-rs/keyring native addon is not built automatically. Rebuild it from

--- a/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
+++ b/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
@@ -298,7 +298,7 @@ export function buildAc2Command(api: OpenClawApi): unknown {
                 ) {
                   throw new BootstrapError(
                     `[ac2-open-claw] KeyResponse.from (${bootstrapped.controllerDid}) does not match ` +
-                      `the linked account (${connectedAccountDid}); refusing to grant identity.`,
+                    `the linked account (${connectedAccountDid}); refusing to grant identity.`,
                   );
                 }
                 controllerDid = connectedAccountDid ?? bootstrapped.controllerDid;
@@ -340,11 +340,11 @@ export function buildAc2Command(api: OpenClawApi): unknown {
             // Adapter to give `streamChannel` a `send` + `isOpen` surface.
             const streamSendable = streamTransport
               ? {
-                  send: (payload: string) => streamTransport.send(payload),
-                  get isOpen() {
-                    return streamTransport.readyState === 'open';
-                  },
-                }
+                send: (payload: string) => streamTransport.send(payload),
+                get isOpen() {
+                  return streamTransport.readyState === 'open';
+                },
+              }
               : undefined;
             const controlSendable = streamSendable ?? transport;
 
@@ -442,12 +442,25 @@ export function buildAc2Command(api: OpenClawApi): unknown {
               'info',
               '[ac2] DataChannel closed — waiting for the controller to re-link. Scan the QR code again.',
             );
-            try {
-              cycle = await startPairingCycle();
-              console.log('\n' + buildInvitationText(cycle.pairing, cycle.qrString));
-            } catch (err) {
-              safeLog(api, 'error', `[ac2] Failed to restart pairing: ${err}`);
-              break;
+            // Retry with capped exponential backoff instead of giving up: a
+            // transient signaling-server/network outage should self-heal so
+            // pairing resumes automatically once conditions improve.
+            let backoffMs = 2_000;
+            // eslint-disable-next-line no-constant-condition
+            while (true) {
+              try {
+                cycle = await startPairingCycle();
+                console.log('\n' + buildInvitationText(cycle.pairing, cycle.qrString));
+                break;
+              } catch (err) {
+                safeLog(
+                  api,
+                  'warn',
+                  `[ac2] Failed to restart pairing; retrying in ${backoffMs}ms: ${err}`,
+                );
+                await new Promise((resolve) => setTimeout(resolve, backoffMs));
+                backoffMs = Math.min(backoffMs * 2, 30_000);
+              }
             }
           }
         })();

--- a/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
+++ b/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
@@ -268,6 +268,85 @@ export function awaitSignalConnect(
   });
 }
 
+/**
+ * Race an arbitrary pairing-handshake promise against `timeoutMs` and an
+ * optional abort `signal`. Used to bound the ICE offer/answer/candidate
+ * exchange (`SignalClient#peer`), which depends on the signaling socket
+ * staying alive for its whole duration — if that socket dies mid-handshake
+ * (e.g. a `ping timeout`) and never reconnects, the underlying promise would
+ * otherwise never settle. On timeout/abort, invokes `onFailure` (torn down
+ * once) and rejects; a later resolution/rejection of `promise` itself is
+ * ignored once the bound has already tripped.
+ */
+export function withPairingTimeout<T>(
+  promise: Promise<T>,
+  opts: { timeoutMs: number; signal?: AbortSignal; onFailure?: () => void },
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = (): void => {
+      if (timer !== undefined) clearTimeout(timer);
+      opts.signal?.removeEventListener('abort', onAbort);
+    };
+
+    const fail = (error: SignalingConnectError): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      try {
+        opts.onFailure?.();
+      } catch {
+        // Teardown is best-effort; still reject the caller.
+      }
+      reject(error);
+    };
+
+    function onAbort(): void {
+      fail(
+        new SignalingConnectError(
+          'aborted',
+          '[ac2-open-claw] pairing aborted before the handshake completed',
+        ),
+      );
+    }
+
+    if (opts.signal?.aborted) {
+      onAbort();
+      return;
+    }
+
+    promise.then(
+      (value) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(value);
+      },
+      (err) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(err);
+      },
+    );
+
+    opts.signal?.addEventListener('abort', onAbort);
+
+    if (Number.isFinite(opts.timeoutMs) && opts.timeoutMs > 0) {
+      timer = setTimeout(() => {
+        fail(
+          new SignalingConnectError(
+            'timeout',
+            `[ac2-open-claw] pairing handshake did not complete within ${opts.timeoutMs}ms`,
+          ),
+        );
+      }, opts.timeoutMs);
+    }
+  });
+}
+
 export interface LiquidAuthChannelProviderOptions {
   /** Liquid Auth signaling server origin. */
   origin?: string;
@@ -308,13 +387,18 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
       }
     });
 
+    // Shared ceiling for both the initial socket connect and the subsequent
+    // ICE offer/answer/candidate exchange in `connect()` — both phases depend
+    // on the same signaling socket staying alive.
+    const pairingTimeoutMs = opts.timeoutMs ?? AC2_DEFAULT_PAIRING_TIMEOUT_MS;
+
     // Block resolving until the signaling socket is up (the caller renders
     // the QR only after `startPairing` resolves). Bounded by `timeoutMs` and
     // the caller's abort signal so an unreachable signaling server rejects
     // instead of hanging the re-pairing loop forever — and the failing socket
     // is torn down so it stops emitting reconnect/ping-timeout noise.
     const waitForConnect = awaitSignalConnect(client, {
-      timeoutMs: opts.timeoutMs ?? AC2_DEFAULT_PAIRING_TIMEOUT_MS,
+      timeoutMs: pairingTimeoutMs,
       ...(opts.signal ? { signal: opts.signal } : {}),
       onFailure: () => {
         try {
@@ -404,9 +488,35 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
         ...(includeStream ? { [AC2_STREAM_LABEL]: { ordered: true } } : {}),
         [AC2_HEARTBEAT_LABEL]: { ordered: true },
       };
-      const primary: any = await client.peer(requestId, 'offer', AC2_ICE_CONFIG, {
-        dataChannels,
-      });
+      // Bounded the same way as the initial socket connect: `peer(...)`'s
+      // offer/answer/candidate exchange depends on the signaling socket for
+      // its whole duration, and has no timeout of its own — if the socket
+      // dies mid-handshake (e.g. a `ping timeout`) and never reconnects, this
+      // would otherwise hang forever waiting for data that will never arrive.
+      const primary: any = await withPairingTimeout(
+        client.peer(requestId, 'offer', AC2_ICE_CONFIG, { dataChannels }),
+        {
+          timeoutMs: pairingTimeoutMs,
+          ...(opts.signal ? { signal: opts.signal } : {}),
+          onFailure: () => {
+            try {
+              (client as any).peerClient?.close?.();
+            } catch {
+              // Best-effort cleanup.
+            }
+            try {
+              client.close(true);
+            } catch {
+              // Already closed; ignore.
+            }
+            try {
+              (socket as { close?: () => void }).close?.();
+            } catch {
+              // Already closed; ignore.
+            }
+          },
+        },
+      );
       controlChannel = controlChannel ?? primary;
 
       if (controlChannel.label !== AC2_CONTROL_LABEL) {

--- a/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
+++ b/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
@@ -290,7 +290,19 @@ export function awaitSignalConnect(
  * healthy, however long the human takes. On failure, invokes `onFailure`
  * (torn down once) and rejects; a later resolution/rejection of `promise`
  * itself is ignored once the guard has already tripped.
+ *
+ * Disconnect reasons that socket.io will NOT auto-reconnect from (a
+ * server-/client-initiated close) fail the current attempt immediately
+ * rather than waiting out `deadSocketTimeoutMs` for a reconnect that can
+ * never happen — handing off to the caller's re-pair loop (which opens a
+ * fresh socket) sooner.
  */
+export const SIGNALING_TERMINAL_DISCONNECT_REASONS: ReadonlySet<string> = new Set([
+  // socket.io reasons where the client does not attempt reconnection.
+  'io server disconnect',
+  'io client disconnect',
+]);
+
 export function withSignalingHealthGuard<T>(
   promise: Promise<T>,
   sock: {
@@ -339,7 +351,20 @@ export function withSignalingHealthGuard<T>(
       );
     }
 
-    function onDisconnect(): void {
+    // socket.io passes the disconnect reason as the first listener arg.
+    function onDisconnect(reason?: string): void {
+      // A server-/client-initiated close will never auto-reconnect this
+      // socket, so there is nothing to wait for — fail now and let the
+      // caller's re-pair loop open a fresh socket.
+      if (typeof reason === 'string' && SIGNALING_TERMINAL_DISCONNECT_REASONS.has(reason)) {
+        fail(
+          new SignalingConnectError(
+            'timeout',
+            `[ac2-open-claw] signaling connection closed during pairing and will not auto-reconnect (${reason})`,
+          ),
+        );
+        return;
+      }
       clearDeadTimer();
       deadTimer = setTimeout(() => {
         fail(

--- a/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
+++ b/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
@@ -108,6 +108,13 @@ const AC2_HEARTBEAT_MS = 20000;
 const AC2_DEFAULT_HEARTBEAT_TIMEOUT_MS = AC2_HEARTBEAT_MS * 2.5;
 /** Default ceiling for awaiting the signaling socket's initial `connect`. */
 const AC2_DEFAULT_PAIRING_TIMEOUT_MS = 120_000;
+/**
+ * Once the signaling socket goes down mid-handshake, give socket.io's own
+ * reconnection this long to recover before treating it as a genuine
+ * ping-timeout/network failure. Deliberately independent of how long the
+ * human takes to scan/approve — that phase has no ceiling of its own.
+ */
+const AC2_DEFAULT_SIGNAL_DEAD_TIMEOUT_MS = 45_000;
 const AC2_CONTROL_LABEL = 'ac2-v1' as const;
 const AC2_STREAM_LABEL = 'ac2-stream' as const;
 /** Dedicated liveness channel — keeps keepalive off the control plane. */
@@ -269,25 +276,45 @@ export function awaitSignalConnect(
 }
 
 /**
- * Race an arbitrary pairing-handshake promise against `timeoutMs` and an
- * optional abort `signal`. Used to bound the ICE offer/answer/candidate
- * exchange (`SignalClient#peer`), which depends on the signaling socket
- * staying alive for its whole duration — if that socket dies mid-handshake
- * (e.g. a `ping timeout`) and never reconnects, the underlying promise would
- * otherwise never settle. On timeout/abort, invokes `onFailure` (torn down
- * once) and rejects; a later resolution/rejection of `promise` itself is
- * ignored once the bound has already tripped.
+ * Race an arbitrary pairing-handshake promise against *sustained* signaling
+ * socket disconnection (plus an optional abort `signal`) — never against a
+ * flat wall-clock deadline. Used to bound the ICE offer/answer/candidate
+ * exchange (`SignalClient#peer`), which waits on the human completing
+ * pairing (scanning the QR, approving in their wallet) and can legitimately
+ * take minutes. A flat timeout there would tear down a perfectly healthy
+ * socket just because the human was slow. Instead, this only rejects once
+ * `sock` has been continuously disconnected for `deadSocketTimeoutMs` — a
+ * real ping-timeout/network failure that socket.io's own reconnection could
+ * not recover from in time. Every reconnect (even after several blips)
+ * clears the dead-socket timer, so the guard never fires while the socket is
+ * healthy, however long the human takes. On failure, invokes `onFailure`
+ * (torn down once) and rejects; a later resolution/rejection of `promise`
+ * itself is ignored once the guard has already tripped.
  */
-export function withPairingTimeout<T>(
+export function withSignalingHealthGuard<T>(
   promise: Promise<T>,
-  opts: { timeoutMs: number; signal?: AbortSignal; onFailure?: () => void },
+  sock: {
+    on: (event: string, listener: (...args: any[]) => void) => void;
+    off?: (event: string, listener: (...args: any[]) => void) => void;
+    connected?: boolean;
+  },
+  opts: { deadSocketTimeoutMs: number; signal?: AbortSignal; onFailure?: () => void },
 ): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     let settled = false;
-    let timer: ReturnType<typeof setTimeout> | undefined;
+    let deadTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const clearDeadTimer = (): void => {
+      if (deadTimer !== undefined) {
+        clearTimeout(deadTimer);
+        deadTimer = undefined;
+      }
+    };
 
     const cleanup = (): void => {
-      if (timer !== undefined) clearTimeout(timer);
+      clearDeadTimer();
+      sock.off?.('disconnect', onDisconnect);
+      sock.off?.('connect', onReconnect);
       opts.signal?.removeEventListener('abort', onAbort);
     };
 
@@ -312,10 +339,33 @@ export function withPairingTimeout<T>(
       );
     }
 
+    function onDisconnect(): void {
+      clearDeadTimer();
+      deadTimer = setTimeout(() => {
+        fail(
+          new SignalingConnectError(
+            'timeout',
+            `[ac2-open-claw] signaling socket stayed disconnected for ${opts.deadSocketTimeoutMs}ms during pairing`,
+          ),
+        );
+      }, opts.deadSocketTimeoutMs);
+    }
+
+    function onReconnect(): void {
+      clearDeadTimer();
+    }
+
     if (opts.signal?.aborted) {
       onAbort();
       return;
     }
+
+    // Already down when the guard was installed — start counting right away.
+    if (sock.connected === false) onDisconnect();
+
+    sock.on('disconnect', onDisconnect);
+    sock.on('connect', onReconnect);
+    opts.signal?.addEventListener('abort', onAbort);
 
     promise.then(
       (value) => {
@@ -331,19 +381,6 @@ export function withPairingTimeout<T>(
         reject(err);
       },
     );
-
-    opts.signal?.addEventListener('abort', onAbort);
-
-    if (Number.isFinite(opts.timeoutMs) && opts.timeoutMs > 0) {
-      timer = setTimeout(() => {
-        fail(
-          new SignalingConnectError(
-            'timeout',
-            `[ac2-open-claw] pairing handshake did not complete within ${opts.timeoutMs}ms`,
-          ),
-        );
-      }, opts.timeoutMs);
-    }
   });
 }
 
@@ -359,7 +396,7 @@ export interface LiquidAuthChannelProviderOptions {
 }
 
 export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
-  constructor(private readonly defaults: LiquidAuthChannelProviderOptions = {}) {}
+  constructor(private readonly defaults: LiquidAuthChannelProviderOptions = {}) { }
 
   async startPairing(opts: Ac2StartPairingOptions = {}): Promise<Ac2PairingHandle> {
     await ensureWebRtcPolyfill();
@@ -387,9 +424,8 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
       }
     });
 
-    // Shared ceiling for both the initial socket connect and the subsequent
-    // ICE offer/answer/candidate exchange in `connect()` — both phases depend
-    // on the same signaling socket staying alive.
+    // Ceiling for the initial socket connect only (see below) — that phase
+    // has no human action to wait on, so a flat deadline is appropriate.
     const pairingTimeoutMs = opts.timeoutMs ?? AC2_DEFAULT_PAIRING_TIMEOUT_MS;
 
     // Block resolving until the signaling socket is up (the caller renders
@@ -488,15 +524,17 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
         ...(includeStream ? { [AC2_STREAM_LABEL]: { ordered: true } } : {}),
         [AC2_HEARTBEAT_LABEL]: { ordered: true },
       };
-      // Bounded the same way as the initial socket connect: `peer(...)`'s
-      // offer/answer/candidate exchange depends on the signaling socket for
-      // its whole duration, and has no timeout of its own — if the socket
-      // dies mid-handshake (e.g. a `ping timeout`) and never reconnects, this
-      // would otherwise hang forever waiting for data that will never arrive.
-      const primary: any = await withPairingTimeout(
+      // Bounded by sustained signaling-socket disconnection, not a flat
+      // deadline: `peer(...)`'s offer/answer/candidate exchange waits on the
+      // human scanning the QR and approving in their wallet, which can take
+      // minutes. Only a real, sustained network/ping-timeout failure (the
+      // socket staying down longer than the reconnect grace period) should
+      // tear this down — not the human simply taking their time.
+      const primary: any = await withSignalingHealthGuard(
         client.peer(requestId, 'offer', AC2_ICE_CONFIG, { dataChannels }),
+        socket,
         {
-          timeoutMs: pairingTimeoutMs,
+          deadSocketTimeoutMs: AC2_DEFAULT_SIGNAL_DEAD_TIMEOUT_MS,
           ...(opts.signal ? { signal: opts.signal } : {}),
           onFailure: () => {
             try {

--- a/packages/ac2-open-claw-reference/tests/liquid-auth-provider.test.ts
+++ b/packages/ac2-open-claw-reference/tests/liquid-auth-provider.test.ts
@@ -6,6 +6,7 @@ import {
   closeAwareTransport,
   closeRtcDataChannel,
   resolveHeartbeatTimeoutMs,
+  withPairingTimeout,
 } from '../src/providers/liquid-auth.js';
 
 function makeBaseTransport(): Ac2Transport & { emitBaseClose: () => void; closes: () => number } {
@@ -129,6 +130,110 @@ describe('awaitSignalConnect', () => {
       await vi.advanceTimersByTimeAsync(5_000);
       client.emit('connect');
       expect(failures).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('withPairingTimeout', () => {
+  it('resolves with the wrapped promise value when it settles first', async () => {
+    let failures = 0;
+    const pending = withPairingTimeout(Promise.resolve('peer-channel'), {
+      timeoutMs: 1_000,
+      onFailure: () => {
+        failures += 1;
+      },
+    });
+    await expect(pending).resolves.toBe('peer-channel');
+    expect(failures).toBe(0);
+  });
+
+  it('passes through a rejection from the wrapped promise unchanged', async () => {
+    let failures = 0;
+    const boom = new Error('peer negotiation failed');
+    const pending = withPairingTimeout(Promise.reject(boom), {
+      timeoutMs: 1_000,
+      onFailure: () => {
+        failures += 1;
+      },
+    });
+    await expect(pending).rejects.toBe(boom);
+    expect(failures).toBe(0);
+  });
+
+  it('rejects and tears down when the wrapped promise never settles in time', async () => {
+    vi.useFakeTimers();
+    try {
+      let failures = 0;
+      // Simulates `client.peer(...)` hanging forever because the signaling
+      // socket died mid-handshake (e.g. a `ping timeout`) and never recovered.
+      const neverSettles = new Promise<never>(() => {});
+      const pending = withPairingTimeout(neverSettles, {
+        timeoutMs: 1_000,
+        onFailure: () => {
+          failures += 1;
+        },
+      });
+      const assertion = expect(pending).rejects.toMatchObject({ code: 'timeout' });
+      await vi.advanceTimersByTimeAsync(1_000);
+      await assertion;
+      expect(failures).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects immediately when the abort signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    let failures = 0;
+    const pending = withPairingTimeout(new Promise<never>(() => {}), {
+      timeoutMs: 5_000,
+      signal: controller.signal,
+      onFailure: () => {
+        failures += 1;
+      },
+    });
+    await expect(pending).rejects.toMatchObject({ code: 'aborted' });
+    expect(failures).toBe(1);
+  });
+
+  it('rejects and tears down when the abort signal fires mid-handshake', async () => {
+    const controller = new AbortController();
+    let failures = 0;
+    const pending = withPairingTimeout(new Promise<never>(() => {}), {
+      timeoutMs: 5_000,
+      signal: controller.signal,
+      onFailure: () => {
+        failures += 1;
+      },
+    });
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ code: 'aborted' });
+    expect(failures).toBe(1);
+  });
+
+  it('ignores a late resolution once the timeout has already tripped', async () => {
+    vi.useFakeTimers();
+    try {
+      let failures = 0;
+      let resolveLate: (value: string) => void = () => {};
+      const late = new Promise<string>((resolve) => {
+        resolveLate = resolve;
+      });
+      const pending = withPairingTimeout(late, {
+        timeoutMs: 1_000,
+        onFailure: () => {
+          failures += 1;
+        },
+      });
+      const assertion = expect(pending).rejects.toMatchObject({ code: 'timeout' });
+      await vi.advanceTimersByTimeAsync(1_000);
+      await assertion;
+      // Resolving after the bound already tripped must not throw or re-settle.
+      resolveLate('too-late');
+      expect(failures).toBe(1);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/ac2-open-claw-reference/tests/liquid-auth-provider.test.ts
+++ b/packages/ac2-open-claw-reference/tests/liquid-auth-provider.test.ts
@@ -6,17 +6,17 @@ import {
   closeAwareTransport,
   closeRtcDataChannel,
   resolveHeartbeatTimeoutMs,
-  withPairingTimeout,
+  withSignalingHealthGuard,
 } from '../src/providers/liquid-auth.js';
 
 function makeBaseTransport(): Ac2Transport & { emitBaseClose: () => void; closes: () => number } {
   let closeHandler: (() => void) | undefined;
   let closes = 0;
   return {
-    send: () => {},
-    onMessage: () => {},
-    onError: () => {},
-    onOpen: () => {},
+    send: () => { },
+    onMessage: () => { },
+    onError: () => { },
+    onOpen: () => { },
     onClose: (handler) => {
       closeHandler = handler;
     },
@@ -136,11 +136,33 @@ describe('awaitSignalConnect', () => {
   });
 });
 
-describe('withPairingTimeout', () => {
+describe('withSignalingHealthGuard', () => {
+  function makeFakeSocket(initialConnected = true): {
+    on: (event: string, listener: (...args: any[]) => void) => void;
+    off: (event: string, listener: (...args: any[]) => void) => void;
+    connected: boolean;
+    emit: (event: string) => void;
+  } {
+    const listeners: Record<string, Set<(...args: any[]) => void>> = {};
+    return {
+      connected: initialConnected,
+      on(event, listener) {
+        (listeners[event] ??= new Set()).add(listener);
+      },
+      off(event, listener) {
+        listeners[event]?.delete(listener);
+      },
+      emit(event) {
+        for (const listener of listeners[event] ?? []) listener();
+      },
+    };
+  }
+
   it('resolves with the wrapped promise value when it settles first', async () => {
+    const sock = makeFakeSocket();
     let failures = 0;
-    const pending = withPairingTimeout(Promise.resolve('peer-channel'), {
-      timeoutMs: 1_000,
+    const pending = withSignalingHealthGuard(Promise.resolve('peer-channel'), sock, {
+      deadSocketTimeoutMs: 1_000,
       onFailure: () => {
         failures += 1;
       },
@@ -150,10 +172,11 @@ describe('withPairingTimeout', () => {
   });
 
   it('passes through a rejection from the wrapped promise unchanged', async () => {
+    const sock = makeFakeSocket();
     let failures = 0;
     const boom = new Error('peer negotiation failed');
-    const pending = withPairingTimeout(Promise.reject(boom), {
-      timeoutMs: 1_000,
+    const pending = withSignalingHealthGuard(Promise.reject(boom), sock, {
+      deadSocketTimeoutMs: 1_000,
       onFailure: () => {
         failures += 1;
       },
@@ -162,15 +185,90 @@ describe('withPairingTimeout', () => {
     expect(failures).toBe(0);
   });
 
-  it('rejects and tears down when the wrapped promise never settles in time', async () => {
+  it('never fires on elapsed time alone while the socket stays connected (slow human)', async () => {
     vi.useFakeTimers();
     try {
+      const sock = makeFakeSocket();
       let failures = 0;
-      // Simulates `client.peer(...)` hanging forever because the signaling
-      // socket died mid-handshake (e.g. a `ping timeout`) and never recovered.
-      const neverSettles = new Promise<never>(() => {});
-      const pending = withPairingTimeout(neverSettles, {
-        timeoutMs: 1_000,
+      let resolveLate: (value: string) => void = () => { };
+      const humanIsSlow = new Promise<string>((resolve) => {
+        resolveLate = resolve;
+      });
+      const pending = withSignalingHealthGuard(humanIsSlow, sock, {
+        deadSocketTimeoutMs: 1_000,
+        onFailure: () => {
+          failures += 1;
+        },
+      });
+      // Far longer than deadSocketTimeoutMs — simulates a human taking minutes
+      // to scan the QR and approve, with the socket healthy throughout.
+      await vi.advanceTimersByTimeAsync(10 * 60_000);
+      resolveLate('approved');
+      await expect(pending).resolves.toBe('approved');
+      expect(failures).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('tolerates a disconnect that recovers before the dead-socket grace period', async () => {
+    vi.useFakeTimers();
+    try {
+      const sock = makeFakeSocket();
+      let failures = 0;
+      let resolveLate: (value: string) => void = () => { };
+      const pending = withSignalingHealthGuard(
+        new Promise<string>((resolve) => {
+          resolveLate = resolve;
+        }),
+        sock,
+        {
+          deadSocketTimeoutMs: 1_000,
+          onFailure: () => {
+            failures += 1;
+          },
+        },
+      );
+      sock.emit('disconnect');
+      await vi.advanceTimersByTimeAsync(500);
+      sock.emit('connect'); // recovers before the 1_000ms grace period elapses
+      await vi.advanceTimersByTimeAsync(5_000);
+      resolveLate('approved');
+      await expect(pending).resolves.toBe('approved');
+      expect(failures).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects and tears down once the socket stays disconnected past the grace period', async () => {
+    vi.useFakeTimers();
+    try {
+      const sock = makeFakeSocket();
+      let failures = 0;
+      const pending = withSignalingHealthGuard(new Promise<never>(() => { }), sock, {
+        deadSocketTimeoutMs: 1_000,
+        onFailure: () => {
+          failures += 1;
+        },
+      });
+      const assertion = expect(pending).rejects.toMatchObject({ code: 'timeout' });
+      sock.emit('disconnect');
+      await vi.advanceTimersByTimeAsync(1_000);
+      await assertion;
+      expect(failures).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('starts counting immediately if the socket is already disconnected', async () => {
+    vi.useFakeTimers();
+    try {
+      const sock = makeFakeSocket(false);
+      let failures = 0;
+      const pending = withSignalingHealthGuard(new Promise<never>(() => { }), sock, {
+        deadSocketTimeoutMs: 1_000,
         onFailure: () => {
           failures += 1;
         },
@@ -185,11 +283,12 @@ describe('withPairingTimeout', () => {
   });
 
   it('rejects immediately when the abort signal is already aborted', async () => {
+    const sock = makeFakeSocket();
     const controller = new AbortController();
     controller.abort();
     let failures = 0;
-    const pending = withPairingTimeout(new Promise<never>(() => {}), {
-      timeoutMs: 5_000,
+    const pending = withSignalingHealthGuard(new Promise<never>(() => { }), sock, {
+      deadSocketTimeoutMs: 5_000,
       signal: controller.signal,
       onFailure: () => {
         failures += 1;
@@ -200,10 +299,11 @@ describe('withPairingTimeout', () => {
   });
 
   it('rejects and tears down when the abort signal fires mid-handshake', async () => {
+    const sock = makeFakeSocket();
     const controller = new AbortController();
     let failures = 0;
-    const pending = withPairingTimeout(new Promise<never>(() => {}), {
-      timeoutMs: 5_000,
+    const pending = withSignalingHealthGuard(new Promise<never>(() => { }), sock, {
+      deadSocketTimeoutMs: 5_000,
       signal: controller.signal,
       onFailure: () => {
         failures += 1;
@@ -214,24 +314,25 @@ describe('withPairingTimeout', () => {
     expect(failures).toBe(1);
   });
 
-  it('ignores a late resolution once the timeout has already tripped', async () => {
+  it('ignores a late settle once the dead-socket bound has already tripped', async () => {
     vi.useFakeTimers();
     try {
+      const sock = makeFakeSocket();
       let failures = 0;
-      let resolveLate: (value: string) => void = () => {};
+      let resolveLate: (value: string) => void = () => { };
       const late = new Promise<string>((resolve) => {
         resolveLate = resolve;
       });
-      const pending = withPairingTimeout(late, {
-        timeoutMs: 1_000,
+      const pending = withSignalingHealthGuard(late, sock, {
+        deadSocketTimeoutMs: 1_000,
         onFailure: () => {
           failures += 1;
         },
       });
       const assertion = expect(pending).rejects.toMatchObject({ code: 'timeout' });
+      sock.emit('disconnect');
       await vi.advanceTimersByTimeAsync(1_000);
       await assertion;
-      // Resolving after the bound already tripped must not throw or re-settle.
       resolveLate('too-late');
       expect(failures).toBe(1);
     } finally {

--- a/packages/ac2-open-claw-reference/tests/liquid-auth-provider.test.ts
+++ b/packages/ac2-open-claw-reference/tests/liquid-auth-provider.test.ts
@@ -141,7 +141,7 @@ describe('withSignalingHealthGuard', () => {
     on: (event: string, listener: (...args: any[]) => void) => void;
     off: (event: string, listener: (...args: any[]) => void) => void;
     connected: boolean;
-    emit: (event: string) => void;
+    emit: (event: string, ...args: any[]) => void;
   } {
     const listeners: Record<string, Set<(...args: any[]) => void>> = {};
     return {
@@ -152,8 +152,8 @@ describe('withSignalingHealthGuard', () => {
       off(event, listener) {
         listeners[event]?.delete(listener);
       },
-      emit(event) {
-        for (const listener of listeners[event] ?? []) listener();
+      emit(event, ...args) {
+        for (const listener of listeners[event] ?? []) listener(...args);
       },
     };
   }
@@ -275,6 +275,28 @@ describe('withSignalingHealthGuard', () => {
       });
       const assertion = expect(pending).rejects.toMatchObject({ code: 'timeout' });
       await vi.advanceTimersByTimeAsync(1_000);
+      await assertion;
+      expect(failures).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects immediately on a server-initiated disconnect (no auto-reconnect)', async () => {
+    vi.useFakeTimers();
+    try {
+      const sock = makeFakeSocket();
+      let failures = 0;
+      const pending = withSignalingHealthGuard(new Promise<never>(() => { }), sock, {
+        deadSocketTimeoutMs: 45_000,
+        onFailure: () => {
+          failures += 1;
+        },
+      });
+      const assertion = expect(pending).rejects.toMatchObject({ code: 'timeout' });
+      // 'io server disconnect' will never auto-reconnect — must fail now,
+      // without waiting out the dead-socket grace period.
+      sock.emit('disconnect', 'io server disconnect');
       await assertion;
       expect(failures).toBe(1);
     } finally {


### PR DESCRIPTION
Often with long running processes/change of network we can get these kind of errors which put the plugin `ac2 pair` into a dead/zombie state:

```
[ac2] Signaling engine closed: ping timeout
[ac2] Signaling socket disconnect reason: ping timeout
[ac2] Signaling socket disconnect reason: ping timeout
```

- timeout handling while waiting for peer to connect. 