### PR TITLE
fix(openclaw): supervise durable Liquid Auth sessions

### DIFF
--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -110,7 +110,9 @@ Once installed, `openclaw.json` will contain an entry like:
 
 `AC2_LIQUID_AUTH_SERVER` overrides `liquidAuthServer` at runtime.
 `AC2_HEARTBEAT_TIMEOUT_MS` overrides the WebRTC heartbeat liveness timeout;
-it defaults to `50000`.
+the timeout is disabled by default so a mobile controller suspended in the
+background is not mistaken for a dead peer. Native WebRTC/DataChannel closure
+remains authoritative. If enabled, the value must be at least `40000`.
 
 ### Using it
 

--- a/packages/ac2-open-claw-reference/openclaw.plugin.json
+++ b/packages/ac2-open-claw-reference/openclaw.plugin.json
@@ -12,7 +12,7 @@
     },
     {
       "name": "AC2_HEARTBEAT_TIMEOUT_MS",
-      "description": "Milliseconds without inbound ac2-heartbeat traffic before the plugin closes the channel. Defaults to 50000.",
+      "description": "Optional milliseconds without inbound ac2-heartbeat traffic before the plugin closes the channel. Disabled by default; values must be at least 40000.",
       "required": false
     }
   ],

--- a/packages/ac2-open-claw-reference/package.json
+++ b/packages/ac2-open-claw-reference/package.json
@@ -58,10 +58,10 @@
   },
   "release": null,
   "dependencies": {
-    "@algorandfoundation/ac2-sdk": "1.0.0-canary.1",
+    "@algorandfoundation/ac2-sdk": "workspace:^",
     "@algorandfoundation/algokit-utils": "10.0.0-beta.4",
     "@algorandfoundation/keystore": "1.0.0-canary.16",
-    "@algorandfoundation/liquid-client": "1.0.0-canary.8",
+    "@algorandfoundation/liquid-client": "^1.0.0-canary.9",
     "@napi-rs/keyring": "^1.3.0",
     "@roamhq/wrtc": "^0.10.0",
     "@sinclair/typebox": "^0.32.0",
@@ -96,7 +96,7 @@
       },
       {
         "name": "AC2_HEARTBEAT_TIMEOUT_MS",
-        "description": "Milliseconds without inbound ac2-heartbeat traffic before the plugin closes the channel. Defaults to 50000.",
+        "description": "Optional milliseconds without inbound ac2-heartbeat traffic before the plugin closes the channel. Disabled by default; values must be at least 40000.",
         "required": false
       }
     ],

--- a/packages/ac2-open-claw-reference/src/channel/channel-object.ts
+++ b/packages/ac2-open-claw-reference/src/channel/channel-object.ts
@@ -2,8 +2,9 @@
 
 import type { ChannelPlugin } from 'openclaw/plugin-sdk';
 
-import { CHANNEL_ID } from '../runtime.js';
+import { CHANNEL_ID, getActiveApi, resolveConfig } from '../runtime.js';
 import { sessionManager } from '../session/manager.js';
+import { connectionSupervisor } from '../session/supervisor.js';
 import { AC2_CHANNEL_ENV_VARS } from '../setup/config.js';
 import {
   AC2_DEFAULT_ACK_POLICY,
@@ -66,39 +67,60 @@ export function buildChannelObject(): ChannelPlugin {
     },
     channelEnvVars: AC2_CHANNEL_ENV_VARS,
     config: {
-      listAccountIds: (): string[] => {
-        const active = sessionManager.getActive();
-        return active ? [active.controllerDid] : [];
-      },
+      // The gateway must be able to start the provider before a controller is
+      // online, so account discovery cannot depend on the active DataChannel.
+      listAccountIds: (): string[] => ['default'],
       resolveAccount: (
-        _cfg: unknown,
+        cfg: unknown,
         accountId?: string | null,
-      ): { accountId: string | null; config: Record<string, unknown> } => {
-        const active = sessionManager.getActive();
-        if (
-          active &&
-          (accountId === undefined || accountId === null || accountId === active.controllerDid)
-        ) {
-          return {
-            accountId: active.controllerDid,
-            config: { peerDid: active.controllerDid },
-          };
-        }
-        return { accountId: accountId ?? null, config: {} };
+      ): { accountId: string; config: Record<string, unknown> } => {
+        const channelConfig =
+          (cfg as { channels?: { ac2?: Record<string, unknown> } } | undefined)?.channels?.ac2 ??
+          {};
+        return { accountId: accountId ?? 'default', config: channelConfig };
       },
       inspectAccount: (_cfg: unknown, accountId?: string | null): unknown => {
         const active = sessionManager.getActive();
-        if (
-          !active ||
-          (accountId !== undefined && accountId !== null && accountId !== active.controllerDid)
-        ) {
-          return null;
-        }
+        const supervisor = connectionSupervisor.getStatus();
         return {
-          peerDid: active.controllerDid,
-          paired: true,
-          online: true,
+          accountId: accountId ?? 'default',
+          ...(active ? { peerDid: active.controllerDid } : {}),
+          paired: supervisor.pairingId !== undefined,
+          online: active !== null,
+          state: supervisor.state,
         };
+      },
+      isConfigured: (): boolean => true,
+    },
+    gateway: {
+      startAccount: async (ctx: any): Promise<void> => {
+        const api = getActiveApi();
+        if (!api) throw new Error('[ac2] OpenClaw API is unavailable during gateway startup');
+        const accountConfig = (ctx.account?.config ?? {}) as {
+          liquidAuthServer?: string;
+          defaultTimeoutMs?: number;
+        };
+        const baseConfig = resolveConfig(api);
+        await connectionSupervisor.start({
+          api,
+          config: { ...baseConfig, ...accountConfig },
+          signal: ctx.abortSignal,
+          setStatus: (status) => {
+            ctx.setStatus({
+              ...ctx.getStatus(),
+              accountId: ctx.accountId,
+              running: status.state !== 'stopped',
+              connected: status.state === 'online',
+              linked: status.pairingId !== undefined,
+              statusState: status.state,
+              reconnectAttempts: status.reconnectAttempts,
+              lastError: status.lastError ?? null,
+            });
+          },
+        });
+      },
+      stopAccount: async (): Promise<void> => {
+        await connectionSupervisor.stop();
       },
     },
     outbound: {

--- a/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
+++ b/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
@@ -1,48 +1,19 @@
 /** The `ac2` shell + slash command: `pair`, `status`, `connections`, `forget`. */
 
 import qrcode from 'qrcode-terminal';
-import { Ac2Client } from '@algorandfoundation/ac2-sdk';
-import { isValidAddress } from '@algorandfoundation/algokit-utils/common';
-import { resolveConfig, safeLog, type OpenClawApi } from '../runtime.js';
-import { BootstrapError, bootstrapAgentIdentity } from '../session/bootstrap.js';
-import type { ChannelContext } from '../session/contracts.js';
+import { resolveConfig, type OpenClawApi } from '../runtime.js';
 import { sessionManager } from '../session/manager.js';
 import {
   clearAc2State,
-  ensureConversation,
+  clearAc2StatePendingRevocation,
   listConnections,
   listConversations,
   loadAc2State,
-  saveAc2State,
-  setConnectionIdentity,
-  touchConnection,
+  withAc2StateLock,
 } from '../identity/state.js';
-import { normalizeDidKey } from '../identity/did.js';
-import {
-  clearAgentIdentities,
-  hasAgentIdentity,
-  recordAgentIdentity,
-} from '../identity/keystore.js';
-import {
-  DEFAULT_THID,
-  clearActiveConversation,
-  replayConversationHistory,
-  replayConversationList,
-  routeInboundToAgent,
-  sendFinalize,
-  setActiveConversation,
-  warmUpAgent,
-} from '../channel/index.js';
-
-/** Chat notice shown when the wallet has not granted the agent an identity. */
-const NO_IDENTITY_NOTICE =
-  "I don't have an identity yet. To work with you securely I need my own " +
-  'dedicated key — a `did:key` identity your wallet issues to me. It lets me ' +
-  'prove who I am on this channel and sign my own messages, and it is kept ' +
-  'separate from your personal accounts and keys (I never see or use those). ' +
-  'Until you grant one, I can chat with you but cannot perform signing-related ' +
-  'actions. When you are ready, approve the identity request in your wallet to ' +
-  'continue.';
+import { clearAgentIdentities, hasAgentIdentity } from '../identity/keystore.js';
+import { ensurePersistedPairing } from '../identity/pairing.js';
+import { revokePairing } from '../providers/liquid-auth.js';
 
 const NODE_MODULE_LOAD_ERROR_CODES = new Set(['ERR_MODULE_NOT_FOUND', 'MODULE_NOT_FOUND']);
 const ROAMHQ_WRTC_PACKAGE_PATTERN = /@roamhq\/wrtc(?:-[a-z0-9-]+)?/i;
@@ -62,22 +33,6 @@ export function isMissingWebRtcError(err: unknown): boolean {
     ROAMHQ_WRTC_PACKAGE_PATTERN.test(message);
 
   return isNodeModuleLoadError || isMissingWrtcBinary;
-}
-
-function webRtcUnavailableInstructions(): string {
-  return [
-    'AC2 pairing could not load the @roamhq/wrtc WebRTC module for this platform.',
-    '',
-    '@roamhq/wrtc ships prebuilt binaries, so this usually means the matching',
-    'platform package was not installed. Reinstall the plugin to fetch it:',
-    '',
-    '```bash',
-    'openclaw plugins install npm:@algorandfoundation/ac2-open-claw-reference --force',
-    'openclaw plugins enable ac2',
-    '```',
-    '',
-    'If this persists, this platform may not have a published @roamhq/wrtc prebuilt binary.',
-  ].join('\n');
 }
 
 export function buildAc2Command(api: OpenClawApi): unknown {
@@ -136,325 +91,63 @@ export function buildAc2Command(api: OpenClawApi): unknown {
       }
 
       if (sub === 'forget') {
+        try {
+          sessionManager.getActive()?.transport.close();
+        } catch {
+          // The transport may already be closing.
+        }
         sessionManager.clearActive();
-        clearAc2State();
+        const cfg = resolveConfig(api);
+        const origin = cfg.liquidAuthServer ?? 'https://debug.liquidauth.com';
+        let pending = false;
+        await withAc2StateLock(async () => {
+          const pairing = loadAc2State().pairing;
+          if (!pairing) {
+            clearAc2State();
+            return;
+          }
+          try {
+            await revokePairing(origin, pairing, AbortSignal.timeout(5_000));
+            clearAc2State();
+          } catch {
+            pending = true;
+            clearAc2StatePendingRevocation(pairing);
+          }
+        });
         clearAgentIdentities();
-        return { text: 'Pairing record cleared.' };
+        return {
+          text: pending
+            ? 'Pairing removed locally. Server revocation is pending and will retry automatically.'
+            : 'Pairing revoked and local record cleared.',
+        };
       }
 
       if (sub === 'pair') {
-        const cfg = resolveConfig(api);
-
-        // Warm up the runtime while the user is scanning the QR.
-        await warmUpAgent(api, '__warmup__');
-
-        const origin = cfg.liquidAuthServer ?? 'https://debug.liquidauth.com';
-        const startPairingCycle = async (): Promise<{
-          pairing: import('@algorandfoundation/ac2-sdk/signaling').Ac2PairingInfo;
-          connect: () => Promise<import('@algorandfoundation/ac2-sdk/signaling').Ac2PairedChannel>;
-          qrString: string;
-        }> => {
-          // Reuse a persisted requestId so the wallet reconnects to the same connection.
-          const persistedRequestId = loadAc2State().requestId;
-          const { LiquidAuthChannelProvider } = await import('../providers/liquid-auth.js');
-          const provider: import('@algorandfoundation/ac2-sdk/signaling').Ac2ChannelProvider =
-            new LiquidAuthChannelProvider({
-              origin,
-              ...(persistedRequestId ? { requestId: persistedRequestId } : {}),
-            });
-          const handle = await provider.startPairing({
-            timeoutMs: cfg.defaultTimeoutMs ?? 120_000,
-          });
-          const usedRequestId = handle.pairing.metadata?.['requestId'];
-          if (typeof usedRequestId === 'string' && usedRequestId.length > 0) {
-            saveAc2State({ requestId: usedRequestId });
-          }
-          const qr = await new Promise<string>((resolve) => {
-            qrcode.generate(handle.pairing.qrPayload, { small: true }, (rendered) => {
-              resolve(rendered);
-            });
-          });
-          return { pairing: handle.pairing, connect: handle.connect, qrString: qr };
-        };
-
-        const buildInvitationText = (
-          pairing: import('@algorandfoundation/ac2-sdk/signaling').Ac2PairingInfo,
-          qrString: string,
-        ): string =>
-          [
+        // Pairing is gateway-owned. This command only creates/reads the
+        // durable invitation and renders it; it never starts a second,
+        // process-local connection loop.
+        const durableCfg = resolveConfig(api);
+        const durableOrigin =
+          durableCfg.liquidAuthServer ?? 'https://debug.liquidauth.com';
+        const durableState = loadAc2State();
+        const { pairing: durablePairing } = await ensurePersistedPairing(
+          durableOrigin,
+          durableState.requestId,
+        );
+        const durableUrl = `liquid://${durableOrigin.replace(/^https:\/\//, '').replace(/\/$/, '')}/?requestId=${durablePairing.pairingId}`;
+        const durableQr = await new Promise<string>((resolve) => {
+          qrcode.generate(durableUrl, { small: true }, resolve);
+        });
+        return {
+          text: [
             'AC2 Pairing Invitation',
             '',
-            qrString,
+            durableQr,
             '',
-            `Pairing URL: ${pairing.qrPayload}`,
+            `Pairing URL: ${durableUrl}`,
             '',
-            'Scan the QR code with your AC2 Controller. The channel will activate once paired.',
-          ].join('\n');
-
-        let firstCycle: Awaited<ReturnType<typeof startPairingCycle>>;
-        try {
-          firstCycle = await startPairingCycle();
-        } catch (err) {
-          if (isMissingWebRtcError(err)) {
-            return { text: webRtcUnavailableInstructions() };
-          }
-          throw err;
-        }
-
-        const context: ChannelContext = {
-          logger: {
-            info: (m) => safeLog(api, 'info', m),
-            error: (m) => safeLog(api, 'error', m),
-          },
-          async receive(text) {
-            // Routing happens in `transport.onRawMessage` below.
-            safeLog(api, 'info', `Received chat from wallet: ${text}`);
-          },
-          onOutput(_handler) {
-            // Outbound is wired by the channel object's `sendText`.
-          },
-        };
-
-        const runConnectedSession = async (
-          connect: () => Promise<import('@algorandfoundation/ac2-sdk/signaling').Ac2PairedChannel>,
-        ): Promise<void> => {
-          let paired: import('@algorandfoundation/ac2-sdk/signaling').Ac2PairedChannel | undefined;
-          try {
-            const connected = await connect();
-            paired = connected;
-            const { transport, streamChannel: streamTransport } = connected;
-            const client = new Ac2Client(transport);
-
-            const connectionRequestId = loadAc2State().requestId;
-            if (connectionRequestId) touchConnection(connectionRequestId);
-
-            const peerDidOpt =
-              connected.peer?.did !== undefined ? { peerDid: connected.peer.did } : {};
-            const timeoutOpt =
-              cfg.defaultTimeoutMs !== undefined ? { timeoutMs: cfg.defaultTimeoutMs } : {};
-
-            // Prefer the wallet from the Liquid Auth `link` response as `controllerDid`.
-            const connectedAccount =
-              typeof connected.peer?.['wallet'] === 'string'
-                ? (connected.peer['wallet'] as string)
-                : undefined;
-            const walletAddress =
-              connectedAccount !== undefined && isValidAddress(connectedAccount)
-                ? connectedAccount
-                : undefined;
-            const connectedAccountDid =
-              connectedAccount !== undefined
-                ? normalizeDidKey(`did:key:${connectedAccount}`)
-                : connected.peer?.did;
-
-            // Reuse a stored identity for this connection, otherwise bootstrap.
-            const storedIdentity =
-              (connectionRequestId
-                ? loadAc2State().connections?.[connectionRequestId]?.identity
-                : undefined) ?? loadAc2State().identity;
-            // Placeholders — overridden on a granted identity, else session goes active
-            // with `identityGranted = false` so the agent can explain.
-            let agentDid = 'did:ac2:agent';
-            let controllerDid = connectedAccountDid ?? 'did:key:zAc2Controller';
-            let identityGranted = true;
-            if (storedIdentity) {
-              ({ agentDid } = storedIdentity);
-              controllerDid = connectedAccountDid ?? storedIdentity.controllerDid;
-              // Migrate legacy plaintext material into the keystore.
-              if (storedIdentity.material && !hasAgentIdentity(agentDid)) {
-                await recordAgentIdentity({
-                  agentDid,
-                  publicKey: storedIdentity.publicKey,
-                  material: storedIdentity.material,
-                });
-              }
-              safeLog(api, 'info', '[ac2] Reusing persisted agent identity.');
-            } else {
-              let bootstrapped: Awaited<ReturnType<typeof bootstrapAgentIdentity>> | undefined;
-              try {
-                bootstrapped = await bootstrapAgentIdentity(client, {
-                  ...peerDidOpt,
-                  ...timeoutOpt,
-                });
-              } catch (err) {
-                if (err instanceof BootstrapError) {
-                  identityGranted = false;
-                  safeLog(
-                    api,
-                    'warn',
-                    `[ac2] No agent identity granted: ${err.message}. Keeping channel open to explain.`,
-                  );
-                } else {
-                  throw err;
-                }
-              }
-              if (bootstrapped) {
-                agentDid = bootstrapped.agentDid;
-                // Refuse to bind on a `KeyResponse.from` mismatch — a spoofed `from`
-                // is a security failure, not a missing identity.
-                if (
-                  connectedAccountDid !== undefined &&
-                  bootstrapped.controllerDid !== connectedAccountDid
-                ) {
-                  throw new BootstrapError(
-                    `[ac2-open-claw] KeyResponse.from (${bootstrapped.controllerDid}) does not match ` +
-                      `the linked account (${connectedAccountDid}); refusing to grant identity.`,
-                  );
-                }
-                controllerDid = connectedAccountDid ?? bootstrapped.controllerDid;
-                const material = bootstrapped.response.body.material;
-                if (material !== undefined) {
-                  await recordAgentIdentity({
-                    agentDid,
-                    publicKey: bootstrapped.response.body.public_key,
-                    material,
-                  });
-                }
-                const grantedIdentity = {
-                  agentDid,
-                  controllerDid,
-                  publicKey: bootstrapped.response.body.public_key,
-                };
-                if (connectionRequestId) {
-                  setConnectionIdentity(connectionRequestId, grantedIdentity);
-                } else {
-                  saveAc2State({ identity: grantedIdentity });
-                }
-              }
-            }
-            sessionManager.setActive({
-              transport,
-              client,
-              controllerDid,
-              agentDid,
-              identityGranted,
-              ...(walletAddress ? { walletAddress } : {}),
-              ...(connectionRequestId ? { requestId: connectionRequestId } : {}),
-            });
-            safeLog(
-              api,
-              'info',
-              `[ac2] Channel paired and active. agentDid=${agentDid} controllerDid=${controllerDid}`,
-            );
-
-            // Adapter to give `streamChannel` a `send` + `isOpen` surface.
-            const streamSendable = streamTransport
-              ? {
-                  send: (payload: string) => streamTransport.send(payload),
-                  get isOpen() {
-                    return streamTransport.readyState === 'open';
-                  },
-                }
-              : undefined;
-            const controlSendable = streamSendable ?? transport;
-
-            client.updateHandlers({
-              'ac2/ConversationOpen': (msg) => {
-                const openThid =
-                  typeof (msg.body as any)?.thid === 'string' && (msg.body as any).thid.length > 0
-                    ? ((msg.body as any).thid as string)
-                    : msg.thid;
-                if (!openThid) return;
-                const title =
-                  typeof (msg.body as any)?.title === 'string'
-                    ? ((msg.body as any).title as string)
-                    : undefined;
-                setActiveConversation(controllerDid, openThid, connectionRequestId);
-                if (connectionRequestId) ensureConversation(connectionRequestId, openThid, title);
-                safeLog(
-                  api,
-                  'info',
-                  `[ac2] Conversation opened (thid=${openThid}${title ? `, title="${title}"` : ''}).`,
-                );
-                replayConversationHistory(controlSendable, connectionRequestId, openThid);
-              },
-              'ac2/ConversationClose': (msg) => {
-                const closeThid =
-                  typeof (msg.body as any)?.thid === 'string' && (msg.body as any).thid.length > 0
-                    ? ((msg.body as any).thid as string)
-                    : msg.thid;
-                if (!closeThid) return;
-                clearActiveConversation(controllerDid, closeThid, connectionRequestId);
-                safeLog(api, 'info', `[ac2] Conversation closed (thid=${closeThid}).`);
-              },
-            });
-
-            // Replay threads + default-thread history for reconnecting controllers.
-            replayConversationList(controlSendable, connectionRequestId);
-            replayConversationHistory(controlSendable, connectionRequestId, DEFAULT_THID);
-
-            if (!identityGranted) {
-              sendFinalize(
-                controlSendable,
-                DEFAULT_THID,
-                `ac2-noid-${Date.now()}`,
-                NO_IDENTITY_NOTICE,
-              );
-            }
-
-            if (streamTransport) {
-              streamTransport.onmessage = async (event: { data: unknown }) => {
-                const raw = event.data;
-                if (typeof raw === 'string' && raw.trim().length > 0) {
-                  const active = sessionManager.getActive()!;
-                  await routeInboundToAgent(
-                    api,
-                    raw,
-                    streamSendable!,
-                    active.controllerDid,
-                    active.requestId,
-                  );
-                }
-              };
-            }
-            transport.onRawMessage?.(async (text: string) => {
-              const active = sessionManager.getActive()!;
-              await routeInboundToAgent(
-                api,
-                text,
-                streamSendable ?? transport,
-                active.controllerDid,
-                active.requestId,
-              );
-            });
-
-            await new Promise<void>((resolve) => {
-              transport.onClose(() => resolve());
-              transport.onError(() => resolve());
-              if (streamTransport) (streamTransport as any).onclose = () => resolve();
-            });
-          } catch (err) {
-            safeLog(api, 'error', `[ac2] Pairing failed: ${err}`);
-          } finally {
-            sessionManager.clearActive();
-            if (paired) await paired.close();
-          }
-        };
-
-        void (async () => {
-          let cycle = firstCycle;
-          // Re-pairing loop: re-render the QR after a dropped DataChannel.
-          // eslint-disable-next-line no-constant-condition
-          while (true) {
-            await runConnectedSession(cycle.connect);
-            safeLog(
-              api,
-              'info',
-              '[ac2] DataChannel closed — waiting for the controller to re-link. Scan the QR code again.',
-            );
-            try {
-              cycle = await startPairingCycle();
-              console.log('\n' + buildInvitationText(cycle.pairing, cycle.qrString));
-            } catch (err) {
-              safeLog(api, 'error', `[ac2] Failed to restart pairing: ${err}`);
-              break;
-            }
-          }
-        })();
-
-        return {
-          text: buildInvitationText(firstCycle.pairing, firstCycle.qrString),
-          keepAlive: true,
+            'The OpenClaw gateway owns this durable connection. Once paired, future reconnects are automatic.',
+          ].join('\n'),
         };
       }
 

--- a/packages/ac2-open-claw-reference/src/identity/pairing.ts
+++ b/packages/ac2-open-claw-reference/src/identity/pairing.ts
@@ -1,0 +1,36 @@
+/** Cross-process-safe durable pairing invitation creation. */
+
+import {
+  createPairingInvitation,
+  isLiquidAuthPairingCredential,
+  type LiquidAuthPairingCredential,
+} from '../providers/liquid-auth.js';
+import { loadAc2State, saveAc2State, withAc2StateLock } from './state.js';
+
+export interface EnsuredPairing {
+  pairing: LiquidAuthPairingCredential;
+  created: boolean;
+}
+
+export async function ensurePersistedPairing(
+  origin: string,
+  requestId?: string,
+  signal?: AbortSignal,
+): Promise<EnsuredPairing> {
+  return withAc2StateLock(async () => {
+    const state = loadAc2State();
+    if (state.pairing !== undefined) {
+      if (!isLiquidAuthPairingCredential(state.pairing)) {
+        throw new Error('[ac2] Persisted pairing credential is invalid');
+      }
+      return { pairing: state.pairing, created: false };
+    }
+    const pairing = await createPairingInvitation(origin, requestId ?? state.requestId, signal);
+    saveAc2State({
+      pairing,
+      requestId: pairing.pairingId,
+      activeRequestId: pairing.pairingId,
+    });
+    return { pairing, created: true };
+  }, signal);
+}

--- a/packages/ac2-open-claw-reference/src/identity/state.ts
+++ b/packages/ac2-open-claw-reference/src/identity/state.ts
@@ -1,8 +1,18 @@
 /** On-disk persistence for connections, identities, and per-thread history. */
 
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
+import type { LiquidAuthPairingCredential } from '../providers/liquid-auth.js';
 
 /** Persisted agent identity, as issued by the wallet during bootstrap. */
 export interface PersistedIdentity {
@@ -62,11 +72,51 @@ export interface PersistedConnection {
 
 /** Everything the plugin persists across restarts. */
 export interface Ac2PersistedState {
+  /** Durable Liquid Auth provider credential; retained until explicit forget. */
+  pairing?: LiquidAuthPairingCredential;
+  /** Revocation that could not be delivered yet. Never used to reconnect. */
+  pendingRevocation?: {
+    pairing: LiquidAuthPairingCredential;
+    requestedAt: number;
+  };
   /** Active `requestId` mirror (legacy single-connection field). */
   requestId?: string;
   identity?: PersistedIdentity;
   activeRequestId?: string;
   connections?: Record<string, PersistedConnection>;
+}
+
+export type Ac2StateErrorCode = 'AC2_STATE_INVALID' | 'AC2_STATE_UNREADABLE';
+
+/** Existing state must never be mistaken for a missing state file. */
+export class Ac2StateError extends Error {
+  readonly code: Ac2StateErrorCode;
+
+  constructor(code: Ac2StateErrorCode, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'Ac2StateError';
+    this.code = code;
+  }
+}
+
+function writeAc2State(state: Ac2PersistedState): void {
+  const path = statePath();
+  const temporary = `${path}.${process.pid}.${Date.now()}.tmp`;
+  mkdirSync(dirname(path), { recursive: true });
+  try {
+    writeFileSync(temporary, JSON.stringify(state, null, 2), {
+      encoding: 'utf-8',
+      mode: 0o600,
+    });
+    renameSync(temporary, path);
+  } catch (error) {
+    try {
+      unlinkSync(temporary);
+    } catch {
+      // The temporary file may not have been created.
+    }
+    throw error;
+  }
 }
 
 function statePath(): string {
@@ -75,38 +125,214 @@ function statePath(): string {
   return join(base, 'ac2-state.json');
 }
 
-/** Load persisted state (returns `{}` if missing/corrupt). */
-export function loadAc2State(): Ac2PersistedState {
+interface StateLockOwner {
+  pid: number;
+  createdAt: number;
+}
+
+function writeStateLockOwner(descriptor: number): void {
+  const owner: StateLockOwner = { pid: process.pid, createdAt: Date.now() };
+  writeFileSync(descriptor, JSON.stringify(owner), { encoding: 'utf-8' });
+}
+
+function stateLockIsStale(lockPath: string): boolean {
   try {
-    const raw = readFileSync(statePath(), 'utf-8');
-    const parsed = JSON.parse(raw) as Ac2PersistedState;
-    return parsed && typeof parsed === 'object' ? parsed : {};
+    const ageMs = Date.now() - statSync(lockPath).mtimeMs;
+    if (ageMs > 5 * 60_000) return true;
+    const owner = JSON.parse(readFileSync(lockPath, 'utf-8')) as Partial<StateLockOwner>;
+    if (!Number.isSafeInteger(owner.pid) || (owner.pid ?? 0) <= 0) return false;
+    try {
+      process.kill(owner.pid!, 0);
+      return false;
+    } catch (error) {
+      return (error as NodeJS.ErrnoException).code === 'ESRCH';
+    }
   } catch {
-    return {};
+    return false;
+  }
+}
+
+function tryReplaceStaleStateLock(lockPath: string): number | undefined {
+  if (!stateLockIsStale(lockPath)) return undefined;
+  const breakerPath = `${lockPath}.breaker`;
+  let breaker: number | undefined;
+  try {
+    breaker = openSync(breakerPath, 'wx', 0o600);
+    writeStateLockOwner(breaker);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+      if (stateLockIsStale(breakerPath)) {
+        try {
+          unlinkSync(breakerPath);
+        } catch {
+          // Another process may have reclaimed the breaker first.
+        }
+      }
+      return undefined;
+    }
+    if (breaker !== undefined) {
+      closeSync(breaker);
+      try {
+        unlinkSync(breakerPath);
+      } catch {
+        // Best-effort cleanup after a metadata write failure.
+      }
+    }
+    throw error;
+  }
+  try {
+    if (!stateLockIsStale(lockPath)) return undefined;
+    try {
+      unlinkSync(lockPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+    try {
+      const descriptor = openSync(lockPath, 'wx', 0o600);
+      try {
+        writeStateLockOwner(descriptor);
+      } catch (error) {
+        closeSync(descriptor);
+        try {
+          unlinkSync(lockPath);
+        } catch {
+          // Best-effort cleanup after a metadata write failure.
+        }
+        throw error;
+      }
+      return descriptor;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EEXIST') return undefined;
+      throw error;
+    }
+  } finally {
+    closeSync(breaker);
+    try {
+      unlinkSync(breakerPath);
+    } catch {
+      // Another interrupted process may already have cleaned it up.
+    }
+  }
+}
+
+function waitForStateLock(signal?: AbortSignal): Promise<void> {
+  if (!signal) return new Promise((resolve) => setTimeout(resolve, 50));
+  signal.throwIfAborted();
+  return new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(done, 50);
+    function done(): void {
+      clearTimeout(timeout);
+      signal!.removeEventListener('abort', onAbort);
+      resolve();
+    }
+    function onAbort(): void {
+      clearTimeout(timeout);
+      signal!.removeEventListener('abort', onAbort);
+      reject(signal!.reason);
+    }
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/** Serialize cross-process invitation creation and state migrations. */
+export async function withAc2StateLock<T>(
+  operation: () => Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  const lockPath = `${statePath()}.lock`;
+  mkdirSync(dirname(lockPath), { recursive: true });
+  let descriptor: number | undefined;
+  while (descriptor === undefined) {
+    signal?.throwIfAborted();
+    try {
+      descriptor = openSync(lockPath, 'wx', 0o600);
+      try {
+        writeStateLockOwner(descriptor);
+      } catch (error) {
+        closeSync(descriptor);
+        descriptor = undefined;
+        try {
+          unlinkSync(lockPath);
+        } catch {
+          // Best-effort cleanup after a metadata write failure.
+        }
+        throw error;
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      descriptor = tryReplaceStaleStateLock(lockPath);
+      if (descriptor === undefined) await waitForStateLock(signal);
+    }
+  }
+  try {
+    return await operation();
+  } finally {
+    closeSync(descriptor);
+    try {
+      unlinkSync(lockPath);
+    } catch {
+      // The lock may have been cleaned up after a process interruption.
+    }
+  }
+}
+
+/** Load persisted state. Only a genuinely missing file means fresh state. */
+export function loadAc2State(): Ac2PersistedState {
+  let raw: string;
+  try {
+    raw = readFileSync(statePath(), 'utf-8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return {};
+    throw new Ac2StateError(
+      'AC2_STATE_UNREADABLE',
+      `[ac2] Unable to read persisted state at ${statePath()}`,
+      { cause: error },
+    );
+  }
+  try {
+    const parsed = JSON.parse(raw) as Ac2PersistedState;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('The state root must be a JSON object');
+    }
+    return parsed;
+  } catch (error) {
+    throw new Ac2StateError(
+      'AC2_STATE_INVALID',
+      `[ac2] Persisted state at ${statePath()} is invalid JSON; refusing to replace it`,
+      { cause: error },
+    );
   }
 }
 
 /** Clear all persisted state (`ac2 forget`). */
 export function clearAc2State(): void {
-  const path = statePath();
-  try {
-    mkdirSync(dirname(path), { recursive: true });
-    writeFileSync(path, JSON.stringify({}, null, 2), 'utf-8');
-  } catch {
-    // best-effort
-  }
+  writeAc2State({});
+}
+
+/** Clear usable pairing state while retaining a revocation retry tombstone. */
+export function clearAc2StatePendingRevocation(
+  pairing: LiquidAuthPairingCredential,
+): void {
+  writeAc2State({ pendingRevocation: { pairing, requestedAt: Date.now() } });
+}
+
+/** Remove only an unapproved/expired invitation, preserving unrelated history. */
+export function discardPendingPairing(pairingId: string): void {
+  const state = loadAc2State();
+  if (state.pairing?.pairingId !== pairingId) return;
+  const {
+    pairing: _pairing,
+    requestId: _requestId,
+    activeRequestId: _activeRequestId,
+    ...remaining
+  } = state;
+  writeAc2State(remaining);
 }
 
 /** Merge `patch` into the state and write it back. */
 export function saveAc2State(patch: Partial<Ac2PersistedState>): void {
-  const path = statePath();
   const next: Ac2PersistedState = { ...loadAc2State(), ...patch };
-  try {
-    mkdirSync(dirname(path), { recursive: true });
-    writeFileSync(path, JSON.stringify(next, null, 2), 'utf-8');
-  } catch {
-    // best-effort
-  }
+  writeAc2State(next);
 }
 
 /** Known connections, most-recent first. */

--- a/packages/ac2-open-claw-reference/src/index.ts
+++ b/packages/ac2-open-claw-reference/src/index.ts
@@ -17,11 +17,18 @@ export {
   BootstrapError,
   bootstrapAgentIdentity,
   sessionManager,
+  Ac2ConnectionSupervisor,
+  connectionSupervisor,
+  isPairingAuthorizationError,
+  reconnectDelayMs,
   type SignParams,
   type SignResult,
   type SignDeps,
   type ChannelDeps,
   type ActiveSession,
+  type Ac2SupervisorOptions,
+  type Ac2SupervisorState,
+  type Ac2SupervisorStatus,
   type CapabilitiesResult,
   type ToolContext,
   type ChannelContext,
@@ -61,7 +68,17 @@ export {
   type X402PaymentContext,
   type X402PaymentSelection,
 } from './x402/index.js';
-export type { LiquidAuthChannelProviderOptions } from './providers/liquid-auth.js';
+export {
+  createPairingInvitation,
+  getLiquidAuthPairingErrorCode,
+  revokePairing,
+  isLiquidAuthPairingCredential,
+  LiquidAuthPairingError,
+  waitForSignalingConnect,
+  type LiquidAuthChannelProviderOptions,
+  type LiquidAuthPairingErrorCode,
+  type LiquidAuthPairingCredential,
+} from './providers/liquid-auth.js';
 export async function loadLiquidAuthChannelProvider(): Promise<
   typeof import('./providers/liquid-auth.js')
 > {

--- a/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
+++ b/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
@@ -101,11 +101,6 @@ const AC2_ICE_CONFIG: any = {
 };
 
 const AC2_HEARTBEAT_MS = 20000;
-/**
- * Treat the peer as gone if we receive no `ac2-heartbeat` traffic for this
- * long. 2.5× the send interval tolerates one missed round-trip plus jitter.
- */
-const AC2_DEFAULT_HEARTBEAT_TIMEOUT_MS = AC2_HEARTBEAT_MS * 2.5;
 const AC2_CONTROL_LABEL = 'ac2-v1' as const;
 const AC2_STREAM_LABEL = 'ac2-stream' as const;
 /** Dedicated liveness channel — keeps keepalive off the control plane. */
@@ -178,13 +173,249 @@ export function closeAwareTransport(base: Ac2Transport): {
   return { transport, emitClose };
 }
 
-export function resolveHeartbeatTimeoutMs(value?: string): number {
-  if (value === undefined || value.trim().length === 0) return AC2_DEFAULT_HEARTBEAT_TIMEOUT_MS;
+export function resolveHeartbeatTimeoutMs(value?: string | number): number | undefined {
+  // Mobile runtimes suspend JavaScript in the background, so lack of an
+  // application-level pong is not proof that the native WebRTC peer is dead.
+  // Keep the timeout opt-in and rely on DataChannel/ICE close events by default.
+  if (value === undefined || (typeof value === 'string' && value.trim().length === 0)) {
+    return undefined;
+  }
   const parsed = Number(value);
   const minimum = AC2_HEARTBEAT_MS * 2;
-  return Number.isFinite(parsed) && parsed >= minimum
-    ? parsed
-    : AC2_DEFAULT_HEARTBEAT_TIMEOUT_MS;
+  return Number.isFinite(parsed) && parsed >= minimum ? parsed : undefined;
+}
+
+interface HeartbeatDataChannelLike {
+  readyState?: string;
+  onmessage: ((event: { data: unknown }) => void) | null;
+  send(payload: string): void;
+}
+
+/** Install heartbeat liveness and ping-response handling as soon as a channel is discovered. */
+export function attachHeartbeatResponder(
+  channel: HeartbeatDataChannelLike,
+  onInbound: () => void,
+): void {
+  channel.onmessage = (event: { data: unknown }) => {
+    onInbound();
+    if (event?.data !== AC2_HEARTBEAT_PING || channel.readyState !== 'open') return;
+    try {
+      channel.send(AC2_HEARTBEAT_PONG);
+    } catch {
+      // Channel closing between check and send; ignore.
+    }
+  };
+}
+
+/** Durable provider credential issued by the Liquid Auth pairing service. */
+export interface LiquidAuthPairingCredential {
+  version: 2;
+  pairingId: string;
+  role: 'provider';
+  credential: string;
+}
+
+export type LiquidAuthPairingErrorCode = 'PAIRING_UNAUTHORIZED' | 'PAIRING_REVOKED';
+
+/** Stable pairing-auth failure surfaced by the Socket.IO handshake. */
+export class LiquidAuthPairingError extends Error {
+  readonly code: LiquidAuthPairingErrorCode;
+
+  constructor(code: LiquidAuthPairingErrorCode, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'LiquidAuthPairingError';
+    this.code = code;
+  }
+}
+
+/** Read an explicit server pairing error without classifying transient network failures. */
+export function getLiquidAuthPairingErrorCode(
+  error: unknown,
+): LiquidAuthPairingErrorCode | undefined {
+  let current = error;
+  const seen = new Set<unknown>();
+  while (current !== null && typeof current === 'object' && !seen.has(current)) {
+    seen.add(current);
+    const record = current as {
+      code?: unknown;
+      data?: { code?: unknown };
+      cause?: unknown;
+    };
+    const code = record.code ?? record.data?.code;
+    if (code === 'PAIRING_UNAUTHORIZED' || code === 'PAIRING_REVOKED') return code;
+    current = record.cause;
+  }
+  return undefined;
+}
+
+interface SignalingSocketLike {
+  connected?: boolean;
+  on(event: 'connect', listener: () => void): unknown;
+  on(event: 'connect_error', listener: (error: unknown) => void): unknown;
+  off(event: 'connect', listener: () => void): unknown;
+  off(event: 'connect_error', listener: (error: unknown) => void): unknown;
+}
+
+/** Wait for signaling while failing fast only for explicit credential rejection. */
+export function waitForSignalingConnect(socket: SignalingSocketLike): Promise<void> {
+  if (socket.connected) return Promise.resolve();
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const cleanup = (): void => {
+      socket.off('connect', onConnect);
+      socket.off('connect_error', onConnectError);
+    };
+    const finish = (operation: () => void): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      operation();
+    };
+    const onConnect = (): void => finish(resolve);
+    const onConnectError = (error: unknown): void => {
+      const code = getLiquidAuthPairingErrorCode(error);
+      if (!code) return;
+      const fallback =
+        code === 'PAIRING_REVOKED'
+          ? 'Pairing has been revoked'
+          : 'Pairing credential was not accepted';
+      const message =
+        error instanceof Error && error.message.length > 0 ? error.message : fallback;
+      finish(() => reject(new LiquidAuthPairingError(code, message, { cause: error })));
+    };
+
+    socket.on('connect', onConnect);
+    socket.on('connect_error', onConnectError);
+    // Close the race where the socket connected between the first check and
+    // listener registration.
+    if (socket.connected) onConnect();
+  });
+}
+
+export function isLiquidAuthPairingCredential(
+  value: unknown,
+): value is LiquidAuthPairingCredential {
+  if (value === null || typeof value !== 'object') return false;
+  const pairing = value as Partial<LiquidAuthPairingCredential>;
+  return (
+    pairing.version === 2 &&
+    pairing.role === 'provider' &&
+    typeof pairing.pairingId === 'string' &&
+    pairing.pairingId.length > 0 &&
+    typeof pairing.credential === 'string' &&
+    pairing.credential.length > 0
+  );
+}
+
+/** Create a durable invitation when no provider credential has been persisted. */
+export async function createPairingInvitation(
+  origin: string,
+  requestId?: string,
+  signal?: AbortSignal,
+): Promise<LiquidAuthPairingCredential> {
+  const response = await fetch(`${origin.replace(/\/$/, '')}/pairings/invitations`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(requestId ? { requestId } : {}),
+    ...(signal !== undefined ? { signal } : {}),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `[ac2] Liquid Auth invitation failed (${response.status} ${response.statusText})`,
+    );
+  }
+  const pairing: unknown = await response.json();
+  if (!isLiquidAuthPairingCredential(pairing)) {
+    throw new Error('[ac2] Liquid Auth invitation returned an invalid provider credential');
+  }
+  return pairing;
+}
+
+/** Revoke a durable pairing. A missing record is already effectively revoked. */
+export async function revokePairing(
+  origin: string,
+  pairing: LiquidAuthPairingCredential,
+  signal?: AbortSignal,
+): Promise<void> {
+  const response = await fetch(
+    `${origin.replace(/\/$/, '')}/pairings/${encodeURIComponent(pairing.pairingId)}`,
+    {
+      method: 'DELETE',
+      headers: {
+        authorization: `Bearer ${pairing.credential}`,
+        'x-pairing-role': pairing.role,
+      },
+      ...(signal !== undefined ? { signal } : {}),
+    },
+  );
+  if (!response.ok && response.status !== 404 && response.status !== 410) {
+    throw new Error(
+      `[ac2] Liquid Auth pairing revocation failed (${response.status} ${response.statusText})`,
+    );
+  }
+}
+
+export function buildSignalingSocketOptions(pairing: LiquidAuthPairingCredential): {
+  autoConnect: true;
+  withCredentials: true;
+  transports: ['websocket', 'polling'];
+  tryAllTransports: true;
+  auth: LiquidAuthPairingCredential;
+} {
+  return {
+    autoConnect: true,
+    withCredentials: true,
+    // Prefer a real WebSocket so deployments that reject Engine.IO's XHR
+    // polling transport do not get stuck in a connect_error loop. Retain
+    // polling as a compatibility fallback for networks that block WebSockets.
+    transports: ['websocket', 'polling'],
+    tryAllTransports: true,
+    auth: pairing,
+  };
+}
+
+function pairingAbortError(): Error {
+  const error = new Error('[ac2] Pairing aborted');
+  error.name = 'AbortError';
+  return error;
+}
+
+function waitForPairingPhase<T>(
+  promise: Promise<T>,
+  options: Ac2StartPairingOptions,
+  phase: string,
+): Promise<T> {
+  const { signal, timeoutMs } = options;
+  if (signal?.aborted) return Promise.reject(pairingAbortError());
+  if (signal === undefined && timeoutMs === undefined) return promise;
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const cleanup = (): void => {
+      if (timeout) clearTimeout(timeout);
+      signal?.removeEventListener('abort', onAbort);
+    };
+    const settle = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      fn();
+    };
+    const onAbort = (): void => settle(() => reject(pairingAbortError()));
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+    if (timeoutMs !== undefined) {
+      timeout = setTimeout(
+        () => settle(() => reject(new Error(`[ac2] Timeout waiting for ${phase}`))),
+        timeoutMs,
+      );
+    }
+    promise.then(
+      (value) => settle(() => resolve(value)),
+      (error) => settle(() => reject(error)),
+    );
+  });
 }
 
 export interface LiquidAuthChannelProviderOptions {
@@ -192,32 +423,78 @@ export interface LiquidAuthChannelProviderOptions {
   origin?: string;
   /** Pre-supplied requestId (otherwise `SignalClient.generateRequestId()`). */
   requestId?: string;
+  /** Durable provider credential returned by `/pairings/invitations`. */
+  pairing?: LiquidAuthPairingCredential;
   /** Request the optional `ac2-stream` channel (default `true`). */
   includeStreamChannel?: boolean;
-  /** Milliseconds without inbound heartbeat traffic before closing. */
+  /**
+   * Optional milliseconds without inbound heartbeat traffic before closing.
+   * Disabled by default because mobile controllers can suspend JavaScript in
+   * the background while their native WebRTC connection remains valid. Values
+   * below two heartbeat intervals (40 seconds) are ignored.
+   */
   heartbeatTimeoutMs?: number;
 }
 
 export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
   constructor(private readonly defaults: LiquidAuthChannelProviderOptions = {}) {}
 
-  async startPairing(_opts: Ac2StartPairingOptions = {}): Promise<Ac2PairingHandle> {
+  async startPairing(opts: Ac2StartPairingOptions = {}): Promise<Ac2PairingHandle> {
+    opts.signal?.throwIfAborted();
     await ensureWebRtcPolyfill();
 
     const origin = this.defaults.origin ?? 'https://debug.liquidauth.com';
-    const requestId = this.defaults.requestId ?? SignalClient.generateRequestId();
+    const invitationPromise = this.defaults.pairing
+      ? Promise.resolve(this.defaults.pairing)
+      : createPairingInvitation(origin, this.defaults.requestId, opts.signal);
+    const durablePairing = await waitForPairingPhase(invitationPromise, opts, 'pairing invitation');
+    const requestId = durablePairing.pairingId;
     const includeStream = this.defaults.includeStreamChannel ?? true;
-    const heartbeatTimeoutMs =
-      this.defaults.heartbeatTimeoutMs ??
-      resolveHeartbeatTimeoutMs(process.env['AC2_HEARTBEAT_TIMEOUT_MS']);
+    const heartbeatTimeoutMs = resolveHeartbeatTimeoutMs(
+      this.defaults.heartbeatTimeoutMs ?? process.env['AC2_HEARTBEAT_TIMEOUT_MS'],
+    );
 
     // Build the signaling socket from the Node-native `socket.io-client` and
     // pass it to `SignalClient` via its `{ socket }` option.
-    const socket = createSocketIoClient(origin, {
-      autoConnect: true,
-    });
+    const socket = createSocketIoClient(origin, buildSignalingSocketOptions(durablePairing));
 
     const client = new SignalClient(origin, { socket: socket as any });
+
+    let heartbeat: ReturnType<typeof setInterval> | undefined;
+    let controlChannel: any;
+    let streamChannel: any;
+    let heartbeatChannel: any;
+    let lastHeartbeatInboundAt = Date.now();
+    let emitTransportClose: () => void = () => {};
+    let closed = false;
+
+    const close = async (): Promise<void> => {
+      if (closed) return;
+      closed = true;
+      if (heartbeat) {
+        clearInterval(heartbeat);
+        heartbeat = undefined;
+      }
+      closeRtcDataChannel(heartbeatChannel);
+      closeRtcDataChannel(streamChannel);
+      closeRtcDataChannel(controlChannel);
+      emitTransportClose();
+      try {
+        (client as unknown as { peerClient?: { close?: () => void } }).peerClient?.close?.();
+      } catch {
+        // Already closed; ignore.
+      }
+      try {
+        client.close(true);
+      } catch {
+        // Already closed; ignore.
+      }
+    };
+
+    const onAbort = (): void => {
+      void close();
+    };
+    opts.signal?.addEventListener('abort', onAbort, { once: true });
 
     // Capture the wallet account from the Liquid Auth `link` response.
     let linkedWallet: string | undefined;
@@ -229,9 +506,7 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
 
     // Block resolving until the signaling socket is up (the caller renders
     // the QR only after `startPairing` resolves).
-    const waitForConnect = new Promise<void>((resolve) => {
-      client.on('connect', () => resolve());
-    });
+    const waitForConnect = waitForSignalingConnect(socket as unknown as SignalingSocketLike);
     // Bind low-level error/disconnect diagnostics once the socket is built.
     void (async () => {
       try {
@@ -278,27 +553,24 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
 
     const pairing: Ac2PairingInfo = {
       qrPayload,
-      metadata: { origin, requestId },
-    };
-
-    let heartbeat: ReturnType<typeof setInterval> | undefined;
-    let closed = false;
-
-    // Forward-declare so the heartbeat interval (defined inside `connect`)
-    // can call it on liveness timeout.
-    let close: () => Promise<void> = async () => {
-      /* assigned in connect() */
+      metadata: { origin, requestId, pairing: durablePairing },
     };
 
     const connect = async (): Promise<Ac2PairedChannel> => {
       // `peer(...)` resolves with the primary channel; the rest arrive via `'data-channel'`.
-      let controlChannel: any;
-      let streamChannel: any;
-      let heartbeatChannel: any;
       client.on('data-channel', (channel: any) => {
         if (channel.label === AC2_CONTROL_LABEL) controlChannel = channel;
         else if (channel.label === AC2_STREAM_LABEL) streamChannel = channel;
-        else if (channel.label === AC2_HEARTBEAT_LABEL) heartbeatChannel = channel;
+        else if (channel.label === AC2_HEARTBEAT_LABEL) {
+          heartbeatChannel = channel;
+          lastHeartbeatInboundAt = Date.now();
+          // Side channels may arrive after `peer()` resolves its first channel.
+          // Wire the responder here rather than after the connection grace
+          // period so a late heartbeat channel can never miss its handler.
+          attachHeartbeatResponder(channel, () => {
+            lastHeartbeatInboundAt = Date.now();
+          });
+        }
       });
 
       type DataChannelInit = { ordered?: boolean };
@@ -307,9 +579,19 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
         ...(includeStream ? { [AC2_STREAM_LABEL]: { ordered: true } } : {}),
         [AC2_HEARTBEAT_LABEL]: { ordered: true },
       };
-      const primary: any = await client.peer(requestId, 'offer', AC2_ICE_CONFIG, {
+      const peerPromise: Promise<any> = (
+        client.peer as unknown as (
+          requestId: string,
+          type: 'offer',
+          config: any,
+          options: Record<string, unknown>,
+        ) => Promise<any>
+      )(requestId, 'offer', AC2_ICE_CONFIG, {
         dataChannels,
+        ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
+        ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
       });
+      const primary: any = await waitForPairingPhase(peerPromise, opts, 'peer connection');
       controlChannel = controlChannel ?? primary;
 
       if (controlChannel.label !== AC2_CONTROL_LABEL) {
@@ -323,6 +605,7 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
       await new Promise((resolve) => setTimeout(resolve, 500));
 
       const { transport, emitClose } = closeAwareTransport(rtcDataChannelTransport(controlChannel));
+      emitTransportClose = emitClose;
 
       if (!transport.isOpen) {
         await new Promise<void>((resolve, reject) => {
@@ -343,33 +626,21 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
 
       // Bidirectional keep-alive: each side pings on its own timer AND replies
       // PONG to the peer's pings. `lastInboundAt` is updated on any inbound
-      // frame (PING or PONG); the interval below declares the peer dead if no
-      // inbound traffic arrives within `heartbeatTimeoutMs` and triggers
-      // `close()` so the control transport's `onClose` propagates upstream.
+      // frame (PING or PONG). If an operator explicitly configures
+      // `heartbeatTimeoutMs`, the interval below closes on expiry.
       //
-      // The heartbeat channel is optional and mobile controllers can suspend
-      // it while backgrounded. Only enforce the timeout when the heartbeat
-      // channel is present and open; the WebRTC/control close handlers remain
-      // authoritative for peers that really go away.
-      let lastInboundAt = Date.now();
-
-      if (heartbeatChannel) {
-        heartbeatChannel.onmessage = (ev: { data: unknown }) => {
-          lastInboundAt = Date.now();
-          if (ev?.data === AC2_HEARTBEAT_PING && heartbeatChannel.readyState === 'open') {
-            try {
-              heartbeatChannel.send(AC2_HEARTBEAT_PONG);
-            } catch {
-              // Channel closing between check and send; ignore.
-            }
-          }
-        };
-      }
-
+      // The timeout is disabled by default because mobile controllers can
+      // suspend JavaScript in the background while native WebRTC remains valid.
+      // WebRTC/control close handlers remain authoritative for peers that
+      // really go away.
+      lastHeartbeatInboundAt = Date.now();
       heartbeat = setInterval(() => {
         if (!heartbeatChannel || heartbeatChannel.readyState !== 'open') return;
 
-        if (Date.now() - lastInboundAt > heartbeatTimeoutMs) {
+        if (
+          heartbeatTimeoutMs !== undefined &&
+          Date.now() - lastHeartbeatInboundAt > heartbeatTimeoutMs
+        ) {
           // eslint-disable-next-line no-console
           console.warn(
             `[ac2] Heartbeat timeout (${heartbeatTimeoutMs}ms with no inbound) — closing channel.`,
@@ -385,24 +656,6 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
           // Channel closed between checks; ignore.
         }
       }, AC2_HEARTBEAT_MS);
-
-      close = async (): Promise<void> => {
-        if (closed) return;
-        closed = true;
-        if (heartbeat) {
-          clearInterval(heartbeat);
-          heartbeat = undefined;
-        }
-        closeRtcDataChannel(heartbeatChannel);
-        closeRtcDataChannel(streamChannel);
-        closeRtcDataChannel(controlChannel);
-        emitClose();
-        try {
-          client.close(true);
-        } catch {
-          // Already closed; ignore.
-        }
-      };
 
       const channel: Ac2PairedChannel = {
         transport,
@@ -429,8 +682,23 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
       return channel;
     };
 
-    await waitForConnect;
+    try {
+      await waitForPairingPhase(waitForConnect, opts, 'signaling connection');
+    } catch (error) {
+      await close();
+      throw error;
+    }
 
-    return { pairing, connect };
+    return {
+      pairing,
+      connect: async () => {
+        try {
+          return await connect();
+        } catch (error) {
+          await close();
+          throw error;
+        }
+      },
+    };
   }
 }

--- a/packages/ac2-open-claw-reference/src/session/connected-session.ts
+++ b/packages/ac2-open-claw-reference/src/session/connected-session.ts
@@ -1,0 +1,254 @@
+/** One connected AC2 session, shared by the gateway supervisor and legacy CLI. */
+
+import { Ac2Client } from '@algorandfoundation/ac2-sdk';
+import { isValidAddress } from '@algorandfoundation/algokit-utils/common';
+import type { Ac2PairedChannel } from '@algorandfoundation/ac2-sdk/signaling';
+import type { OpenClawApi, ResolvedConfig } from '../runtime.js';
+import { safeLog } from '../runtime.js';
+import { BootstrapError, bootstrapAgentIdentity } from './bootstrap.js';
+import { sessionManager } from './manager.js';
+import {
+  ensureConversation,
+  loadAc2State,
+  saveAc2State,
+  setConnectionIdentity,
+  touchConnection,
+} from '../identity/state.js';
+import { normalizeDidKey } from '../identity/did.js';
+import { hasAgentIdentity, recordAgentIdentity } from '../identity/keystore.js';
+import {
+  DEFAULT_THID,
+  clearActiveConversation,
+  replayConversationHistory,
+  replayConversationList,
+  routeInboundToAgent,
+  sendFinalize,
+  setActiveConversation,
+} from '../channel/index.js';
+
+const NO_IDENTITY_NOTICE =
+  "I don't have an identity yet. To work with you securely I need my own " +
+  'dedicated key. Until you grant one, I can chat with you but cannot perform signing-related actions.';
+
+export interface ConnectedSessionOptions {
+  api: OpenClawApi;
+  config: ResolvedConfig;
+  connect: () => Promise<Ac2PairedChannel>;
+  /** Pairing id for this exact attempt; avoids reading a concurrently replaced state record. */
+  requestId?: string;
+  signal?: AbortSignal;
+  onState?: (state: 'online' | 'offline') => void;
+}
+
+/** Connect, restore/bootstrap identity, route messages, and wait for transport loss. */
+export async function runConnectedSession(options: ConnectedSessionOptions): Promise<void> {
+  const { api, config, connect, signal, onState } = options;
+  let paired: Ac2PairedChannel | undefined;
+  try {
+    signal?.throwIfAborted();
+    const connected = await connect();
+    paired = connected;
+    const { transport, streamChannel: streamTransport } = connected;
+    const client = new Ac2Client(transport);
+
+    const state = loadAc2State();
+    const connectionRequestId = options.requestId ?? state.pairing?.pairingId ?? state.requestId;
+    if (connectionRequestId) touchConnection(connectionRequestId);
+
+    const connectedAccount =
+      typeof connected.peer?.['wallet'] === 'string'
+        ? (connected.peer['wallet'] as string)
+        : undefined;
+    const walletAddress =
+      connectedAccount !== undefined && isValidAddress(connectedAccount)
+        ? connectedAccount
+        : undefined;
+    const connectedAccountDid =
+      connectedAccount !== undefined
+        ? normalizeDidKey(`did:key:${connectedAccount}`)
+        : connected.peer?.did;
+    const storedIdentity =
+      (connectionRequestId
+        ? loadAc2State().connections?.[connectionRequestId]?.identity
+        : undefined) ?? loadAc2State().identity;
+
+    let agentDid = 'did:ac2:agent';
+    let controllerDid = connectedAccountDid ?? 'did:key:zAc2Controller';
+    let identityGranted = true;
+    if (storedIdentity) {
+      if (
+        connectedAccountDid !== undefined &&
+        storedIdentity.controllerDid !== connectedAccountDid
+      ) {
+        throw new BootstrapError(
+          `[ac2-open-claw] Persisted controller (${storedIdentity.controllerDid}) does not match ` +
+            `the linked account (${connectedAccountDid}); refusing the reconnect.`,
+        );
+      }
+      agentDid = storedIdentity.agentDid;
+      controllerDid = storedIdentity.controllerDid;
+      if (storedIdentity.material && !hasAgentIdentity(agentDid)) {
+        await recordAgentIdentity({
+          agentDid,
+          publicKey: storedIdentity.publicKey,
+          material: storedIdentity.material,
+        });
+      }
+      safeLog(api, 'info', '[ac2] Reusing persisted agent identity.');
+    } else {
+      let bootstrapped: Awaited<ReturnType<typeof bootstrapAgentIdentity>> | undefined;
+      try {
+        bootstrapped = await bootstrapAgentIdentity(client, {
+          ...(connected.peer?.did !== undefined ? { peerDid: connected.peer.did } : {}),
+          ...(config.defaultTimeoutMs !== undefined
+            ? { timeoutMs: config.defaultTimeoutMs }
+            : {}),
+        });
+      } catch (error) {
+        if (!(error instanceof BootstrapError)) throw error;
+        identityGranted = false;
+        safeLog(
+          api,
+          'warn',
+          `[ac2] No agent identity granted: ${error.message}. Keeping chat available.`,
+        );
+      }
+      if (bootstrapped) {
+        agentDid = bootstrapped.agentDid;
+        if (
+          connectedAccountDid !== undefined &&
+          bootstrapped.controllerDid !== connectedAccountDid
+        ) {
+          throw new BootstrapError(
+            `[ac2-open-claw] KeyResponse.from (${bootstrapped.controllerDid}) does not match ` +
+              `the linked account (${connectedAccountDid}); refusing to grant identity.`,
+          );
+        }
+        controllerDid = connectedAccountDid ?? bootstrapped.controllerDid;
+        if (bootstrapped.response.body.material !== undefined) {
+          await recordAgentIdentity({
+            agentDid,
+            publicKey: bootstrapped.response.body.public_key,
+            material: bootstrapped.response.body.material,
+          });
+        }
+        const identity = {
+          agentDid,
+          controllerDid,
+          publicKey: bootstrapped.response.body.public_key,
+        };
+        if (connectionRequestId) setConnectionIdentity(connectionRequestId, identity);
+        else saveAc2State({ identity });
+      }
+    }
+
+    sessionManager.setActive({
+      transport,
+      client,
+      controllerDid,
+      agentDid,
+      identityGranted,
+      ...(walletAddress ? { walletAddress } : {}),
+      ...(connectionRequestId ? { requestId: connectionRequestId } : {}),
+    });
+    safeLog(
+      api,
+      'info',
+      `[ac2] Channel paired and active. agentDid=${agentDid} controllerDid=${controllerDid}`,
+    );
+    onState?.('online');
+
+    const streamSendable = streamTransport
+      ? {
+          send: (payload: string) => streamTransport.send(payload),
+          get isOpen() {
+            return streamTransport.readyState === 'open';
+          },
+        }
+      : undefined;
+    const controlSendable = {
+      send(payload: string): void {
+        if (streamSendable?.isOpen) {
+          try {
+            streamSendable.send(payload);
+            return;
+          } catch {
+            // The stream can close between readyState and send; fall back to control.
+          }
+        }
+        transport.send(payload);
+      },
+      get isOpen() {
+        return Boolean(streamSendable?.isOpen || transport.isOpen);
+      },
+    };
+
+    client.updateHandlers({
+      'ac2/ConversationOpen': (msg) => {
+        const thid =
+          typeof (msg.body as any)?.thid === 'string' && (msg.body as any).thid.length > 0
+            ? ((msg.body as any).thid as string)
+            : msg.thid;
+        if (!thid) return;
+        const title =
+          typeof (msg.body as any)?.title === 'string'
+            ? ((msg.body as any).title as string)
+            : undefined;
+        setActiveConversation(controllerDid, thid, connectionRequestId);
+        if (connectionRequestId) {
+          ensureConversation(connectionRequestId, thid, title);
+        }
+        replayConversationHistory(controlSendable, connectionRequestId, thid);
+      },
+      'ac2/ConversationClose': (msg) => {
+        const thid =
+          typeof (msg.body as any)?.thid === 'string' && (msg.body as any).thid.length > 0
+            ? ((msg.body as any).thid as string)
+            : msg.thid;
+        if (thid) clearActiveConversation(controllerDid, thid, connectionRequestId);
+      },
+    });
+
+    replayConversationList(controlSendable, connectionRequestId);
+    replayConversationHistory(controlSendable, connectionRequestId, DEFAULT_THID);
+    if (!identityGranted) {
+      sendFinalize(controlSendable, DEFAULT_THID, `ac2-noid-${Date.now()}`, NO_IDENTITY_NOTICE);
+    }
+
+    if (streamTransport) {
+      streamTransport.onmessage = async (event: { data: unknown }) => {
+        if (typeof event.data !== 'string' || event.data.trim().length === 0) return;
+        const active = sessionManager.getActive();
+        if (!active) return;
+        await routeInboundToAgent(
+          api,
+          event.data,
+          controlSendable,
+          active.controllerDid,
+          active.requestId,
+        );
+      };
+    }
+    transport.onRawMessage?.(async (text: string) => {
+      const active = sessionManager.getActive();
+      if (!active) return;
+      await routeInboundToAgent(
+        api,
+        text,
+        controlSendable,
+        active.controllerDid,
+        active.requestId,
+      );
+    });
+
+    await new Promise<void>((resolve) => {
+      transport.onClose(resolve);
+      transport.onError(() => resolve());
+      signal?.addEventListener('abort', () => resolve(), { once: true });
+    });
+  } finally {
+    onState?.('offline');
+    sessionManager.clearActive();
+    if (paired) await paired.close();
+  }
+}

--- a/packages/ac2-open-claw-reference/src/session/index.ts
+++ b/packages/ac2-open-claw-reference/src/session/index.ts
@@ -34,3 +34,13 @@ export {
   type CapabilitiesResult,
 } from './flows.js';
 export { runAc2Channel, renderPairingQr, type ChannelDeps } from './channel-runtime.js';
+export { runConnectedSession, type ConnectedSessionOptions } from './connected-session.js';
+export {
+  Ac2ConnectionSupervisor,
+  connectionSupervisor,
+  isPairingAuthorizationError,
+  reconnectDelayMs,
+  type Ac2SupervisorOptions,
+  type Ac2SupervisorState,
+  type Ac2SupervisorStatus,
+} from './supervisor.js';

--- a/packages/ac2-open-claw-reference/src/session/supervisor.ts
+++ b/packages/ac2-open-claw-reference/src/session/supervisor.ts
@@ -1,0 +1,289 @@
+/** Gateway-owned durable AC2 connection supervisor. */
+
+import type { OpenClawApi, ResolvedConfig } from '../runtime.js';
+import { safeLog } from '../runtime.js';
+import {
+  LiquidAuthChannelProvider,
+  getLiquidAuthPairingErrorCode,
+  isLiquidAuthPairingCredential,
+  renderPairingQr,
+  revokePairing,
+  type LiquidAuthPairingCredential,
+} from '../providers/liquid-auth.js';
+import {
+  clearAc2State,
+  discardPendingPairing,
+  getConnection,
+  loadAc2State,
+} from '../identity/state.js';
+import { ensurePersistedPairing } from '../identity/pairing.js';
+import { sessionManager } from './manager.js';
+import { runConnectedSession } from './connected-session.js';
+
+const DEFAULT_LIQUID_AUTH_SERVER = 'https://debug.liquidauth.com';
+const MIN_RETRY_MS = 1_000;
+const MAX_RETRY_MS = 30_000;
+
+export type Ac2SupervisorState =
+  | 'stopped'
+  | 'unpaired'
+  | 'revoking'
+  | 'connecting'
+  | 'paired_offline'
+  | 'online';
+
+export interface Ac2SupervisorStatus {
+  state: Ac2SupervisorState;
+  pairingId?: string;
+  reconnectAttempts: number;
+  lastError?: string;
+}
+
+export interface Ac2SupervisorOptions {
+  api: OpenClawApi;
+  config: ResolvedConfig;
+  signal?: AbortSignal;
+  renderQr?: (pairing: { qrPayload: string }) => void;
+  random?: () => number;
+  setStatus?: (status: Ac2SupervisorStatus) => void;
+}
+
+function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timeout = setTimeout(done, ms);
+    function done(): void {
+      clearTimeout(timeout);
+      signal.removeEventListener('abort', done);
+      resolve();
+    }
+    signal.addEventListener('abort', done, { once: true });
+  });
+}
+
+export function reconnectDelayMs(attempt: number, random: () => number = Math.random): number {
+  const exponential = Math.min(MAX_RETRY_MS, MIN_RETRY_MS * 2 ** Math.max(0, attempt - 1));
+  const jitter = 0.8 + random() * 0.4;
+  return Math.min(MAX_RETRY_MS, Math.round(exponential * jitter));
+}
+
+/** Only an explicit unauthorized response can mean a pending invitation expired. */
+export function isPairingAuthorizationError(error: unknown): boolean {
+  return getLiquidAuthPairingErrorCode(error) === 'PAIRING_UNAUTHORIZED';
+}
+
+export class Ac2ConnectionSupervisor {
+  private controller: AbortController | undefined;
+  private running: Promise<void> | undefined;
+  private status: Ac2SupervisorStatus = { state: 'stopped', reconnectAttempts: 0 };
+
+  getStatus(): Ac2SupervisorStatus {
+    return { ...this.status };
+  }
+
+  start(options: Ac2SupervisorOptions): Promise<void> {
+    if (this.running) return this.running;
+    const controller = new AbortController();
+    this.controller = controller;
+    const onAbort = (): void => controller.abort();
+    if (options.signal?.aborted) controller.abort();
+    else options.signal?.addEventListener('abort', onAbort, { once: true });
+    this.running = this.run(options, controller.signal).finally(() => {
+      options.signal?.removeEventListener('abort', onAbort);
+      this.controller = undefined;
+      this.running = undefined;
+      this.update(options, { state: 'stopped', reconnectAttempts: 0 });
+    });
+    return this.running;
+  }
+
+  async stop(): Promise<void> {
+    this.controller?.abort();
+    try {
+      sessionManager.getActive()?.transport.close();
+    } catch {
+      // The active transport may already be closing.
+    }
+    await this.running;
+  }
+
+  private update(options: Ac2SupervisorOptions, patch: Ac2SupervisorStatus): void {
+    this.status = patch;
+    options.setStatus?.(this.getStatus());
+  }
+
+  private async run(options: Ac2SupervisorOptions, signal: AbortSignal): Promise<void> {
+    const origin =
+      process.env['AC2_LIQUID_AUTH_SERVER'] ??
+      options.config.liquidAuthServer ??
+      DEFAULT_LIQUID_AUTH_SERVER;
+    const renderQr = options.renderQr ?? renderPairingQr;
+    const random = options.random ?? Math.random;
+    let reconnectAttempts = 0;
+    let renderedPairingId: string | undefined;
+
+    while (!signal.aborted) {
+      let persisted: ReturnType<typeof loadAc2State>;
+      try {
+        persisted = loadAc2State();
+      } catch (error) {
+        reconnectAttempts += 1;
+        const message = error instanceof Error ? error.message : String(error);
+        this.update(options, {
+          state: 'paired_offline',
+          reconnectAttempts,
+          lastError: message,
+        });
+        safeLog(options.api, 'error', message);
+        await abortableDelay(reconnectDelayMs(reconnectAttempts, random), signal);
+        continue;
+      }
+      const pendingRevocation = persisted.pendingRevocation;
+      if (pendingRevocation) {
+        this.update(options, {
+          state: 'revoking',
+          pairingId: pendingRevocation.pairing.pairingId,
+          reconnectAttempts,
+        });
+        try {
+          await revokePairing(
+            origin,
+            pendingRevocation.pairing,
+            AbortSignal.any([signal, AbortSignal.timeout(10_000)]),
+          );
+          clearAc2State();
+          persisted = {};
+        } catch (error) {
+          if (signal.aborted) break;
+          reconnectAttempts += 1;
+          const message = error instanceof Error ? error.message : String(error);
+          this.update(options, {
+            state: 'revoking',
+            pairingId: pendingRevocation.pairing.pairingId,
+            reconnectAttempts,
+            lastError: message,
+          });
+          await abortableDelay(reconnectDelayMs(reconnectAttempts, random), signal);
+          continue;
+        }
+      }
+
+      const state = persisted;
+      const existingPairing = state.pairing;
+      let attemptPairing: LiquidAuthPairingCredential | undefined;
+      const attemptController = new AbortController();
+      const abortAttempt = (): void => attemptController.abort();
+      signal.addEventListener('abort', abortAttempt, { once: true });
+      let stateWatcher: ReturnType<typeof setInterval> | undefined;
+      try {
+        this.update(options, {
+          state: existingPairing ? 'paired_offline' : 'unpaired',
+          ...(existingPairing ? { pairingId: existingPairing.pairingId } : {}),
+          reconnectAttempts,
+        });
+        const ensured = await ensurePersistedPairing(
+          origin,
+          state.requestId,
+          attemptController.signal,
+        );
+        attemptPairing = ensured.pairing;
+        stateWatcher = setInterval(() => {
+          let current: LiquidAuthPairingCredential | undefined;
+          try {
+            current = loadAc2State().pairing;
+          } catch {
+            attemptController.abort();
+            return;
+          }
+          if (!current || current.credential !== attemptPairing?.credential) {
+            attemptController.abort();
+          }
+        }, 1_000);
+        const provider = new LiquidAuthChannelProvider({
+          origin,
+          pairing: attemptPairing,
+        });
+        const handle = await provider.startPairing({
+          signal: attemptController.signal,
+          timeoutMs: options.config.defaultTimeoutMs ?? 120_000,
+        });
+        const issued = handle.pairing.metadata?.['pairing'];
+        if (!isLiquidAuthPairingCredential(issued)) {
+          throw new Error('[ac2] Pairing provider did not return a durable credential');
+        }
+        const pairing: LiquidAuthPairingCredential = issued;
+        if (ensured.created && renderedPairingId !== pairing.pairingId) {
+          renderedPairingId = pairing.pairingId;
+          renderQr(handle.pairing);
+        }
+
+        this.update(options, {
+          state: 'connecting',
+          pairingId: pairing.pairingId,
+          reconnectAttempts,
+        });
+        await runConnectedSession({
+          api: options.api,
+          config: options.config,
+          connect: handle.connect,
+          requestId: pairing.pairingId,
+          signal: attemptController.signal,
+          onState: (connectedState) => {
+            if (connectedState === 'online') reconnectAttempts = 0;
+            this.update(options, {
+              state: connectedState === 'online' ? 'online' : 'paired_offline',
+              pairingId: pairing.pairingId,
+              reconnectAttempts,
+            });
+          },
+        });
+        safeLog(options.api, 'info', '[ac2] Transport offline; retaining durable pairing.');
+      } catch (error) {
+        if (signal.aborted) break;
+        reconnectAttempts += 1;
+        const message = error instanceof Error ? error.message : String(error);
+        const pairingId = attemptPairing?.pairingId ?? existingPairing?.pairingId;
+        let rotatePendingInvitation = false;
+        if (attemptPairing !== undefined && isPairingAuthorizationError(error)) {
+          try {
+            if (getConnection(attemptPairing.pairingId) === undefined) {
+              discardPendingPairing(attemptPairing.pairingId);
+              rotatePendingInvitation = true;
+            }
+          } catch (stateError) {
+            safeLog(
+              options.api,
+              'error',
+              stateError instanceof Error ? stateError.message : String(stateError),
+            );
+          }
+        }
+        if (rotatePendingInvitation) {
+          renderedPairingId = undefined;
+          safeLog(
+            options.api,
+            'warn',
+            `[ac2] Pending invitation ${pairingId} is no longer authorized; rotating it.`,
+          );
+        }
+        this.update(options, {
+          state: pairingId && !rotatePendingInvitation ? 'paired_offline' : 'unpaired',
+          ...(pairingId && !rotatePendingInvitation ? { pairingId } : {}),
+          reconnectAttempts,
+          lastError: message,
+        });
+        safeLog(options.api, 'warn', `[ac2] Connection attempt failed: ${message}`);
+      } finally {
+        if (stateWatcher) clearInterval(stateWatcher);
+        signal.removeEventListener('abort', abortAttempt);
+        attemptController.abort();
+      }
+
+      if (!signal.aborted) {
+        await abortableDelay(reconnectDelayMs(Math.max(1, reconnectAttempts), random), signal);
+      }
+    }
+  }
+}
+
+export const connectionSupervisor = new Ac2ConnectionSupervisor();

--- a/packages/ac2-open-claw-reference/tests/liquid-auth-provider.test.ts
+++ b/packages/ac2-open-claw-reference/tests/liquid-auth-provider.test.ts
@@ -1,11 +1,191 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Ac2Transport } from '@algorandfoundation/ac2-sdk/transport';
 
 import {
+  attachHeartbeatResponder,
   closeAwareTransport,
   closeRtcDataChannel,
+  buildSignalingSocketOptions,
+  createPairingInvitation,
+  isLiquidAuthPairingCredential,
+  revokePairing,
   resolveHeartbeatTimeoutMs,
+  waitForSignalingConnect,
 } from '../src/providers/liquid-auth.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+class FakeSignalingSocket {
+  connected = false;
+  private readonly listeners = new Map<string, Set<(...args: any[]) => void>>();
+
+  on(event: string, listener: (...args: any[]) => void): this {
+    const handlers = this.listeners.get(event) ?? new Set();
+    handlers.add(listener);
+    this.listeners.set(event, handlers);
+    return this;
+  }
+
+  off(event: string, listener: (...args: any[]) => void): this {
+    this.listeners.get(event)?.delete(listener);
+    return this;
+  }
+
+  emit(event: string, ...args: any[]): void {
+    for (const listener of this.listeners.get(event) ?? []) listener(...args);
+  }
+
+  listenerCount(event: string): number {
+    return this.listeners.get(event)?.size ?? 0;
+  }
+}
+
+describe('Liquid Auth signaling authentication', () => {
+  it('fails immediately with a stable code and removes phase listeners', async () => {
+    const socket = new FakeSignalingSocket();
+    const pending = waitForSignalingConnect(socket);
+    const handshakeError = Object.assign(new Error('Invalid pairing credentials'), {
+      data: { code: 'PAIRING_UNAUTHORIZED' },
+    });
+
+    socket.emit('connect_error', handshakeError);
+
+    await expect(pending).rejects.toMatchObject({
+      name: 'LiquidAuthPairingError',
+      code: 'PAIRING_UNAUTHORIZED',
+    });
+    expect(socket.listenerCount('connect')).toBe(0);
+    expect(socket.listenerCount('connect_error')).toBe(0);
+  });
+
+  it('ignores transient polling errors and resolves on a later reconnect', async () => {
+    const socket = new FakeSignalingSocket();
+    const pending = waitForSignalingConnect(socket);
+
+    socket.emit('connect_error', Object.assign(new Error('xhr poll error'), {
+      context: { status: 0 },
+    }));
+    expect(socket.listenerCount('connect')).toBe(1);
+    expect(socket.listenerCount('connect_error')).toBe(1);
+
+    socket.connected = true;
+    socket.emit('connect');
+
+    await expect(pending).resolves.toBeUndefined();
+    expect(socket.listenerCount('connect')).toBe(0);
+    expect(socket.listenerCount('connect_error')).toBe(0);
+  });
+});
+
+describe('Liquid Auth durable pairing invitation', () => {
+  const pairing = {
+    version: 2 as const,
+    pairingId: 'pairing-1',
+    role: 'provider' as const,
+    credential: 'provider-secret',
+  };
+
+  it('validates and authenticates the signaling socket with the exact credential', () => {
+    expect(isLiquidAuthPairingCredential(pairing)).toBe(true);
+    expect(buildSignalingSocketOptions(pairing)).toEqual({
+      autoConnect: true,
+      withCredentials: true,
+      transports: ['websocket', 'polling'],
+      tryAllTransports: true,
+      auth: pairing,
+    });
+    expect(isLiquidAuthPairingCredential({ ...pairing, role: 'controller' })).toBe(false);
+  });
+
+  it('creates an invitation with an optional legacy request id', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      statusText: 'Created',
+      json: async () => pairing,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      createPairingInvitation('https://liquid.example/', 'legacy-request-id'),
+    ).resolves.toEqual(pairing);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://liquid.example/pairings/invitations',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ requestId: 'legacy-request-id' }),
+      }),
+    );
+  });
+
+  it('rejects invalid invitation responses', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 201,
+        statusText: 'Created',
+        json: async () => ({ pairingId: 'missing-credential' }),
+      }),
+    );
+
+    await expect(createPairingInvitation('https://liquid.example')).rejects.toThrow(
+      'invalid provider credential',
+    );
+  });
+
+  it('revokes with the provider bearer credential', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      statusText: 'No Content',
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await revokePairing('https://liquid.example/', pairing);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://liquid.example/pairings/pairing-1',
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: {
+          authorization: 'Bearer provider-secret',
+          'x-pairing-role': 'provider',
+        },
+      }),
+    );
+  });
+
+  it.each([404, 410])('treats a %i revocation response as already removed', async (status) => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status,
+        statusText: status === 404 ? 'Not Found' : 'Gone',
+      }),
+    );
+
+    await expect(revokePairing('https://liquid.example/', pairing)).resolves.toBeUndefined();
+  });
+
+  it('does not hide an unauthenticated revocation response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+      }),
+    );
+
+    await expect(revokePairing('https://liquid.example/', pairing)).rejects.toThrow(
+      '401 Unauthorized',
+    );
+  });
+});
 
 function makeBaseTransport(): Ac2Transport & { emitBaseClose: () => void; closes: () => number } {
   let closeHandler: (() => void) | undefined;
@@ -30,19 +210,51 @@ function makeBaseTransport(): Ac2Transport & { emitBaseClose: () => void; closes
 }
 
 describe('LiquidAuthChannelProvider heartbeat timeout', () => {
-  it('defaults to the standard heartbeat timeout', () => {
-    expect(resolveHeartbeatTimeoutMs()).toBe(50_000);
-    expect(resolveHeartbeatTimeoutMs('')).toBe(50_000);
+  it('is disabled by default so mobile background suspension is not treated as death', () => {
+    expect(resolveHeartbeatTimeoutMs()).toBeUndefined();
+    expect(resolveHeartbeatTimeoutMs('')).toBeUndefined();
   });
 
   it('accepts timeout overrides at or above two heartbeat intervals', () => {
     expect(resolveHeartbeatTimeoutMs('40000')).toBe(40_000);
+    expect(resolveHeartbeatTimeoutMs(40_000)).toBe(40_000);
     expect(resolveHeartbeatTimeoutMs('900000')).toBe(900_000);
   });
 
-  it('falls back for invalid or too-small overrides', () => {
-    expect(resolveHeartbeatTimeoutMs('not-a-number')).toBe(50_000);
-    expect(resolveHeartbeatTimeoutMs('39999')).toBe(50_000);
+  it('disables invalid or too-small overrides', () => {
+    expect(resolveHeartbeatTimeoutMs('not-a-number')).toBeUndefined();
+    expect(resolveHeartbeatTimeoutMs('39999')).toBeUndefined();
+    expect(resolveHeartbeatTimeoutMs(39_999)).toBeUndefined();
+  });
+
+  it('wires ping responses immediately when a heartbeat channel is discovered', () => {
+    const onInbound = vi.fn();
+    const channel = {
+      readyState: 'open',
+      onmessage: null as ((event: { data: unknown }) => void) | null,
+      send: vi.fn(),
+    };
+
+    attachHeartbeatResponder(channel, onInbound);
+    channel.onmessage?.({ data: 'ping' });
+
+    expect(onInbound).toHaveBeenCalledOnce();
+    expect(channel.send).toHaveBeenCalledWith('pong');
+  });
+
+  it('records other heartbeat traffic without echoing it', () => {
+    const onInbound = vi.fn();
+    const channel = {
+      readyState: 'open',
+      onmessage: null as ((event: { data: unknown }) => void) | null,
+      send: vi.fn(),
+    };
+
+    attachHeartbeatResponder(channel, onInbound);
+    channel.onmessage?.({ data: 'pong' });
+
+    expect(onInbound).toHaveBeenCalledOnce();
+    expect(channel.send).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/ac2-open-claw-reference/tests/state.test.ts
+++ b/packages/ac2-open-claw-reference/tests/state.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -11,9 +11,13 @@ import {
   loadAc2State,
   recordConversationMessage,
   recordToolActivity,
+  saveAc2State,
+  clearAc2StatePendingRevocation,
+  discardPendingPairing,
   setConnectionIdentity,
   touchConnection,
 } from '../src/identity/state.js';
+import { ensurePersistedPairing } from '../src/identity/pairing.js';
 import { replayConversationHistory, replayConversationList } from '../src/index.js';
 
 /** Minimal transport spy capturing the frames sent to the controller. */
@@ -49,11 +53,102 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.unstubAllGlobals();
   delete process.env['OPENCLAW_STATE_DIR'];
   rmSync(stateDir, { recursive: true, force: true });
 });
 
 describe('multi-connection persistence', () => {
+  it('atomically persists a mode-0600 durable pairing credential', () => {
+    const pairing = {
+      version: 2 as const,
+      pairingId: 'pairing-1',
+      role: 'provider' as const,
+      credential: 'secret',
+    };
+    saveAc2State({ pairing });
+
+    expect(loadAc2State().pairing).toEqual(pairing);
+    expect(statSync(join(stateDir, 'ac2-state.json')).mode & 0o777).toBe(0o600);
+  });
+
+  it('retains only a revocation tombstone when local pairing is forgotten offline', () => {
+    const pairing = {
+      version: 2 as const,
+      pairingId: 'pairing-1',
+      role: 'provider' as const,
+      credential: 'secret',
+    };
+    saveAc2State({ pairing, requestId: pairing.pairingId });
+    clearAc2StatePendingRevocation(pairing);
+
+    const state = loadAc2State();
+    expect(state.pairing).toBeUndefined();
+    expect(state.requestId).toBeUndefined();
+    expect(state.pendingRevocation?.pairing).toEqual(pairing);
+  });
+
+  it('deduplicates concurrent invitation creation and persists before returning', async () => {
+    const pairing = {
+      version: 2 as const,
+      pairingId: 'pairing-shared',
+      role: 'provider' as const,
+      credential: 'secret-shared',
+    };
+    const fetchMock = vi.fn(async () => {
+      await new Promise<void>((resolve) => setTimeout(resolve, 10));
+      return {
+        ok: true,
+        status: 201,
+        statusText: 'Created',
+        json: async () => pairing,
+      };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const results = await Promise.all([
+      ensurePersistedPairing('https://liquid.example'),
+      ensurePersistedPairing('https://liquid.example'),
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(results.map((result) => result.created).sort()).toEqual([false, true]);
+    expect(results[0]?.pairing).toEqual(pairing);
+    expect(results[1]?.pairing).toEqual(pairing);
+    expect(loadAc2State().pairing).toEqual(pairing);
+  });
+
+  it('refuses to replace malformed existing state with a new invitation', async () => {
+    writeFileSync(join(stateDir, 'ac2-state.json'), '{"pairing":', 'utf-8');
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    expect(() => loadAc2State()).toThrowError(
+      expect.objectContaining({ code: 'AC2_STATE_INVALID' }),
+    );
+    await expect(
+      ensurePersistedPairing('https://liquid.example'),
+    ).rejects.toMatchObject({ code: 'AC2_STATE_INVALID' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('discards only an unapproved invitation and preserves connection history', () => {
+    const pairing = {
+      version: 2 as const,
+      pairingId: 'pairing-pending',
+      role: 'provider' as const,
+      credential: 'secret-pending',
+    };
+    saveAc2State({ pairing, requestId: pairing.pairingId });
+    touchConnection('older-established-pairing');
+
+    discardPendingPairing(pairing.pairingId);
+
+    const state = loadAc2State();
+    expect(state.pairing).toBeUndefined();
+    expect(state.connections?.['older-established-pairing']).toBeDefined();
+  });
+
   it('touchConnection creates a connection and marks it active', () => {
     const conn = touchConnection('req-1');
     expect(conn.requestId).toBe('req-1');

--- a/packages/ac2-open-claw-reference/tests/supervisor.test.ts
+++ b/packages/ac2-open-claw-reference/tests/supervisor.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  Ac2ConnectionSupervisor,
+  buildChannelObject,
+  isPairingAuthorizationError,
+  reconnectDelayMs,
+} from '../src/index.js';
+
+describe('AC2 gateway supervisor', () => {
+  it('uses bounded exponential backoff with jitter', () => {
+    expect(reconnectDelayMs(1, () => 0)).toBe(800);
+    expect(reconnectDelayMs(2, () => 0.5)).toBe(2_000);
+    expect(reconnectDelayMs(100, () => 1)).toBe(30_000);
+  });
+
+  it('rotates only explicit unauthorized invitations, never revoked pairings', () => {
+    expect(isPairingAuthorizationError({ data: { code: 'PAIRING_UNAUTHORIZED' } })).toBe(true);
+    expect(isPairingAuthorizationError({ code: 'PAIRING_REVOKED' })).toBe(false);
+    expect(isPairingAuthorizationError({ code: 'SIGNAL_SERVER_ERROR' })).toBe(false);
+    expect(
+      isPairingAuthorizationError({
+        status: 'error',
+        message: 'Internal server error',
+        cause: { pattern: 'link' },
+      }),
+    ).toBe(false);
+    expect(isPairingAuthorizationError(new Error('xhr poll error'))).toBe(false);
+  });
+
+  it('stops without starting network work when the gateway is already aborted', async () => {
+    const abort = new AbortController();
+    abort.abort();
+    const supervisor = new Ac2ConnectionSupervisor();
+
+    await supervisor.start({
+      api: {} as never,
+      config: {},
+      signal: abort.signal,
+    });
+
+    expect(supervisor.getStatus()).toEqual({ state: 'stopped', reconnectAttempts: 0 });
+  });
+
+  it('exposes a stable gateway account while no controller is online', () => {
+    const channel = buildChannelObject() as any;
+
+    expect(channel.config.listAccountIds({})).toEqual(['default']);
+    expect(channel.config.resolveAccount({}, undefined).accountId).toBe('default');
+    expect(typeof channel.gateway.startAccount).toBe('function');
+    expect(typeof channel.gateway.stopAccount).toBe('function');
+  });
+});

--- a/packages/ac2-sdk/EXTENDING.md
+++ b/packages/ac2-sdk/EXTENDING.md
@@ -67,16 +67,24 @@ client.updateHandlers({
 ```ts
 interface Ac2Transport {
   send(text: string): void;
-  onMessage(handler: (msg: AC2BaseMessage) => void): () => void;
-  onRawMessage?(handler: (raw: string) => void): () => void;
-  onBinaryMessage?(handler: (data: ArrayBuffer) => void): () => void; // attachments (SPEC §3)
-  onOpen(handler: () => void): void;
-  onClose(handler: () => void): void;
-  onError(handler: (err: Error) => void): void;
+  onMessage(handler: (msg: AC2BaseMessage) => void): void | (() => void);
+  onRawMessage?(handler: (raw: string) => void): void | (() => void);
+  onBinaryMessage?(handler: (data: ArrayBuffer) => void): void | (() => void); // attachments (SPEC §3)
+  onOpen(handler: () => void): void | (() => void);
+  onClose(handler: () => void): void | (() => void);
+  onError(handler: (err: Error) => void): void | (() => void);
   readonly isOpen: boolean;
   close(): void;
 }
 ```
+
+Listener methods should return an idempotent unsubscribe function. The `void`
+alternative preserves compatibility with transports built against older SDK
+versions, but it prevents consumers from releasing individual listeners. Both
+built-in transports return unsubscribe functions, and `Ac2Client.close()` uses
+them automatically. Their return type is the stronger
+`Ac2DisposableTransport` interface, so callers do not need to narrow the
+registration result before invoking it.
 
 Two concrete adapters ship with the SDK:
 

--- a/packages/ac2-sdk/src/client.ts
+++ b/packages/ac2-sdk/src/client.ts
@@ -43,7 +43,7 @@ import {
   generateMessageId,
 } from './protocol/messages.js';
 import { defaultMessageHandlers, type MessageHandlerMap } from './protocol/handlers.js';
-import type { Ac2Transport } from './transport/index.js';
+import type { Ac2Subscription, Ac2Transport, Ac2Unsubscribe } from './transport/index.js';
 
 /**
  * Options accepted by `Ac2Client`. Handlers are a type-keyed map indexed
@@ -88,6 +88,7 @@ export class Ac2Client {
   private onUnknown?: (msg: AC2BaseMessage) => void;
   private onError?: (err: Error) => void;
   private readonly pending = new Map<string, Pending>();
+  private readonly transportUnsubscribes: Ac2Unsubscribe[] = [];
   private closed = false;
 
   constructor(transport: Ac2Transport, options: Ac2ClientOptions = {}) {
@@ -96,16 +97,9 @@ export class Ac2Client {
     if (options.onUnknown !== undefined) this.onUnknown = options.onUnknown;
     if (options.onError !== undefined) this.onError = options.onError;
 
-    transport.onMessage((msg) => this.dispatch(msg));
-    transport.onError((err) => this.onError?.(err));
-    transport.onClose(() => {
-      this.closed = true;
-      for (const [, p] of this.pending) {
-        if (p.timer) clearTimeout(p.timer);
-        p.reject(new Error('[ac2-sdk] Transport closed'));
-      }
-      this.pending.clear();
-    });
+    this.trackTransportSubscription(transport.onMessage((msg) => this.dispatch(msg)));
+    this.trackTransportSubscription(transport.onError((err) => this.onError?.(err)));
+    this.trackTransportSubscription(transport.onClose(() => this.finishClose()));
   }
 
   /**
@@ -277,7 +271,13 @@ export class Ac2Client {
   close(): void {
     if (this.closed) return;
     this.closed = true;
-    this.transport.close();
+    try {
+      this.transport.close();
+    } finally {
+      // A custom transport is not required to emit onClose synchronously (or
+      // at all), so make local cleanup independent of that notification.
+      this.finishClose();
+    }
   }
 
   /**
@@ -341,6 +341,36 @@ export class Ac2Client {
 
   private reportError(err: unknown): void {
     this.onError?.(err instanceof Error ? err : new Error(String(err)));
+  }
+
+  private trackTransportSubscription(subscription: Ac2Subscription): void {
+    if (typeof subscription !== 'function') return;
+    // A transport that was already closed may notify onClose synchronously
+    // during registration. Do not retain the disposer in that case.
+    if (this.closed) {
+      subscription();
+      return;
+    }
+    this.transportUnsubscribes.push(subscription);
+  }
+
+  private finishClose(): void {
+    this.closed = true;
+    for (const [, pending] of this.pending) {
+      if (pending.timer) clearTimeout(pending.timer);
+      pending.reject(new Error('[ac2-sdk] Transport closed'));
+    }
+    this.pending.clear();
+
+    const unsubscribes = this.transportUnsubscribes.splice(0);
+    for (const unsubscribe of unsubscribes) {
+      try {
+        unsubscribe();
+      } catch {
+        // Cleanup is best-effort. One third-party disposer must not prevent
+        // the remaining transport listeners from being released.
+      }
+    }
   }
 
   private dispatch(msg: AC2BaseMessage): void {

--- a/packages/ac2-sdk/src/transport/index.ts
+++ b/packages/ac2-sdk/src/transport/index.ts
@@ -28,6 +28,17 @@ export type Ac2ErrorHandler = (err: Error) => void;
 /** Lifecycle event handler. */
 export type Ac2EventHandler = () => void;
 
+/** Remove a previously registered transport listener. Safe to call more than once. */
+export type Ac2Unsubscribe = () => void;
+
+/**
+ * Listener registration result.
+ *
+ * New transports SHOULD return an unsubscribe function. `void` remains allowed
+ * so transports written against older SDK releases remain source-compatible.
+ */
+export type Ac2Subscription = Ac2Unsubscribe | void;
+
 /** Callback for raw (non-AC2 JSON) messages. Used for chat. */
 export type RawMessageHandler = (payload: string) => void;
 
@@ -52,24 +63,37 @@ export interface Ac2Transport {
   /** Send a single, already-serialized AC2 message. */
   send(payload: string): void;
   /** Register a handler for inbound, parsed AC2 messages. */
-  onMessage(handler: Ac2MessageHandler): void;
-  /** Register a optional handler for inbound raw (non-AC2) messages. */
-  onRawMessage?(handler: RawMessageHandler): void;
+  onMessage(handler: Ac2MessageHandler): Ac2Subscription;
+  /** Register an optional handler for inbound raw (non-AC2) messages. */
+  onRawMessage?(handler: RawMessageHandler): Ac2Subscription;
   /**
    * Register an optional handler for inbound binary DataChannel frames.
    * If unregistered, binary frames are silently dropped (per spec).
    */
-  onBinaryMessage?(handler: BinaryMessageHandler): void;
+  onBinaryMessage?(handler: BinaryMessageHandler): Ac2Subscription;
   /** Register a handler for parse / transport errors. */
-  onError(handler: Ac2ErrorHandler): void;
+  onError(handler: Ac2ErrorHandler): Ac2Subscription;
   /** Register a handler for when the transport becomes ready. */
-  onOpen(handler: Ac2EventHandler): void;
+  onOpen(handler: Ac2EventHandler): Ac2Subscription;
   /** Register a handler for when the transport closes. */
-  onClose(handler: Ac2EventHandler): void;
+  onClose(handler: Ac2EventHandler): Ac2Subscription;
   /** Close the transport. */
   close(): void;
   /** True once the transport is ready to send. */
   readonly isOpen: boolean;
+}
+
+/**
+ * An AC2 transport whose listener registrations are all individually
+ * disposable. The SDK's built-in transports implement this stronger contract.
+ */
+export interface Ac2DisposableTransport extends Ac2Transport {
+  onMessage(handler: Ac2MessageHandler): Ac2Unsubscribe;
+  onRawMessage(handler: RawMessageHandler): Ac2Unsubscribe;
+  onBinaryMessage(handler: BinaryMessageHandler): Ac2Unsubscribe;
+  onError(handler: Ac2ErrorHandler): Ac2Unsubscribe;
+  onOpen(handler: Ac2EventHandler): Ac2Unsubscribe;
+  onClose(handler: Ac2EventHandler): Ac2Unsubscribe;
 }
 
 // ---------------------------------------------------------------------------
@@ -91,6 +115,16 @@ export interface RtcDataChannelLike {
   onmessage: ((ev: { data: unknown }) => void) | null;
 }
 
+function subscribe<T>(handlers: Set<T>, handler: T): Ac2Unsubscribe {
+  handlers.add(handler);
+  let active = true;
+  return () => {
+    if (!active) return;
+    active = false;
+    handlers.delete(handler);
+  };
+}
+
 /**
  * Wrap an existing `RTCDataChannel` (or compatible object) as an
  * `Ac2Transport`. The caller is responsible for creating the DataChannel
@@ -100,7 +134,7 @@ export interface RtcDataChannelLike {
  *
  * The wrapper enforces that the label matches `ac2-v1` and throws otherwise.
  */
-export function rtcDataChannelTransport(channel: RtcDataChannelLike): Ac2Transport {
+export function rtcDataChannelTransport(channel: RtcDataChannelLike): Ac2DisposableTransport {
   if (channel.label !== AC2_DATACHANNEL_LABEL) {
     throw new Error(
       `[ac2-sdk] DataChannel label MUST be "${AC2_DATACHANNEL_LABEL}" ` +
@@ -108,18 +142,22 @@ export function rtcDataChannelTransport(channel: RtcDataChannelLike): Ac2Transpo
     );
   }
 
-  let messageHandler: Ac2MessageHandler | null = null;
-  let rawMessageHandler: RawMessageHandler | null = null;
-  let binaryMessageHandler: BinaryMessageHandler | null = null;
-  let errorHandler: Ac2ErrorHandler | null = null;
-  let openHandler: Ac2EventHandler | null = null;
-  let closeHandler: Ac2EventHandler | null = null;
+  const messageHandlers = new Set<Ac2MessageHandler>();
+  const rawMessageHandlers = new Set<RawMessageHandler>();
+  const binaryMessageHandlers = new Set<BinaryMessageHandler>();
+  const errorHandlers = new Set<Ac2ErrorHandler>();
+  const openHandlers = new Set<Ac2EventHandler>();
+  const closeHandlers = new Set<Ac2EventHandler>();
 
-  channel.onopen = () => openHandler?.();
-  channel.onclose = () => closeHandler?.();
+  channel.onopen = () => {
+    for (const handler of [...openHandlers]) handler();
+  };
+  channel.onclose = () => {
+    for (const handler of [...closeHandlers]) handler();
+  };
   channel.onerror = (ev) => {
     const err = ev instanceof Error ? ev : new Error(`[ac2-sdk] DataChannel error: ${String(ev)}`);
-    errorHandler?.(err);
+    for (const handler of [...errorHandlers]) handler(err);
   };
   channel.onmessage = (ev) => {
     // Binary frames: route to the optional binary hook. Per SPEC.md →
@@ -127,15 +165,16 @@ export function rtcDataChannelTransport(channel: RtcDataChannelLike): Ac2Transpo
     // DataChannel messages — so this is NOT an error condition. If no
     // binary handler is registered, drop the frame silently.
     if (typeof ev.data !== 'string') {
-      if (!binaryMessageHandler) return;
       const data = ev.data;
       if (data instanceof ArrayBuffer) {
-        binaryMessageHandler(data);
+        for (const handler of [...binaryMessageHandlers]) handler(data);
       } else if (ArrayBuffer.isView(data)) {
         const view = data as ArrayBufferView;
-        binaryMessageHandler(
-          view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength) as ArrayBuffer,
-        );
+        const bytes = view.buffer.slice(
+          view.byteOffset,
+          view.byteOffset + view.byteLength,
+        ) as ArrayBuffer;
+        for (const handler of [...binaryMessageHandlers]) handler(bytes);
       }
       // Other shapes (e.g. Blob) are intentionally unhandled; consumers
       // that need Blob support should set `channel.binaryType = 'arraybuffer'`.
@@ -149,16 +188,16 @@ export function rtcDataChannelTransport(channel: RtcDataChannelLike): Ac2Transpo
       parsed = JSON.parse(raw);
     } catch (e) {
       // Not JSON; treat as raw chat
-      rawMessageHandler?.(raw);
+      for (const handler of [...rawMessageHandlers]) handler(raw);
       return;
     }
 
     if (!isAc2Message(parsed)) {
       // JSON but not AC2; treat as raw
-      rawMessageHandler?.(raw);
+      for (const handler of [...rawMessageHandlers]) handler(raw);
       return;
     }
-    messageHandler?.(parsed);
+    for (const handler of [...messageHandlers]) handler(parsed);
   };
 
   return {
@@ -169,23 +208,26 @@ export function rtcDataChannelTransport(channel: RtcDataChannelLike): Ac2Transpo
       channel.send(payload);
     },
     onMessage(h) {
-      messageHandler = h;
+      return subscribe(messageHandlers, h);
     },
     onRawMessage(h) {
-      rawMessageHandler = h;
+      return subscribe(rawMessageHandlers, h);
     },
     onBinaryMessage(h) {
-      binaryMessageHandler = h;
+      return subscribe(binaryMessageHandlers, h);
     },
     onError(h) {
-      errorHandler = h;
+      return subscribe(errorHandlers, h);
     },
     onOpen(h) {
-      openHandler = h;
+      const unsubscribe = subscribe(openHandlers, h);
       if (channel.readyState === 'open') h();
+      return unsubscribe;
     },
     onClose(h) {
-      closeHandler = h;
+      const unsubscribe = subscribe(closeHandlers, h);
+      if (channel.readyState === 'closed') h();
+      return unsubscribe;
     },
     close() {
       channel.close();
@@ -205,7 +247,7 @@ export function rtcDataChannelTransport(channel: RtcDataChannelLike): Ac2Transpo
  * surfaces on `b.onMessage` (and vice versa). Useful for unit tests of the
  * `Ac2Client` and for plumbing higher-level flows without a real DataChannel.
  */
-export function createInMemoryTransportPair(): [Ac2Transport, Ac2Transport] {
+export function createInMemoryTransportPair(): [Ac2DisposableTransport, Ac2DisposableTransport] {
   const a = makeMemTransport();
   const b = makeMemTransport();
   a._link(b);
@@ -218,19 +260,21 @@ export function createInMemoryTransportPair(): [Ac2Transport, Ac2Transport] {
   return [a, b];
 }
 
-interface MemTransport extends Ac2Transport {
+interface MemTransport extends Ac2DisposableTransport {
   _link(peer: MemTransport): void;
   _open(): void;
-  _deliver(payload: string): void;
+  _deliver(payload: string | ArrayBuffer | ArrayBufferView): void;
+  _error(error: Error): void;
 }
 
 function makeMemTransport(): MemTransport {
   let peer: MemTransport | null = null;
-  let messageHandler: Ac2MessageHandler | null = null;
-  let rawMessageHandler: RawMessageHandler | null = null;
-  let errorHandler: Ac2ErrorHandler | null = null;
-  let openHandler: Ac2EventHandler | null = null;
-  let closeHandler: Ac2EventHandler | null = null;
+  const messageHandlers = new Set<Ac2MessageHandler>();
+  const rawMessageHandlers = new Set<RawMessageHandler>();
+  const binaryMessageHandlers = new Set<BinaryMessageHandler>();
+  const errorHandlers = new Set<Ac2ErrorHandler>();
+  const openHandlers = new Set<Ac2EventHandler>();
+  const closeHandlers = new Set<Ac2EventHandler>();
   let open = false;
   let closed = false;
 
@@ -240,29 +284,41 @@ function makeMemTransport(): MemTransport {
       if (!open || !peer) throw new Error('[ac2-sdk] Transport not open');
       // Deliver asynchronously to mimic real channel semantics.
       const target = peer;
-      queueMicrotask(() => target._deliver(payload));
+      queueMicrotask(() => {
+        try {
+          target._deliver(payload);
+        } catch (error) {
+          target._error(error instanceof Error ? error : new Error(String(error)));
+        }
+      });
     },
     onMessage(h) {
-      messageHandler = h;
+      return subscribe(messageHandlers, h);
     },
     onRawMessage(h) {
-      rawMessageHandler = h;
+      return subscribe(rawMessageHandlers, h);
+    },
+    onBinaryMessage(h) {
+      return subscribe(binaryMessageHandlers, h);
     },
     onError(h) {
-      errorHandler = h;
+      return subscribe(errorHandlers, h);
     },
     onOpen(h) {
-      openHandler = h;
+      const unsubscribe = subscribe(openHandlers, h);
       if (open) h();
+      return unsubscribe;
     },
     onClose(h) {
-      closeHandler = h;
+      const unsubscribe = subscribe(closeHandlers, h);
+      if (closed) h();
+      return unsubscribe;
     },
     close() {
       if (closed) return;
       closed = true;
       open = false;
-      closeHandler?.();
+      for (const handler of [...closeHandlers]) handler();
       const p = peer;
       peer = null;
       if (p && !(p as unknown as { _isClosed?: boolean })._isClosed) {
@@ -278,9 +334,22 @@ function makeMemTransport(): MemTransport {
     _open() {
       if (closed || open) return;
       open = true;
-      openHandler?.();
+      for (const handler of [...openHandlers]) handler();
+    },
+    _error(error) {
+      for (const handler of [...errorHandlers]) handler(error);
     },
     _deliver(payload) {
+      if (typeof payload !== 'string') {
+        const bytes = payload instanceof ArrayBuffer
+          ? payload
+          : payload.buffer.slice(
+              payload.byteOffset,
+              payload.byteOffset + payload.byteLength,
+            ) as ArrayBuffer;
+        for (const handler of [...binaryMessageHandlers]) handler(bytes);
+        return;
+      }
       if (payload.trim().length === 0) return; // Ignore heartbeats
 
       let parsed: unknown;
@@ -288,15 +357,15 @@ function makeMemTransport(): MemTransport {
         parsed = JSON.parse(payload);
       } catch (e) {
         // Not JSON; treat as raw chat
-        rawMessageHandler?.(payload);
+        for (const handler of [...rawMessageHandlers]) handler(payload);
         return;
       }
       if (!isAc2Message(parsed)) {
         // JSON but not AC2; treat as raw
-        rawMessageHandler?.(payload);
+        for (const handler of [...rawMessageHandlers]) handler(payload);
         return;
       }
-      messageHandler?.(parsed);
+      for (const handler of [...messageHandlers]) handler(parsed);
     },
   };
   return t;

--- a/packages/ac2-sdk/tests/client.test.ts
+++ b/packages/ac2-sdk/tests/client.test.ts
@@ -1,10 +1,53 @@
 /// <reference types="vitest/globals" />
 
 import { Ac2Client } from '../src/client';
-import { createInMemoryTransportPair } from '../src/transport';
+import { createInMemoryTransportPair, type Ac2Transport } from '../src/transport';
 import { createSigningResponse, createSigningRejected, createKeyResponse } from '../src/protocol';
 
 const NOW = Math.floor(Date.now() / 1000);
+
+describe('Ac2Client transport listener lifecycle', () => {
+  it('unsubscribes its listeners on close even when a custom transport does not emit close', () => {
+    const unsubscribeMessage = vi.fn(() => {
+      throw new Error('broken custom disposer');
+    });
+    const unsubscribeError = vi.fn();
+    const unsubscribeClose = vi.fn();
+    const close = vi.fn();
+    const transport: Ac2Transport = {
+      send: vi.fn(),
+      onMessage: () => unsubscribeMessage,
+      onError: () => unsubscribeError,
+      onOpen: () => undefined,
+      onClose: () => unsubscribeClose,
+      close,
+      isOpen: true,
+    };
+    const client = new Ac2Client(transport);
+
+    expect(() => client.close()).not.toThrow();
+    client.close();
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(unsubscribeMessage).toHaveBeenCalledTimes(1);
+    expect(unsubscribeError).toHaveBeenCalledTimes(1);
+    expect(unsubscribeClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts legacy transports whose listener registrations return void', () => {
+    const transport: Ac2Transport = {
+      send: vi.fn(),
+      onMessage(): void {},
+      onError(): void {},
+      onOpen(): void {},
+      onClose(): void {},
+      close: vi.fn(),
+      isOpen: true,
+    };
+
+    expect(() => new Ac2Client(transport).close()).not.toThrow();
+  });
+});
 
 describe('Ac2Client request/response primitive', () => {
   it('requestSignature resolves with a SigningResponse paired by thid', async () => {

--- a/packages/ac2-sdk/tests/transport.test.ts
+++ b/packages/ac2-sdk/tests/transport.test.ts
@@ -1,0 +1,204 @@
+/// <reference types="vitest/globals" />
+
+import { createSigningRequest } from '../src/protocol';
+import {
+  createInMemoryTransportPair,
+  rtcDataChannelTransport,
+  type RtcDataChannelLike,
+} from '../src/transport';
+
+class TestDataChannel implements RtcDataChannelLike {
+  readonly label = 'ac2-v1';
+  readyState: RtcDataChannelLike['readyState'] = 'connecting';
+  onopen: ((ev: unknown) => void) | null = null;
+  onclose: ((ev: unknown) => void) | null = null;
+  onerror: ((ev: unknown) => void) | null = null;
+  onmessage: ((ev: { data: unknown }) => void) | null = null;
+  send(): void {}
+  close(): void {
+    this.readyState = 'closed';
+    this.onclose?.({});
+  }
+}
+
+const message = createSigningRequest(
+  {
+    id: 'request-1',
+    from: 'did:key:agent',
+    to: ['did:key:controller'],
+    created_time: 1,
+  },
+  { description: 'test', encoding: 'base64', payload: 'dGVzdA==' },
+);
+
+describe('rtcDataChannelTransport subscribers', () => {
+  it('fans out every inbound and lifecycle event', () => {
+    const channel = new TestDataChannel();
+    const transport = rtcDataChannelTransport(channel);
+    const seen: string[] = [];
+
+    transport.onMessage(() => seen.push('message-1'));
+    transport.onMessage(() => seen.push('message-2'));
+    transport.onRawMessage?.(() => seen.push('raw-1'));
+    transport.onRawMessage?.(() => seen.push('raw-2'));
+    transport.onBinaryMessage?.(() => seen.push('binary-1'));
+    transport.onBinaryMessage?.(() => seen.push('binary-2'));
+    transport.onError(() => seen.push('error-1'));
+    transport.onError(() => seen.push('error-2'));
+    transport.onOpen(() => seen.push('open-1'));
+    transport.onOpen(() => seen.push('open-2'));
+    transport.onClose(() => seen.push('close-1'));
+    transport.onClose(() => seen.push('close-2'));
+
+    channel.onmessage?.({ data: JSON.stringify(message) });
+    channel.onmessage?.({ data: 'chat' });
+    channel.onmessage?.({ data: new Uint8Array([1, 2, 3]) });
+    channel.onerror?.(new Error('boom'));
+    channel.readyState = 'open';
+    channel.onopen?.({});
+    channel.close();
+
+    expect(seen).toEqual([
+      'message-1',
+      'message-2',
+      'raw-1',
+      'raw-2',
+      'binary-1',
+      'binary-2',
+      'error-1',
+      'error-2',
+      'open-1',
+      'open-2',
+      'close-1',
+      'close-2',
+    ]);
+  });
+
+  it('immediately notifies late open and close subscribers', () => {
+    const channel = new TestDataChannel();
+    channel.readyState = 'open';
+    const transport = rtcDataChannelTransport(channel);
+    let opened = 0;
+    let closed = 0;
+
+    transport.onOpen(() => opened++);
+    channel.close();
+    transport.onClose(() => closed++);
+
+    expect(opened).toBe(1);
+    expect(closed).toBe(1);
+  });
+
+  it('returns idempotent disposers that stop every event category', () => {
+    const channel = new TestDataChannel();
+    const transport = rtcDataChannelTransport(channel);
+    const seen: string[] = [];
+    const subscriptions = [
+      transport.onMessage(() => seen.push('message')),
+      transport.onRawMessage(() => seen.push('raw')),
+      transport.onBinaryMessage(() => seen.push('binary')),
+      transport.onError(() => seen.push('error')),
+      transport.onOpen(() => seen.push('open')),
+      transport.onClose(() => seen.push('close')),
+    ];
+
+    for (const subscription of subscriptions) {
+      expect(subscription).toBeTypeOf('function');
+      subscription();
+      subscription();
+    }
+
+    channel.onmessage?.({ data: JSON.stringify(message) });
+    channel.onmessage?.({ data: 'chat' });
+    channel.onmessage?.({ data: new Uint8Array([1, 2, 3]) });
+    channel.onerror?.(new Error('boom'));
+    channel.readyState = 'open';
+    channel.onopen?.({});
+    channel.close();
+
+    expect(seen).toEqual([]);
+  });
+});
+
+describe('in-memory transport subscribers', () => {
+  it('fans out message, raw, binary, error, open, and close events', async () => {
+    const [sender, receiver] = createInMemoryTransportPair();
+    const seen: string[] = [];
+
+    receiver.onMessage(() => seen.push('message-1'));
+    receiver.onMessage(() => seen.push('message-2'));
+    receiver.onRawMessage?.(() => seen.push('raw-1'));
+    receiver.onRawMessage?.(() => seen.push('raw-2'));
+    receiver.onBinaryMessage?.(() => seen.push('binary-1'));
+    receiver.onBinaryMessage?.(() => seen.push('binary-2'));
+    receiver.onError(() => seen.push('error-1'));
+    receiver.onError(() => seen.push('error-2'));
+    receiver.onOpen(() => seen.push('open-1'));
+    receiver.onOpen(() => seen.push('open-2'));
+    receiver.onClose(() => seen.push('close-1'));
+    receiver.onClose(() => seen.push('close-2'));
+
+    sender.send(JSON.stringify(message));
+    sender.send('chat');
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+
+    const internals = receiver as unknown as {
+      _deliver(payload: ArrayBuffer): void;
+      _error(error: Error): void;
+    };
+    internals._deliver(new Uint8Array([1, 2, 3]).buffer);
+    internals._error(new Error('boom'));
+    receiver.close();
+
+    expect(seen).toEqual([
+      'open-1',
+      'open-2',
+      'message-1',
+      'message-2',
+      'raw-1',
+      'raw-2',
+      'binary-1',
+      'binary-2',
+      'error-1',
+      'error-2',
+      'close-1',
+      'close-2',
+    ]);
+  });
+
+  it('returns idempotent disposers that stop delivery', async () => {
+    const [sender, receiver] = createInMemoryTransportPair();
+    const seen: string[] = [];
+    const subscriptions = [
+      receiver.onMessage(() => seen.push('message')),
+      receiver.onRawMessage(() => seen.push('raw')),
+      receiver.onBinaryMessage(() => seen.push('binary')),
+      receiver.onError(() => seen.push('error')),
+      receiver.onOpen(() => seen.push('open')),
+      receiver.onClose(() => seen.push('close')),
+    ];
+
+    // onOpen fires immediately for the already-open in-memory transport.
+    expect(seen).toEqual(['open']);
+    seen.length = 0;
+    for (const subscription of subscriptions) {
+      expect(subscription).toBeTypeOf('function');
+      subscription();
+      subscription();
+    }
+
+    sender.send(JSON.stringify(message));
+    sender.send('chat');
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+
+    const internals = receiver as unknown as {
+      _deliver(payload: ArrayBuffer): void;
+      _error(error: Error): void;
+    };
+    internals._deliver(new Uint8Array([1, 2, 3]).buffer);
+    internals._error(new Error('boom'));
+    receiver.close();
+
+    expect(seen).toEqual([]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
   packages/ac2-open-claw-reference:
     dependencies:
       '@algorandfoundation/ac2-sdk':
-        specifier: 1.0.0-canary.1
-        version: 1.0.0-canary.1
+        specifier: workspace:^
+        version: link:../ac2-sdk
       '@algorandfoundation/algokit-utils':
         specifier: 10.0.0-beta.4
         version: 10.0.0-beta.4
@@ -84,8 +84,8 @@ importers:
         specifier: 1.0.0-canary.16
         version: 1.0.0-canary.16(@tanstack/store@0.9.3)(before-after-hook@4.0.0)
       '@algorandfoundation/liquid-client':
-        specifier: 1.0.0-canary.8
-        version: 1.0.0-canary.8(socket.io-client@4.8.3)
+        specifier: ^1.0.0-canary.9
+        version: 1.0.0-canary.9(socket.io-client@4.8.3)
       '@napi-rs/keyring':
         specifier: ^1.3.0
         version: 1.3.0
@@ -177,9 +177,6 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  '@algorandfoundation/ac2-sdk@1.0.0-canary.1':
-    resolution: {integrity: sha512-OYP/TpCWTLpcjWtG9+RLxMhCKFb7mQwmF2KgI/Kv/7F5vILZoSoE8jAnrbkRfjo4zylvhmI7bb4G92AGzlZM1A==}
-
   '@algorandfoundation/algokit-utils@10.0.0-alpha.46':
     resolution: {integrity: sha512-Lx56ET6RmrDCFGwx6qyIr7YRX3Q3MyKgqkNeumLkFHXVkqMnXnK1aLeEbV59EOK8UHQ5UPJofSj1zvRMm9Du7w==}
     engines: {node: '>=20.0'}
@@ -201,8 +198,8 @@ packages:
       '@algorandfoundation/log-store':
         optional: true
 
-  '@algorandfoundation/liquid-client@1.0.0-canary.8':
-    resolution: {integrity: sha512-sGsI5PMFy3DZfxuiUyVlotS+NNVJbTZ+z20c+b0Fsc9NjxVxM6cpbFxNx4G+XtrMuGUxHqjSGJmPNKRdotw6gw==}
+  '@algorandfoundation/liquid-client@1.0.0-canary.9':
+    resolution: {integrity: sha512-ACZq4SPJ0XHkb1mAo21rlopgobTrTeLiEHrJuNUgdcCiPwoz/S2/KsKyhEvlb34J2HZmyudN4oh+KvA0EqllXw==}
     peerDependencies:
       qr-code-styling: ^1.9.2
       socket.io-client: ^4.7.5
@@ -3248,9 +3245,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   validate-npm-package-license@3.0.4:
@@ -3509,10 +3505,6 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@algorandfoundation/ac2-sdk@1.0.0-canary.1':
-    dependencies:
-      ajv: 8.20.0
-
   '@algorandfoundation/algokit-utils@10.0.0-alpha.46':
     dependencies:
       '@algorandfoundation/xhd-wallet-api': 2.0.0-canary.1
@@ -3559,11 +3551,11 @@ snapshots:
       '@tanstack/store': 0.9.3
       before-after-hook: 4.0.0
 
-  '@algorandfoundation/liquid-client@1.0.0-canary.8(socket.io-client@4.8.3)':
+  '@algorandfoundation/liquid-client@1.0.0-canary.9(socket.io-client@4.8.3)':
     dependencies:
       '@algorandfoundation/algokit-utils': 10.0.0-beta.4
       eventemitter3: 5.0.4
-      uuid: 10.0.0
+      uuid: 11.1.1
     optionalDependencies:
       socket.io-client: 4.8.3
 
@@ -6437,7 +6429,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@10.0.0: {}
+  uuid@11.1.1: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:


### PR DESCRIPTION
## Summary

- replace process-local reconnect loops with one gateway-owned durable connection supervisor
- persist and reuse Liquid Auth provider credentials across restarts and arbitrarily long outages
- retry transient signaling and transport failures indefinitely with bounded exponential backoff
- bound invitation and initial signaling work without imposing a timeout on human approval
- accumulate signaling outage time and recycle stale negotiations after a genuine process-suspension gap
- monitor established WebRTC peers for authoritative `failed`/`closed` states while treating transient `disconnected` as recoverable
- make pairing-state revocation and invitation rotation compare-and-mutate operations under the cross-process lock
- preserve upstream canary.20 behavior, wallet address exposure, and persistent-volume plugin refresh changes
- harden AC2 SDK transport subscription and close behavior used by the plugin

## Why

The live Socket.IO/WebRTC session was being treated as if it were the pairing itself. Ping timeouts, server restarts, suspended processes, and half-open peers could therefore wedge reconnects or cause duplicate connection owners. Several cleanup paths could also race or erase a newer pairing written by another process.

## Impact

An explicitly paired OpenClaw agent remains reconnectable until the pairing is deliberately removed. Temporary network failures and long offline periods only replace the transport; they do not require a new QR code or identity bootstrap.

## Validation

- AC2 SDK: 91 tests passed and package build passed
- OpenClaw plugin: 136 tests passed, type-check passed, and package build passed
- full AC2 workspace test and build passed
- OpenClaw server shell scripts passed `bash -n`

## Dependencies and release order

- Depends on algorandfoundation/liquid-auth#65.
- Depends on algorandfoundation/liquid-auth-js#34.
- Publish the AC2 SDK changes before publishing the OpenClaw plugin.
- After the Liquid Client and SDK releases exist, bump the packed plugin dependency floors/lockfile and rerun the packaged integration checks before release.

The PR is intentionally a draft until those package versions are available.
