### PR TITLE
feat: presence detection and identity lockdown

### DIFF
--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -23,6 +23,17 @@ identity key is **issued by the wallet** during pairing (bootstrap
 `KeyRequest`) and persisted in an OS-keychain-protected keystore — the
 agent never touches the user's account keys or passkeys.
 
+**First-controller lock.** The agent registers to the **first** wallet
+(controller) that grants it an identity and stays bound to it. If a
+*different* wallet later connects — e.g. because the mobile app flushed
+its keystore and now presents a brand-new account key — the agent refuses
+the takeover: it will **not** reuse the bound identity or regenerate a
+fresh one for the new wallet. The connection is locked (no messages are
+routed to the agent) and the wallet is shown a `notice` banner explaining
+that the operator must clear the agent's keys — run `openclaw ac2 forget`
+(or delete the agent state under `~/.openclaw`) — before a new wallet can
+register and be issued a fresh identity. `ac2 status` reports the lock.
+
 ## Getting started
 
 ### Prerequisites

--- a/packages/ac2-open-claw-reference/package.json
+++ b/packages/ac2-open-claw-reference/package.json
@@ -77,7 +77,7 @@
     "@types/node": "^22.0.0",
     "@types/qrcode-terminal": "^0.12.2",
     "esbuild": "^0.25.12",
-    "openclaw": "2026.6.1",
+    "openclaw": "2026.7.1-2",
     "typescript": "~5.8.3",
     "vitest": "^3.2.0"
   },

--- a/packages/ac2-open-claw-reference/src/channel/channel-object.ts
+++ b/packages/ac2-open-claw-reference/src/channel/channel-object.ts
@@ -15,14 +15,18 @@ import {
   defineAc2MessageAdapter,
   type MessageReceipt,
 } from './message-adapter.js';
-import { sendDiscard, sendPreview } from './stream.js';
+import { sendDiscard, sendFinalize, sendPreview } from './stream.js';
 import {
+  DEFAULT_THID,
   getActiveConversation,
   resolveAc2OutboundSessionRoute,
   resolveAc2SessionConversation,
   type Ac2OutboundSessionRoute,
   type Ac2SessionConversation,
 } from './conversation.js';
+import { recordConversationMessage } from '../identity/state.js';
+import { findPendingTaskForParent, markTaskResult } from './tasks.js';
+import { emitTaskCardUpdate } from './task-card.js';
 
 /** Media-source param map for the message tool's `describeMessageTool`. */
 export type Ac2MediaSourceParams = Readonly<Record<string, readonly string[]>>;
@@ -45,6 +49,76 @@ function emitHeartbeatPresence(
   const thid = getActiveConversation(active.controllerDid, active.requestId);
   if (kind === 'typing') sendPreview(active.transport, thid, 'typing');
   else sendDiscard(active.transport, thid);
+}
+
+/**
+ * Resolve the wallet `thid` for a host-initiated outbound send. `threadId` is
+ * whatever `messaging.resolveOutboundSessionRoute` produced (normally a plain
+ * `thid`); tolerate a full `ac2:<did>:<thid>` session key too, and fall back to
+ * the connection's active conversation.
+ */
+function resolveOutboundThid(threadId: unknown): string {
+  if (typeof threadId === 'string' && threadId.length > 0) {
+    if (threadId.includes(':')) {
+      return resolveAc2SessionConversation(threadId).threadId ?? DEFAULT_THID;
+    }
+    return threadId;
+  }
+  if (typeof threadId === 'number') return String(threadId);
+  const active = sessionManager.getActive();
+  return active ? getActiveConversation(active.controllerDid, active.requestId) : DEFAULT_THID;
+}
+
+/**
+ * Deliver an agent-initiated (host-driven) text message to the wallet.
+ *
+ * Unlike the per-turn streaming reply (which the agent finalizes itself over
+ * the control channel in `routing.ts`), this path handles messages the host
+ * pushes through the channel adapters — most importantly **sub-agent completion
+ * announces**, which arrive as a fresh `agent` turn targeting the requester
+ * session. When a control (stream) transport is available we emit a proper
+ * thread-scoped `finalize` frame so the reply renders in the right conversation
+ * (previously these were written as raw, thread-less text and were effectively
+ * lost). Falls back to a raw transport write when no control channel was
+ * negotiated, preserving the plain-text contract for stream-unaware wallets.
+ *
+ * Special case — background-task completion: if a `sessions_spawn` task is still
+ * running on the target thread, this host-driven agent text IS that task's
+ * completion announce (the rare case where the host's own delivery reaches us).
+ * We then flip the task's card in place to `completed` with the result inline
+ * (the self-contained task-card model) instead of posting a separate reply
+ * bubble, and mark the task reconciled so the poller / `subagent_ended`
+ * follow-up doesn't double-post the same result.
+ */
+function deliverAgentText(params: { to?: string; text: string; threadId?: unknown }): string {
+  const active = sessionManager.requireActive();
+  if (params.to && active.controllerDid !== params.to) {
+    throw new Error(
+      `[${CHANNEL_ID}] target ${params.to} does not match active peer ${active.controllerDid}`,
+    );
+  }
+  const thid = resolveOutboundThid(params.threadId);
+  const messageId = `ac2-${Date.now()}`;
+  const pending = findPendingTaskForParent(thid);
+  if (pending) {
+    markTaskResult(pending.taskThid, 'completed', params.text);
+    emitTaskCardUpdate({ thid, task: pending, status: 'completed', result: params.text });
+    return messageId;
+  }
+  const control = active.controlTransport;
+  if (control && control.isOpen) {
+    sendFinalize(control, thid, messageId, params.text);
+  } else if (active.transport.isOpen) {
+    active.transport.send(params.text);
+  }
+  if (active.requestId) {
+    recordConversationMessage(active.requestId, thid, {
+      role: 'agent',
+      text: params.text,
+      at: Date.now(),
+    });
+  }
+  return messageId;
 }
 
 export function buildChannelObject(): ChannelPlugin {
@@ -106,20 +180,18 @@ export function buildChannelObject(): ChannelPlugin {
         async sendText({
           to,
           text,
+          threadId,
         }: {
           to: { conversationId: string };
           text: string;
+          threadId?: string | number | null;
         }): Promise<{ messageId: string }> {
-          const active = sessionManager.requireActive();
-          if (to.conversationId && active.controllerDid !== to.conversationId) {
-            throw new Error(
-              `[${CHANNEL_ID}] conversationId ${to.conversationId} does not match active peer ${active.controllerDid}`,
-            );
-          }
-          if (active.transport.isOpen) {
-            active.transport.send(text);
-          }
-          return { messageId: `ac2-${Date.now()}` };
+          const messageId = deliverAgentText({
+            ...(to?.conversationId ? { to: to.conversationId } : {}),
+            text,
+            threadId,
+          });
+          return { messageId };
         },
       },
     },
@@ -153,17 +225,18 @@ export function buildChannelObject(): ChannelPlugin {
         capabilities: { ...AC2_DURABLE_FINAL_CAPABILITIES },
       },
       send: {
-        text: async (ctx: { to: string; text: string }): Promise<{ receipt: MessageReceipt }> => {
-          const active = sessionManager.requireActive();
-          if (ctx.to && active.controllerDid !== ctx.to) {
-            throw new Error(
-              `[${CHANNEL_ID}] target ${ctx.to} does not match active peer ${active.controllerDid}`,
-            );
-          }
-          const messageId = `ac2-${Date.now()}`;
-          if (active.transport.isOpen) active.transport.send(ctx.text);
+        text: async (ctx: {
+          to: string;
+          text: string;
+          threadId?: string | number | null;
+        }): Promise<{ receipt: MessageReceipt }> => {
+          const messageId = deliverAgentText({
+            ...(ctx.to ? { to: ctx.to } : {}),
+            text: ctx.text,
+            threadId: ctx.threadId,
+          });
           return {
-            receipt: buildAc2MessageReceipt(messageId, active.controllerDid),
+            receipt: buildAc2MessageReceipt(messageId, sessionManager.requireActive().controllerDid),
           };
         },
       },

--- a/packages/ac2-open-claw-reference/src/channel/conversation.ts
+++ b/packages/ac2-open-claw-reference/src/channel/conversation.ts
@@ -6,6 +6,25 @@ import { sendStreamControl, type Sendable } from './stream.js';
 
 export const DEFAULT_THID = 'default';
 
+/**
+ * Build the canonical OpenClaw session key for a controller + thread.
+ *
+ * The default thread collapses to the bare `ac2:<controllerDid>` base key, so
+ * the key handed to the host on an inbound turn is byte-identical to the one
+ * `resolveAc2OutboundSessionRoute` / `resolveAc2SessionConversation` resolve
+ * for the same conversation. Otherwise an inbound turn on the default thread
+ * would be keyed `ac2:<did>:default` while every other path (outbound sends,
+ * session resolution, the persisted transcript) uses `ac2:<did>`, splitting a
+ * single logical conversation across two OpenClaw sessions — so the agent
+ * "forgets" the thread whenever the two keys diverge (e.g. on a reconnect).
+ */
+export function buildAc2SessionKey(controllerDid: string, thid?: string): string {
+  const base = `${CHANNEL_ID}:${controllerDid}`;
+  return thid !== undefined && thid.length > 0 && thid !== DEFAULT_THID
+    ? `${base}:${thid}`
+    : base;
+}
+
 const activeThreadByConnection = new Map<string, string>();
 
 function connectionThreadKey(controllerDid: string, requestId?: string): string {
@@ -90,8 +109,8 @@ export function resolveAc2OutboundSessionRoute(params: {
       ? String(params.threadId)
       : undefined;
   const thid = explicit ?? parsedThid ?? DEFAULT_THID;
-  const baseSessionKey = `${CHANNEL_ID}:${to}`;
-  const sessionKey = thid === DEFAULT_THID ? baseSessionKey : `${baseSessionKey}:${thid}`;
+  const baseSessionKey = buildAc2SessionKey(to);
+  const sessionKey = buildAc2SessionKey(to, thid);
   return {
     sessionKey,
     baseSessionKey,
@@ -159,22 +178,35 @@ export function replayConversationHistory(
     t: 'history',
     thid,
     ...(conversation.title !== undefined ? { title: conversation.title } : {}),
-    messages: conversation.messages.map((m) =>
-      m.role === 'tool'
-        ? {
-            role: 'tool' as const,
-            text: '',
-            at: m.at,
-            ...(m.id !== undefined ? { id: m.id } : {}),
-            ...(m.tool !== undefined ? { name: m.tool } : {}),
-            ...(m.command !== undefined ? { command: m.command } : {}),
-            ...(m.output !== undefined ? { output: m.output } : {}),
-          }
-        : {
-            role: m.role === 'user' ? ('user' as const) : ('assistant' as const),
-            text: m.text,
-            at: m.at,
-          },
-    ),
+    messages: conversation.messages.map((m) => {
+      if (m.role === 'tool') {
+        return {
+          role: 'tool' as const,
+          text: '',
+          at: m.at,
+          ...(m.id !== undefined ? { id: m.id } : {}),
+          ...(m.tool !== undefined ? { name: m.tool } : {}),
+          ...(m.command !== undefined ? { command: m.command } : {}),
+          ...(m.output !== undefined ? { output: m.output } : {}),
+        };
+      }
+      if (m.role === 'task') {
+        return {
+          role: 'task' as const,
+          text: '',
+          at: m.at,
+          ...(m.id !== undefined ? { id: m.id } : {}),
+          ...(m.title !== undefined ? { title: m.title } : {}),
+          ...(m.prompt !== undefined ? { prompt: m.prompt } : {}),
+          ...(m.status !== undefined ? { status: m.status } : {}),
+          ...(m.result !== undefined ? { result: m.result } : {}),
+        };
+      }
+      return {
+        role: m.role === 'user' ? ('user' as const) : ('assistant' as const),
+        text: m.text,
+        at: m.at,
+      };
+    }),
   });
 }

--- a/packages/ac2-open-claw-reference/src/channel/index.ts
+++ b/packages/ac2-open-claw-reference/src/channel/index.ts
@@ -14,18 +14,63 @@ export {
   replayConversationHistory,
   parseInboundChat,
   resolveAc2OutboundSessionRoute,
+  buildAc2SessionKey,
   DEFAULT_THID,
   type Ac2SessionConversation,
   type Ac2OutboundSessionRoute,
 } from './conversation.js';
-export { routeInboundToAgent, warmUpAgent } from './routing.js';
+export {
+  routeInboundToAgent,
+  warmUpAgent,
+  classifyAgentError,
+  type Ac2AgentError,
+} from './routing.js';
+export { emitTaskCardUpdate } from './task-card.js';
+export {
+  registerSubagentHooks,
+  handleSubagentSpawned,
+  handleSubagentEnded,
+  resetSubagentHooksRegistration,
+  watchTaskCompletion,
+  resetTaskWatchers,
+  subagentPolling,
+} from './subagent-hooks.js';
+export {
+  readChildResultText,
+  readChildSessionStatus,
+  discoverChildSessionKey,
+  describeSubagentCandidates,
+  type ChildSessionStatus,
+} from './subagent-result.js';
+export {
+  deriveTaskThid,
+  isTaskThid,
+  registerTask,
+  attachSpawnResult,
+  taskDisplayTitle,
+  taskCardId,
+  getTaskByThid,
+  findTaskByRun,
+  findPendingTaskForParent,
+  markTaskResult,
+  listTasks,
+  resetTasks,
+  TASK_THREAD_PREFIX,
+  type Ac2Task,
+  type Ac2TaskStatus,
+} from './tasks.js';
 export {
   sendStreamControl,
   sendPreview,
   sendFinalize,
   sendDiscard,
   sendToolActivity,
+  sendTaskCard,
+  sendNotice,
   AC2_STREAM_CONTROL_PREFIX,
   type Ac2LivePhase,
+  type Ac2TaskCardStatus,
+  type Ac2Notice,
+  type Ac2NoticeLevel,
   type Sendable,
 } from './stream.js';

--- a/packages/ac2-open-claw-reference/src/channel/routing.ts
+++ b/packages/ac2-open-claw-reference/src/channel/routing.ts
@@ -1,17 +1,252 @@
 /** Inbound chat routing: wallet → OpenClaw agent → wallet. */
 
 import { CHANNEL_ID, getActiveRuntime, safeLog, type OpenClawApi } from '../runtime.js';
-import { recordConversationMessage, recordToolActivity } from '../identity/state.js';
+import {
+  recordConversationMessage,
+  recordTaskActivity,
+  recordToolActivity,
+} from '../identity/state.js';
 import { sessionManager } from '../session/manager.js';
 import {
   sendDiscard,
   sendFinalize,
+  sendNotice,
   sendPreview,
+  sendTaskCard,
   sendToolActivity,
   type Ac2LivePhase,
   type Sendable,
 } from './stream.js';
-import { getActiveConversation, parseInboundChat } from './conversation.js';
+import { buildAc2SessionKey, getActiveConversation, parseInboundChat } from './conversation.js';
+import {
+  attachSpawnResult,
+  findPendingTaskForParent,
+  registerTask,
+  taskCardId,
+  taskDisplayTitle,
+  type Ac2Task,
+} from './tasks.js';
+import { watchTaskCompletion } from './subagent-hooks.js';
+
+/** Built-in host tool that starts an isolated background sub-agent run. */
+const TOOL_SESSIONS_SPAWN = 'sessions_spawn';
+/** Built-in host tool that ends the turn to await sub-agent completions. */
+const TOOL_SESSIONS_YIELD = 'sessions_yield';
+
+/** A parsed accepted-spawn envelope; both fields best-effort. */
+interface AcceptedSpawn {
+  runId?: string;
+  childSessionKey?: string;
+}
+
+/** A client-facing classification of a failed agent turn. */
+export interface Ac2AgentError {
+  /** Machine-readable code for the wallet's `notice` banner. */
+  code: string;
+  /** Human-facing message delivered to the client as the turn's reply. */
+  text: string;
+}
+
+/**
+ * Substrings (case-insensitive) that mark a provider quota / rate-limit /
+ * billing failure. These are the common, transient "the agent can't answer
+ * right now" errors that a user can recover from by waiting or topping up,
+ * so we surface a tailored, reassuring message rather than a generic failure.
+ */
+const QUOTA_ERROR_MARKERS = [
+  'quota',
+  'rate limit',
+  'rate_limit',
+  'ratelimit',
+  'too many requests',
+  'insufficient_quota',
+  'insufficient funds',
+  'insufficient credit',
+  'out of credit',
+  'billing',
+  'payment required',
+] as const;
+
+/**
+ * Turn a raw agent/provider error into a client-facing message + code.
+ *
+ * A failed turn (most commonly a provider quota / rate-limit error) previously
+ * ended in a silent `discard`, so the wallet was left spinning with no idea the
+ * turn had failed. We now classify the error and deliver a real message back to
+ * the client: quota/rate-limit/billing failures get a tailored, recoverable
+ * message (and a `quota_exceeded` notice code), everything else a generic
+ * "couldn't complete your request" message. The raw error text stays in the
+ * logs only — it is not leaked to the client.
+ */
+export function classifyAgentError(raw: unknown): Ac2AgentError {
+  const message = raw instanceof Error ? raw.message : String(raw ?? '');
+  const lower = message.toLowerCase();
+  const isQuota =
+    QUOTA_ERROR_MARKERS.some((marker) => lower.includes(marker)) || /\b429\b/.test(message);
+  if (isQuota) {
+    return {
+      code: 'quota_exceeded',
+      text: "The agent couldn't respond because it has reached its usage quota. Please try again later.",
+    };
+  }
+  return {
+    code: 'agent_error',
+    text: "The agent ran into an error and couldn't complete your request. Please try again.",
+  };
+}
+
+/** A host sub-agent child session key: `agent:<agentId>:subagent:<uuid>`. */
+const CHILD_SESSION_KEY_RE = /agent:[^:\s"']+:subagent:[0-9a-fA-F-]{8,}/;
+
+function tryParseObject(text: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Extract `{ runId, childSessionKey }` from an accepted `sessions_spawn` tool
+ * result. Capturing `childSessionKey` is what lets the background-task
+ * completion poller find the child session and deliver its result, so we are
+ * deliberately tolerant about where it lives: the dispatcher may surface the
+ * accepted envelope as a JSON string in `.text`/`.output`, inside a
+ * `content: [{ text }]` array, or as a nested/escaped object. We scan every
+ * stringy field we can find, prefer a clean JSON object with the literal keys,
+ * and finally regex-scan the raw text for the child session-key pattern so a
+ * wrapping envelope can never hide it.
+ */
+function extractAcceptedSpawn(payload: unknown): AcceptedSpawn {
+  const blobs: string[] = [];
+  const push = (v: unknown): void => {
+    if (typeof v === 'string' && v.length > 0) blobs.push(v);
+  };
+  if (payload && typeof payload === 'object') {
+    const p = payload as Record<string, unknown>;
+    push(p['text']);
+    push(p['output']);
+    const content = p['content'];
+    if (Array.isArray(content)) {
+      for (const c of content) {
+        if (c && typeof c === 'object') push((c as Record<string, unknown>)['text']);
+        else push(c);
+      }
+    }
+    try {
+      blobs.push(JSON.stringify(payload));
+    } catch {
+      // ignore non-serialisable payloads
+    }
+  } else {
+    push(payload);
+  }
+
+  let runId: string | undefined;
+  let childSessionKey: string | undefined;
+
+  // Prefer a clean JSON object carrying the literal keys.
+  for (const b of blobs) {
+    const parsed = tryParseObject(b);
+    if (!parsed) continue;
+    if (!runId && typeof parsed['runId'] === 'string') runId = parsed['runId'] as string;
+    if (!childSessionKey && typeof parsed['childSessionKey'] === 'string')
+      childSessionKey = parsed['childSessionKey'] as string;
+  }
+
+  // Regex fallbacks over the raw blobs (handles nested / escaped envelopes).
+  if (!childSessionKey || !runId) {
+    const joined = blobs.join('\n');
+    if (!childSessionKey) {
+      const m = CHILD_SESSION_KEY_RE.exec(joined);
+      if (m) childSessionKey = m[0];
+    }
+    if (!runId) {
+      const m = /"runId"\s*:\s*"([^"]+)"/.exec(joined);
+      if (m) runId = m[1];
+    }
+  }
+
+  return {
+    ...(runId ? { runId } : {}),
+    ...(childSessionKey ? { childSessionKey } : {}),
+  };
+}
+
+/**
+ * Record the inbound (user) turn in the host session store *before* the reply
+ * is dispatched, mirroring what every built-in channel does. OpenClaw's own
+ * direct-message pipeline (`dispatchInboundDirectDmWithRuntime`) always runs
+ * `resolveAgentRoute` → `resolveStorePath` → `recordInboundSession` →
+ * `dispatchReplyWithBufferedBlockDispatcher`; the buffered block dispatcher only
+ * *mirrors the assistant reply* into an already-recorded session entry and does
+ * not, on its own, create the durable per-`SessionKey` entry (session id +
+ * route/origin metadata) that the host reloads on the next launch and that
+ * gateway/ACP session discovery scans on disk.
+ *
+ * Our channel drove turns straight through the dispatcher and skipped this
+ * step, so nothing durable was written for the conversation: every OpenClaw
+ * restart reloaded an empty session and the agent "forgot" the thread — even
+ * though the `SessionKey` we send was byte-identical across runs. The upsert is
+ * idempotent and keyed identically, so recording it here makes the session
+ * survive a shutdown without changing the key.
+ *
+ * Best-effort: guarded so a runtime that does not expose the session surface
+ * (older hosts, unit-test doubles) simply skips recording instead of failing
+ * the turn.
+ */
+async function recordInboundSessionForTurn(params: {
+  runtime: any;
+  api: OpenClawApi;
+  cfg: unknown;
+  sessionKey: string;
+  ctx: unknown;
+  agentId: string | undefined;
+}): Promise<void> {
+  const { runtime, api, cfg, sessionKey, ctx, agentId } = params;
+  const session = runtime?.channel?.session;
+  const record = session?.recordInboundSession;
+  const resolveStorePath = session?.resolveStorePath;
+  if (typeof record !== 'function' || typeof resolveStorePath !== 'function') return;
+  try {
+    const store = (cfg as { session?: { store?: string } } | undefined)?.session?.store;
+    // The store path must resolve to the SAME agent the host runs/persists this
+    // turn under, so pass the resolved route's `agentId` (falls back to the
+    // host default when absent — matching how the dispatcher resolves it).
+    const storePath = resolveStorePath.call(
+      session,
+      store,
+      agentId !== undefined ? { agentId } : undefined,
+    );
+    if (typeof storePath !== 'string' || storePath.length === 0) return;
+    await record.call(session, {
+      storePath,
+      sessionKey,
+      ctx,
+      // Create the entry when this is the conversation's first turn — otherwise
+      // there is nothing on disk to reload after a restart.
+      createIfMissing: true,
+      onRecordError: (err: unknown) => {
+        safeLog(
+          api,
+          'warn',
+          `[ac2] failed to record inbound session (sessionKey=${sessionKey}): ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      },
+    });
+  } catch (err) {
+    safeLog(
+      api,
+      'warn',
+      `[ac2] could not record inbound session (sessionKey=${sessionKey}): ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+}
 
 export async function routeInboundToAgent(
   api: OpenClawApi,
@@ -48,12 +283,25 @@ export async function routeInboundToAgent(
   }
 
   const cfg = api.config;
-  const sessionKey = `${CHANNEL_ID}:${controllerDid}:${thid}`;
+  // Build the OpenClaw session key with the SAME canonical rule the outbound
+  // route + session resolution use (`buildAc2SessionKey`), so the default
+  // thread collapses to the bare `ac2:<controllerDid>` key instead of
+  // `ac2:<controllerDid>:default`. Keying it consistently is what lets the host
+  // reload the same persisted agent session on every (re)connect rather than
+  // splitting the conversation across two keys and losing its context.
+  const sessionKey = buildAc2SessionKey(controllerDid, thid);
   const messageSid = `ac2-${Date.now()}`;
 
   let agentReply = '';
   let previewText = '';
   let toolActivitySeq = 0;
+  // True once this turn delegated work via `sessions_spawn`, so a turn that
+  // ends on `sessions_yield` with no assistant text is reported as "working"
+  // instead of silently discarded.
+  let spawnedThisTurn = false;
+  // Tasks spawned during this turn; each gets a background completion watcher
+  // once the turn settles so its result is delivered back to the wallet.
+  const spawnedTaskThids = new Set<string>();
 
   const toolCardIds = new Map<string, string>();
   const toolCommands = new Map<string, string>();
@@ -124,13 +372,98 @@ export async function routeInboundToAgent(
     }
   };
 
+  // Emit/refresh a self-contained background-task card (de-duped by a stable
+  // per-task id) over the stream transport and persist it to history. The
+  // spawning turn uses this for the initial `running` card; the completion path
+  // re-emits the same id from `channel/task-card.ts`.
+  const emitTaskCard = (
+    task: Ac2Task,
+    status: 'running' | 'completed' | 'failed' | 'stopped',
+    result?: string,
+  ): void => {
+    const id = taskCardId(task.taskThid);
+    const cardTitle = taskDisplayTitle(task);
+    const prompt = task.task;
+    const card = {
+      id,
+      title: cardTitle,
+      status,
+      ...(prompt && prompt.length > 0 ? { prompt } : {}),
+      ...(result !== undefined ? { result } : {}),
+    };
+    if (transport != null) sendTaskCard(transport, thid, card);
+    if (requestId) recordTaskActivity(requestId, thid, card);
+  };
+
+  // Render a `sessions_spawn` tool call as a first-class background task card
+  // inline in the parent thread. The task is tracked so its completion can be
+  // delivered back here later; we no longer seed a dedicated `task-<name>`
+  // conversation (the app surfaces background work via its task indicator in
+  // the parent thread). Returns true when the tool was a sub-session tool (so
+  // the generic tool-card path is skipped).
+  const handleSubSessionTool = (
+    name: string | undefined,
+    key: string | undefined,
+    args: Record<string, unknown> | undefined,
+    resultText?: string,
+  ): boolean => {
+    if (name === TOOL_SESSIONS_SPAWN) {
+      const a = args ?? {};
+      const taskText = typeof a['task'] === 'string' ? (a['task'] as string) : '';
+      const taskName = typeof a['taskName'] === 'string' ? (a['taskName'] as string) : undefined;
+      const label = typeof a['label'] === 'string' ? (a['label'] as string) : undefined;
+      const agentId = typeof a['agentId'] === 'string' ? (a['agentId'] as string) : undefined;
+      const task = registerTask({
+        parentThid: thid,
+        parentSessionKey: sessionKey,
+        task: taskText,
+        ...(taskName !== undefined ? { taskName } : {}),
+        ...(label !== undefined ? { label } : {}),
+        ...(agentId !== undefined ? { agentId } : {}),
+      });
+      spawnedThisTurn = true;
+      spawnedTaskThids.add(task.taskThid);
+      // Enrich with the accepted `{ runId, childSessionKey }` when present.
+      const accepted = extractAcceptedSpawn(resultText);
+      if (accepted.runId !== undefined || accepted.childSessionKey !== undefined) {
+        attachSpawnResult(task.taskThid, accepted);
+      }
+      // Render a self-contained background-task card in `running` state. Its
+      // completion path (the poller / `subagent_ended`) later re-emits the SAME
+      // card id with a terminal status + the child's result text inline, so the
+      // one card flips from running to done rather than leaving a stale
+      // "running…" card plus a disconnected reply bubble.
+      emitTaskCard(task, 'running');
+      return true;
+    }
+    if (name === TOOL_SESSIONS_YIELD) {
+      // Yield ends the turn; keep the thread visibly "working" rather than
+      // letting it fall silent while children run.
+      streamPreview('thinking');
+      emitToolCard(key ?? 'yield', {
+        name: '⏳ awaiting background task',
+        output: 'Delegated work is running; results will post here when ready.',
+      });
+      return true;
+    }
+    return false;
+  };
+
+  // Resolve the host agent route for this controller so the inbound session is
+  // recorded (and later reloaded) under the SAME agent + session store the host
+  // runs the turn in. The route is otherwise advisory here, so tolerate older
+  // runtimes that do not expose it.
+  let routeAgentId: string | undefined;
   try {
-    runtime.channel?.routing?.resolveAgentRoute?.({
+    const route = runtime.channel?.routing?.resolveAgentRoute?.({
       cfg,
       channel: CHANNEL_ID,
       accountId: controllerDid,
       peer: { kind: 'direct', id: controllerDid },
     });
+    if (route && typeof (route as { agentId?: unknown }).agentId === 'string') {
+      routeAgentId = (route as { agentId: string }).agentId;
+    }
   } catch {
     // routing is advisory
   }
@@ -145,9 +478,16 @@ export async function routeInboundToAgent(
     SessionKey: sessionKey,
     AccountId: controllerDid,
     MessageSid: messageSid,
+    // Anchor persistence to the resolved agent so `recordInboundSession` and the
+    // dispatcher's own store lookup agree on the `agents/<agentId>/` store.
+    ...(routeAgentId !== undefined ? { AgentId: routeAgentId } : {}),
   };
 
   safeLog(api, 'info', `[ac2] dispatching wallet message to agent (sessionKey=${sessionKey})`);
+
+  // Persist the inbound turn before dispatching so the conversation survives an
+  // OpenClaw restart (see `recordInboundSessionForTurn`).
+  await recordInboundSessionForTurn({ runtime, api, cfg, sessionKey, ctx, agentId: routeAgentId });
 
   sendPreview(transport, thid, 'thinking');
 
@@ -165,6 +505,11 @@ export async function routeInboundToAgent(
     });
   };
 
+  // Set when the agent turn fails (e.g. a provider quota / rate-limit error).
+  // Its presence flips `settle` from a silent discard to delivering a real
+  // error message back to the client.
+  let turnError: Ac2AgentError | undefined;
+
   let settled = false;
   const streamPreview = (phase: Ac2LivePhase, opts?: { text?: string; detail?: string }): void => {
     if (settled) return;
@@ -173,14 +518,55 @@ export async function routeInboundToAgent(
   const settle = (): void => {
     if (settled) return;
     settled = true;
+    if (turnError !== undefined) {
+      // The agent turn failed (most commonly a provider quota / rate-limit
+      // error). Deliver the classified error to the client as the turn's reply
+      // instead of silently discarding the "thinking" preview — otherwise the
+      // wallet is left spinning with no idea the turn failed. Also raise an
+      // out-of-band notice banner so the wallet can special-case it (e.g. a
+      // quota warning). Any partial text the agent managed to stream is kept,
+      // with the error appended after it.
+      const partial = finalReplyText();
+      const errorText =
+        partial.length > 0 ? `${partial}\n\n${turnError.text}` : turnError.text;
+      sendFinalize(transport, thid, messageSid, errorText);
+      if (requestId) {
+        recordConversationMessage(requestId, thid, {
+          role: 'agent',
+          text: errorText,
+          at: Date.now(),
+        });
+      }
+      sendNotice(transport, { code: turnError.code, level: 'error', text: turnError.text });
+      safeLog(api, 'info', `[ac2] delivered agent-error reply to wallet (code=${turnError.code}).`);
+      for (const taskThid of spawnedTaskThids) watchTaskCompletion(taskThid);
+      return;
+    }
     persistAgentReply();
     const replyText = finalReplyText();
     if (replyText.length > 0) {
       sendFinalize(transport, thid, messageSid, replyText);
       safeLog(api, 'info', `[ac2] Finalized agent reply to wallet (len=${replyText.length})`);
+    } else if (spawnedThisTurn) {
+      // The turn delegated work and yielded without composing a reply. Post a
+      // durable "working" note so the thread isn't left silent; the child's
+      // result arrives later on its own host-initiated turn.
+      const note =
+        'Working on that in the background \u2014 I\'ll post the result here as soon as the task finishes.';
+      sendFinalize(transport, thid, messageSid, note);
+      if (requestId) {
+        recordConversationMessage(requestId, thid, { role: 'agent', text: note, at: Date.now() });
+      }
+      safeLog(api, 'info', '[ac2] turn yielded to background task(s); posted working note.');
     } else {
       sendDiscard(transport, thid);
     }
+    // Watch every task spawned this turn until its child session finishes, then
+    // deliver the real result into this thread ourselves. The host's own
+    // announce can't reach our no-gateway CLI and the `subagent_ended` hook
+    // never fires here, so this poll-based watcher is the reliable path (see
+    // `watchTaskCompletion`).
+    for (const taskThid of spawnedTaskThids) watchTaskCompletion(taskThid);
   };
 
   try {
@@ -206,6 +592,13 @@ export async function routeInboundToAgent(
                   : typeof payload?.name === 'string'
                     ? payload.name
                     : undefined;
+            // Sub-session tools render as durable task cards (see onToolStart);
+            // keep the transient spinner generic instead of flashing the raw
+            // `sessions_spawn` / `sessions_yield` name.
+            if (toolName === TOOL_SESSIONS_SPAWN || toolName === TOOL_SESSIONS_YIELD) {
+              streamPreview('thinking');
+              return;
+            }
             streamPreview('tool', toolName ? { detail: toolName } : undefined);
             return;
           }
@@ -222,6 +615,9 @@ export async function routeInboundToAgent(
         },
         onError: (err: unknown): void => {
           const msg = err instanceof Error ? err.message : String(err);
+          // Classify the failure (quota-aware) and set it BEFORE settling so the
+          // client receives a real error message instead of a silent discard.
+          if (turnError === undefined) turnError = classifyAgentError(err);
           settle();
           safeLog(api, 'warn', `[ac2] agent reply dispatcher error: ${msg}`);
         },
@@ -251,9 +647,10 @@ export async function routeInboundToAgent(
           args?: Record<string, unknown>;
         }): void => {
           const detail = typeof payload?.name === 'string' ? payload.name : undefined;
-          streamPreview('tool', detail ? { detail } : undefined);
           const key =
             payload?.toolCallId ?? payload?.itemId ?? (detail ? `name:${detail}` : undefined);
+          if (handleSubSessionTool(detail, key ?? undefined, payload?.args)) return;
+          streamPreview('tool', detail ? { detail } : undefined);
           if (key == null) return;
           const command = formatToolCommand(payload?.args);
           if (command) toolCommands.set(key, command);
@@ -294,6 +691,40 @@ export async function routeInboundToAgent(
           });
         },
         onToolResult: (payload: any): void => {
+          const toolName = typeof payload?.name === 'string' ? payload.name : undefined;
+          if (toolName === TOOL_SESSIONS_SPAWN) {
+            // Enrich the task registered at spawn-start with the accepted
+            // `{ runId, childSessionKey }` envelope; never render it raw. Pass
+            // the whole payload so the extractor can dig the key out of any
+            // envelope shape (text / output / content[] / nested JSON).
+            const accepted = extractAcceptedSpawn(payload);
+            const pending = findPendingTaskForParent(thid);
+            if (
+              pending &&
+              (accepted.runId !== undefined || accepted.childSessionKey !== undefined)
+            ) {
+              attachSpawnResult(pending.taskThid, accepted);
+              safeLog(
+                api,
+                'info',
+                `[ac2] captured background task spawn (child=${accepted.childSessionKey ?? '?'}, run=${accepted.runId ?? '?'}).`,
+              );
+            } else if (!pending) {
+              safeLog(
+                api,
+                'warn',
+                '[ac2] sessions_spawn result had no pending task to enrich; completion polling may not start.',
+              );
+            } else {
+              safeLog(
+                api,
+                'warn',
+                '[ac2] sessions_spawn result did not carry a childSessionKey; completion polling cannot locate the child session.',
+              );
+            }
+            return;
+          }
+          if (toolName === TOOL_SESSIONS_YIELD) return;
           const key =
             typeof payload?.toolCallId === 'string'
               ? payload.toolCallId
@@ -340,8 +771,11 @@ export async function routeInboundToAgent(
       },
     });
   } catch (err) {
-    settle();
     const msg = err instanceof Error ? err.message : String(err);
+    // A throw from the dispatch call itself (rather than via onError) must also
+    // reach the client as an error message, not a silent discard.
+    if (turnError === undefined) turnError = classifyAgentError(err);
+    settle();
     safeLog(api, 'error', `[ac2] failed to route message to agent: ${msg}`);
   }
 }

--- a/packages/ac2-open-claw-reference/src/channel/stream.ts
+++ b/packages/ac2-open-claw-reference/src/channel/stream.ts
@@ -1,6 +1,7 @@
 /**
  * `ac2-stream` control-frame protocol. Each frame is `STX` (`\u0002`) + JSON:
- * `preview` / `finalize` / `discard` / `tool` / `conversations` / `history`.
+ * `preview` / `finalize` / `discard` / `tool` / `task` / `conversations` /
+ * `history` / `notice`.
  */
 
 /** Transport a control frame can be written to. */
@@ -12,6 +13,43 @@ export interface Sendable {
 export const AC2_STREAM_CONTROL_PREFIX = '\u0002';
 
 export type Ac2LivePhase = 'thinking' | 'tool' | 'typing';
+
+/** Lifecycle of a background-task (`sessions_spawn`) card on the wire. */
+export type Ac2TaskCardStatus = 'running' | 'completed' | 'failed' | 'stopped';
+
+/** Severity for an out-of-band `notice` control frame. */
+export type Ac2NoticeLevel = 'info' | 'warning' | 'error';
+
+/** An out-of-band advisory the wallet renders as a banner (never a chat bubble). */
+export interface Ac2Notice {
+  /** Machine-readable code so the wallet can special-case a notice. */
+  code: string;
+  /** Severity; defaults to `warning` on the wire when omitted. */
+  level?: Ac2NoticeLevel;
+  /** Optional short heading. */
+  title?: string;
+  /** Human-facing body text. */
+  text: string;
+}
+
+/**
+ * Resolve the control-frame surface for a host-initiated (out-of-turn) send:
+ * prefer the dedicated `ac2-stream` channel when the wallet negotiated one,
+ * otherwise fall back to the main transport. STX control frames are parsed by
+ * the wallet on either channel — the spawning turn in `routing.ts` likewise
+ * emits over `streamSendable ?? transport` — so completion/announce paths must
+ * NOT downgrade to a raw text write when there is no separate stream channel
+ * (that posts a stray reply bubble and leaves the task card stuck `running`).
+ * Returns `undefined` only when nothing is open.
+ */
+export function resolveControlSendable(active: {
+  controlTransport?: Sendable;
+  transport: Sendable;
+}): Sendable | undefined {
+  if (active.controlTransport && active.controlTransport.isOpen) return active.controlTransport;
+  if (active.transport.isOpen) return active.transport;
+  return undefined;
+}
 
 /** Write one control frame. Best-effort, never throws. */
 export function sendStreamControl(transport: Sendable, frame: Record<string, unknown>): void {
@@ -62,5 +100,45 @@ export function sendToolActivity(
     ...(activity.name ? { name: activity.name } : {}),
     ...(activity.command ? { command: activity.command } : {}),
     ...(activity.output !== undefined ? { output: activity.output } : {}),
+  });
+}
+
+/**
+ * Emit a durable background-task card (de-duped by `id`). Unlike a tool card,
+ * a task card is a self-contained sub-agent run: it starts as `running` and is
+ * later re-emitted with the SAME `id` carrying a terminal `status` plus the
+ * child's `result` text inline, so the wallet renders one card that flips from
+ * running to done/failed with the answer inside it (no separate reply bubble).
+ */
+export function sendTaskCard(
+  transport: Sendable,
+  thid: string,
+  task: {
+    id: string;
+    title: string;
+    status: Ac2TaskCardStatus;
+    prompt?: string;
+    result?: string;
+  },
+): void {
+  sendStreamControl(transport, {
+    t: 'task',
+    thid,
+    id: task.id,
+    title: task.title,
+    status: task.status,
+    ...(task.prompt !== undefined ? { prompt: task.prompt } : {}),
+    ...(task.result !== undefined ? { result: task.result } : {}),
+  });
+}
+
+/** Emit an out-of-band advisory banner (e.g. a locked/new-controller notice). */
+export function sendNotice(transport: Sendable, notice: Ac2Notice): void {
+  sendStreamControl(transport, {
+    t: 'notice',
+    code: notice.code,
+    level: notice.level ?? 'warning',
+    ...(notice.title ? { title: notice.title } : {}),
+    text: notice.text,
   });
 }

--- a/packages/ac2-open-claw-reference/src/channel/subagent-hooks.ts
+++ b/packages/ac2-open-claw-reference/src/channel/subagent-hooks.ts
@@ -1,0 +1,496 @@
+/**
+ * Reliable sub-agent ("background task") lifecycle via the OpenClaw host's
+ * plugin-hook surface.
+ *
+ * A `sessions_spawn` child runs in its own isolated session and, when it
+ * finishes, the host tries to push its result back to the *requester* thread.
+ * In our standalone pairing CLI (no in-process gateway) that host-driven
+ * delivery is unreliable for any non-default thread: the direct-completion
+ * fallback refuses targets that carry a `threadId`, and the announce-agent path
+ * needs a driven turn we never run. The net effect the user sees is a task that
+ * "completes without any response" even though the agent promised to follow up.
+ *
+ * The host also exposes an in-process hook surface that fires regardless of the
+ * gateway: `subagent_spawned` when a child launches and `subagent_ended` when it
+ * finishes. We subscribe to both. `subagent_spawned` lets us bind the host's
+ * authoritative `{ runId, childSessionKey }` to the task we registered from the
+ * `sessions_spawn` tool call, and `subagent_ended` lets us post the completion
+ * follow-up into the parent conversation ourselves — the missing "I'll let you
+ * know when it's done" message.
+ *
+ * The `subagent_ended` event itself does NOT carry the child's final result
+ * *text*, but the child persists that text to its own session transcript, which
+ * the public plugin SDK lets us read. So on completion we fetch the real answer
+ * (via `readChildResultText`) and post it into the parent conversation — the
+ * follow-up the agent promised. If the text can't be read we fall back to a
+ * plain lifecycle notice (finished / failed / stopped). Everything is delivered
+ * into the parent thread the work was requested from; we no longer split
+ * background work into dedicated `task-…` threads (the app renders the task
+ * inline via its status indicator).
+ */
+
+import { CHANNEL_ID, getActiveApi, safeLog, type OpenClawApi } from '../runtime.js';
+import { sessionManager } from '../session/manager.js';
+import { recordConversationMessage } from '../identity/state.js';
+import { sendFinalize, type Sendable } from './stream.js';
+import { emitTaskCardUpdate } from './task-card.js';
+import { DEFAULT_THID, resolveAc2SessionConversation } from './conversation.js';
+import {
+  describeSubagentCandidates,
+  discoverChildSessionKey,
+  readChildResultText,
+  readChildSessionStatus,
+} from './subagent-result.js';
+import {
+  attachSpawnResult,
+  findPendingTaskForParent,
+  findTaskByRun,
+  getTaskByThid,
+  listTasks,
+  markTaskResult,
+  registerTask,
+  taskDisplayTitle,
+  type Ac2Task,
+} from './tasks.js';
+
+/** Plugin-hook name: a sub-agent run has launched. */
+const HOOK_SUBAGENT_SPAWNED = 'subagent_spawned';
+/** Plugin-hook name: a sub-agent run has finished (ok/error/timeout/…). */
+const HOOK_SUBAGENT_ENDED = 'subagent_ended';
+
+/** Non-empty-string coercion. */
+function str(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}
+
+/** Coerce a `threadId` (string | number) into a wallet thread id. */
+function thidFrom(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.length > 0) return value;
+  if (typeof value === 'number') return String(value);
+  return undefined;
+}
+
+function log(level: 'info' | 'warn' | 'error', msg: string): void {
+  const api = getActiveApi();
+  if (api) safeLog(api, level, msg);
+}
+
+/**
+ * `subagent_spawned` handler. Binds the host's authoritative
+ * `{ runId, childSessionKey }` to the task we registered from the
+ * `sessions_spawn` tool call so `subagent_ended` can find it later. Falls back
+ * to registering a task if the tool-call path missed it (e.g. the accepted
+ * envelope did not parse), using the requester thread the host reports.
+ *
+ * Event shape (host): `{ runId, childSessionKey, agentId?, label?, requester?:
+ * { channel, accountId, to, threadId } , … }`; ctx: `{ runId, childSessionKey,
+ * requesterSessionKey }`.
+ */
+export function handleSubagentSpawned(event: unknown, ctx?: unknown): void {
+  const e = (event ?? {}) as Record<string, unknown>;
+  const c = (ctx ?? {}) as Record<string, unknown>;
+  const runId = str(c['runId']) ?? str(e['runId']);
+  const childSessionKey = str(c['childSessionKey']) ?? str(e['childSessionKey']);
+  const agentId = str(e['agentId']);
+  const label = str(e['label']);
+  const requester = (e['requester'] ?? {}) as Record<string, unknown>;
+  const parentThid = thidFrom(requester['threadId']);
+
+  // Prefer correlating to the task routing already registered from the tool
+  // call (it carries the real task prompt + display title); enrich it with the
+  // authoritative ids so the ended hook can locate it deterministically.
+  let task = findTaskByRun({
+    ...(runId !== undefined ? { runId } : {}),
+    ...(childSessionKey !== undefined ? { childSessionKey } : {}),
+  });
+  if (!task && parentThid) task = findPendingTaskForParent(parentThid);
+
+  if (task) {
+    attachSpawnResult(task.taskThid, {
+      ...(runId !== undefined ? { runId } : {}),
+      ...(childSessionKey !== undefined ? { childSessionKey } : {}),
+      ...(agentId !== undefined ? { agentId } : {}),
+    });
+    return;
+  }
+
+  // Backstop: the tool path did not register a task; create one from the hook.
+  // The task prompt text is not available on this event, so leave it empty.
+  registerTask({
+    parentThid: parentThid ?? DEFAULT_THID,
+    task: '',
+    ...(label !== undefined ? { label } : {}),
+    ...(agentId !== undefined ? { agentId } : {}),
+    ...(runId !== undefined ? { runId } : {}),
+    ...(childSessionKey !== undefined ? { childSessionKey } : {}),
+  });
+}
+
+/**
+ * Build the user-facing lifecycle notice for a finished task. `title` is the
+ * task's display title when we tracked one; omitted for untracked runs (we
+ * still deliver a generic notice so the promised follow-up is never silent).
+ */
+function completionMessage(
+  title: string | undefined,
+  kind: 'completed' | 'failed' | 'stopped',
+  errorText?: string,
+): string {
+  const named = title ? `\u201c${title}\u201d ` : '';
+  if (kind === 'completed') {
+    return `\u2705 Background task ${named}finished.`;
+  }
+  if (kind === 'stopped') {
+    return `\u23f9\ufe0f Background task ${named}was stopped.`;
+  }
+  return `\u274c Background task ${named}failed${errorText ? `: ${errorText}` : '.'}`;
+}
+
+/**
+ * `subagent_ended` handler. Correlates the finished run to a tracked task,
+ * flips its lifecycle, and posts the follow-up into the parent conversation the
+ * work was requested from — the child's real result text when we can read it,
+ * otherwise a plain lifecycle notice. Best-effort and never throws (hooks are
+ * fire-and-forget). Async so it can read the child's transcript.
+ *
+ * Event shape (host): `{ targetSessionKey, targetKind, reason, runId?, endedAt?,
+ * outcome?, error? }`; ctx: `{ runId, childSessionKey, requesterSessionKey }`.
+ */
+export async function handleSubagentEnded(event: unknown, ctx?: unknown): Promise<void> {
+  try {
+    const e = (event ?? {}) as Record<string, unknown>;
+    const c = (ctx ?? {}) as Record<string, unknown>;
+    const runId = str(c['runId']) ?? str(e['runId']);
+    const childSessionKey = str(c['childSessionKey']) ?? str(e['targetSessionKey']);
+    const requesterSessionKey = str(c['requesterSessionKey']) ?? str(e['requesterSessionKey']);
+    const outcome = str(e['outcome']);
+    const reason = str(e['reason']);
+    const errorText = str(e['error']);
+
+    // Evidence line: proves the in-process hook actually fired for this run
+    // (the host only emits `subagent_ended` when a listener is registered).
+    log(
+      'info',
+      `[ac2] subagent_ended fired (runId=${runId ?? '?'}, child=${childSessionKey ?? '?'}, ` +
+        `outcome=${outcome ?? 'ok'}, reason=${reason ?? '-'}).`,
+    );
+
+    // Internal lifecycle churn (session reset / deletion) is not a user-visible
+    // task completion — ignore it.
+    if (reason === 'reset' || reason === 'deleted') return;
+
+    const kind: 'completed' | 'failed' | 'stopped' =
+      outcome === 'error' || outcome === 'timeout' || reason === 'killed'
+        ? reason === 'killed'
+          ? 'stopped'
+          : 'failed'
+        : 'completed';
+
+    // On success, deliver the child's actual answer read from its own session
+    // transcript; failed/stopped runs (or an unreadable transcript) fall back to
+    // a plain lifecycle notice. Used by both the tracked and untracked paths.
+    const resolveResult = async (
+      key: string | undefined,
+      agentId: string | undefined,
+    ): Promise<string | undefined> => {
+      if (kind !== 'completed') return undefined;
+      return readChildResultText({
+        ...(key !== undefined ? { childSessionKey: key } : {}),
+        ...(agentId !== undefined ? { agentId } : {}),
+      });
+    };
+
+    const task = findTaskByRun({
+      ...(runId !== undefined ? { runId } : {}),
+      ...(childSessionKey !== undefined ? { childSessionKey } : {}),
+    });
+
+    if (task) {
+      if (task.status !== 'running') return; // already reconciled (e.g. deliverAgentText)
+      let message = completionMessage(taskDisplayTitle(task), kind, errorText);
+      const resultText = await resolveResult(task.childSessionKey ?? childSessionKey, task.agentId);
+      if (resultText) message = resultText;
+      // Re-check: a concurrent path (poller / direct delivery) may have
+      // reconciled the task while we awaited the transcript read.
+      const fresh = getTaskByThid(task.taskThid);
+      if (!fresh || fresh.status !== 'running') return;
+      markTaskResult(task.taskThid, kind, message);
+      // Flip the running task card in place to its terminal state with the
+      // child's result inline (no separate reply bubble).
+      emitTaskCardUpdate({ thid: task.parentThid, task, status: kind, result: message });
+      log('info', `[ac2] delivered subagent_ended task card into \`${task.parentThid}\` (${kind}).`);
+      return;
+    }
+
+    // No task was tracked for this run — e.g. the `sessions_spawn` tool-result
+    // envelope did not parse and the `subagent_spawned` hook never bound it.
+    // Deliver anyway so the agent's promised follow-up is never silently
+    // dropped: derive the parent thread from the requester session key and read
+    // the child's answer straight from its transcript. Only handle runs whose
+    // requester belongs to this channel (`ac2:<did>[:<thid>]`) so we never post
+    // another channel's sub-agent output — or warmup churn — into the wallet.
+    if (!requesterSessionKey || !requesterSessionKey.startsWith(`${CHANNEL_ID}:`)) {
+      log(
+        'info',
+        `[ac2] subagent_ended for run outside this channel (requester=${requesterSessionKey ?? '?'}); skipping delivery.`,
+      );
+      return;
+    }
+    const parentThid = resolveAc2SessionConversation(requesterSessionKey).threadId ?? DEFAULT_THID;
+    let message = await resolveResult(childSessionKey, undefined);
+    if (!message) message = completionMessage(undefined, kind, errorText);
+    deliverCompletion(parentThid, message, kind);
+    log('info', `[ac2] delivered untracked subagent completion into \`${parentThid}\` (${kind}).`);
+  } catch (err) {
+    log('warn', `[ac2] subagent_ended handler error: ${err instanceof Error ? err.message : err}`);
+  }
+}
+
+/**
+ * Deliver a completion follow-up into a parent conversation thread. Emits a
+ * thread-scoped `finalize` frame over the control (stream) transport and
+ * persists it. Falls back to a raw transport write when no control channel was
+ * negotiated. Background work is surfaced inline in the parent thread (no
+ * dedicated `task-…` conversation).
+ */
+function deliverCompletion(parentThid: string, message: string, statusLabel: string): void {
+  const active = sessionManager.getActive();
+  if (!active) return;
+  const control: Sendable | undefined =
+    active.controlTransport && active.controlTransport.isOpen ? active.controlTransport : undefined;
+
+  const messageId = `ac2-task-${Date.now()}`;
+  if (control) {
+    sendFinalize(control, parentThid, messageId, message);
+  } else if (active.transport.isOpen) {
+    // Stream-unaware wallet: a single plain-text write is the best we can do.
+    try {
+      active.transport.send(message);
+    } catch {
+      // best-effort
+    }
+  }
+
+  if (active.requestId) {
+    recordConversationMessage(active.requestId, parentThid, {
+      role: 'agent',
+      text: message,
+      at: Date.now(),
+    });
+  }
+
+  log('info', `[ac2] posted background-task completion into \`${parentThid}\` (${statusLabel}).`);
+}
+
+/**
+ * Test/tuning seam for the background-task completion poller. The readers are
+ * overridable so tests can inject a fake session store, and the timings can be
+ * shrunk so a watcher resolves within a test tick.
+ */
+export const subagentPolling: {
+  readStatus: typeof readChildSessionStatus;
+  readResult: typeof readChildResultText;
+  discover: typeof discoverChildSessionKey;
+  intervalMs: number;
+  maxWaitMs: number;
+} = {
+  readStatus: readChildSessionStatus,
+  readResult: readChildResultText,
+  discover: discoverChildSessionKey,
+  intervalMs: 2000,
+  maxWaitMs: 20 * 60 * 1000,
+};
+
+/**
+ * Child session keys already claimed by *other* tracked tasks, so discovery for
+ * one task never re-adopts a sibling task's child.
+ */
+function claimedChildKeys(exceptThid: string): Set<string> {
+  const claimed = new Set<string>();
+  for (const t of listTasks()) {
+    if (t.taskThid === exceptThid) continue;
+    if (t.childSessionKey) claimed.add(t.childSessionKey);
+  }
+  return claimed;
+}
+
+/**
+ * Resolve the child session key for a task: use the captured one, else try to
+ * discover it from the store by `spawnedBy === parentSessionKey`. Returns the
+ * key (and records it on the task) or `undefined` if it can't be resolved yet.
+ */
+function resolveTaskChildKey(task: Ac2Task): string | undefined {
+  if (task.childSessionKey) return task.childSessionKey;
+  const discovered = subagentPolling.discover({
+    ...(task.parentSessionKey !== undefined ? { parentSessionKey: task.parentSessionKey } : {}),
+    ...(task.agentId !== undefined ? { agentId: task.agentId } : {}),
+    excludeKeys: claimedChildKeys(task.taskThid),
+  });
+  if (discovered) {
+    attachSpawnResult(task.taskThid, { childSessionKey: discovered });
+    log(
+      'info',
+      `[ac2] discovered child session for background task \`${task.taskThid}\` via spawnedBy (${discovered}).`,
+    );
+  }
+  return discovered;
+}
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Task thids with an in-flight completion watcher (dedupe re-entry). */
+const watchedTasks = new Set<string>();
+
+/**
+ * Start polling a spawned background task's child session until it finishes,
+ * then deliver its result into the parent conversation ourselves. This is the
+ * PRIMARY completion path in the standalone pairing CLI.
+ *
+ * Why polling and not the `subagent_ended` hook: that hook only fires when the
+ * host's *global* hook runner has been initialized, which happens during a full
+ * gateway/server plugin-load boot. Our CLI hand-drives replies via
+ * `dispatchReplyWithBufferedBlockDispatcher` and never runs that boot, so the
+ * global runner stays null and `subagent_ended` is silently never dispatched to
+ * us (`emitSubagentEndedHookOnce` early-returns). The host's own completion
+ * "direct announce" also fails here because it needs a gateway request scope we
+ * don't have (hence the repeated `… gateway request scope …` warnings). What
+ * DOES happen regardless is that the host persists `status`/`endedAt` onto the
+ * child's session entry when the run ends — so we observe completion by polling
+ * that entry, then read the child's final assistant text from its transcript
+ * and deliver it over our own DataChannel.
+ *
+ * Idempotent per `taskThid`; safe to call for the same task more than once.
+ */
+export function watchTaskCompletion(taskThid: string): void {
+  if (watchedTasks.has(taskThid)) return;
+  watchedTasks.add(taskThid);
+  void pollTaskUntilComplete(taskThid).finally(() => watchedTasks.delete(taskThid));
+}
+
+/** Reset the in-flight watcher set (tests). */
+export function resetTaskWatchers(): void {
+  watchedTasks.clear();
+}
+
+async function pollTaskUntilComplete(taskThid: string): Promise<void> {
+  const deadline = Date.now() + subagentPolling.maxWaitMs;
+  const initial = getTaskByThid(taskThid);
+  log(
+    'info',
+    `[ac2] watching background task \`${taskThid}\` for completion (child=${initial?.childSessionKey ?? 'unknown, will discover'}, parent=${initial?.parentSessionKey ?? '?'}).`,
+  );
+  // Emit the store diagnostic at most once, the first time we cannot resolve the
+  // child session key, so a single failing run pinpoints any residual mismatch
+  // (store path / agent id / owner casing) instead of polling silently.
+  let diagLogged = false;
+  try {
+    while (Date.now() < deadline) {
+      const task = getTaskByThid(taskThid);
+      // Gone, or already reconciled by another path (e.g. the hook, if it ever
+      // fires, or a direct delivery). Nothing left to do.
+      if (!task || task.status !== 'running') return;
+      // Resolve the child session key: captured at spawn, or discovered from the
+      // store by `spawnedBy` when the accepted envelope never surfaced it.
+      const childSessionKey = resolveTaskChildKey(task);
+      if (childSessionKey) {
+        const st = subagentPolling.readStatus({
+          childSessionKey,
+          ...(task.agentId !== undefined ? { agentId: task.agentId } : {}),
+        });
+        if (st.ended) {
+          await finalizePolledTask({ ...task, childSessionKey }, st.status);
+          return;
+        }
+      } else if (!diagLogged) {
+        diagLogged = true;
+        log(
+          'warn',
+          `[ac2] background task \`${taskThid}\` child session not resolved yet — ${describeSubagentCandidates(
+            {
+              ...(task.parentSessionKey !== undefined
+                ? { parentSessionKey: task.parentSessionKey }
+                : {}),
+              ...(task.agentId !== undefined ? { agentId: task.agentId } : {}),
+            },
+          )}`,
+        );
+      }
+      await delay(subagentPolling.intervalMs);
+    }
+    log(
+      'info',
+      `[ac2] background task \`${taskThid}\` still running after the watch window; stopped polling.`,
+    );
+  } catch (err) {
+    log(
+      'warn',
+      `[ac2] background-task watcher error for \`${taskThid}\`: ${err instanceof Error ? err.message : err}`,
+    );
+  }
+}
+
+async function finalizePolledTask(task: Ac2Task, rawStatus?: string): Promise<void> {
+  const kind: 'completed' | 'failed' | 'stopped' =
+    rawStatus === 'failed' || rawStatus === 'timeout'
+      ? 'failed'
+      : rawStatus === 'killed'
+        ? 'stopped'
+        : 'completed';
+
+  // On success deliver the child's actual answer (its final assistant text);
+  // otherwise a plain lifecycle notice.
+  let message = completionMessage(taskDisplayTitle(task), kind);
+  if (kind === 'completed') {
+    const text = await subagentPolling.readResult({
+      ...(task.childSessionKey !== undefined ? { childSessionKey: task.childSessionKey } : {}),
+      ...(task.agentId !== undefined ? { agentId: task.agentId } : {}),
+    });
+    if (text) message = text;
+  }
+
+  // Re-check: a concurrent path may have reconciled the task while we awaited
+  // the transcript read.
+  const fresh = getTaskByThid(task.taskThid);
+  if (!fresh || fresh.status !== 'running') return;
+  markTaskResult(task.taskThid, kind, message);
+  // Flip the running task card in place to its terminal state with the child's
+  // result inline (the self-contained task card, not a separate reply bubble).
+  emitTaskCardUpdate({ thid: task.parentThid, task, status: kind, result: message });
+  log(
+    'info',
+    `[ac2] delivered polled background-task card into \`${task.parentThid}\` (${kind}).`,
+  );
+}
+
+/**
+ * Register the sub-agent lifecycle hooks on the host plugin api (idempotent).
+ *
+ * These are typed *plugin hooks* — they must be registered via `api.on(hookName,
+ * handler)` (the same surface Discord/Matrix use for `subagent_ended`), NOT via
+ * `api.registerHook(...)`, which targets the unrelated internal command/session/
+ * agent/gateway/message hook system and rejects these names ("hook registration
+ * missing name"). The `api.on` handler is invoked with `(event, ctx)`, matching
+ * our `handleSubagent*` signatures.
+ */
+let hooksRegistered = false;
+export function registerSubagentHooks(api: OpenClawApi): void {
+  if (hooksRegistered) return;
+  if (typeof api.on !== 'function') {
+    safeLog(api, 'warn', '[ac2] plugin api.on unavailable — subagent lifecycle hooks not registered.');
+    return;
+  }
+  try {
+    api.on(HOOK_SUBAGENT_SPAWNED, ((event: unknown, ctx: unknown) =>
+      handleSubagentSpawned(event, ctx)) as never);
+    api.on(HOOK_SUBAGENT_ENDED, ((event: unknown, ctx: unknown) =>
+      handleSubagentEnded(event, ctx)) as never);
+    hooksRegistered = true;
+  } catch (err) {
+    safeLog(api, 'error', `[ac2] api.on (subagent lifecycle) registration failed: ${err}`);
+  }
+}
+
+/** Test hook: allow re-registration in isolated tests. */
+export function resetSubagentHooksRegistration(): void {
+  hooksRegistered = false;
+}

--- a/packages/ac2-open-claw-reference/src/channel/subagent-result.ts
+++ b/packages/ac2-open-claw-reference/src/channel/subagent-result.ts
@@ -1,0 +1,322 @@
+/**
+ * Read a finished sub-agent ("background task") child's final result text.
+ *
+ * The host's own completion delivery cannot reach our standalone pairing CLI:
+ * the direct announce performs an in-process gateway `agent` dispatch that
+ * requires a gateway request scope we never have (no HTTP/WS listener), so it
+ * fails and retries until it gives up — the child's answer never arrives. That
+ * is the root cause behind "the task completes without any response".
+ *
+ * However, the child *does* persist its final assistant text to its own session
+ * transcript, and the public plugin SDK exposes readers for it. We use them to
+ * fetch the real answer from the child's session and deliver it ourselves over
+ * our DataChannel (see `subagent-hooks.ts`). This is best-effort: if the text
+ * cannot be read we fall back to a plain lifecycle notice.
+ */
+
+import {
+  getSessionEntry,
+  listSessionEntries,
+  readLatestAssistantTextFromSessionTranscript,
+  readRecentUserAssistantTextForSession,
+  resolveStorePath,
+} from 'openclaw/plugin-sdk/session-store-runtime';
+import { getRuntimeConfig } from 'openclaw/plugin-sdk/config-runtime';
+
+/** A host sub-agent child session key: `agent:<agentId>:subagent:<uuid>`. */
+const SUBAGENT_SESSION_KEY_RE = /^agent:[^:]+:subagent:/;
+
+/**
+ * Normalize a session key for equality matching against the value the host
+ * persists in a child entry's `spawnedBy`.
+ *
+ * CRITICAL: the host lower-cases session keys when it stores them (see
+ * `normalizeSessionKeyPreservingOpaquePeerIds` in the host runtime — everything
+ * is folded to lower-case *except* opaque peer segments for the `signal` and
+ * `matrix` channels, which are the only registered case-preserving peers). Our
+ * channel is `ac2`, so the ENTIRE key — including the mixed-case `did:key:`
+ * controller DID — is stored lower-cased (e.g. the host's own warning logs show
+ * `requester=ac2:did:key:z6mkk…:default`). Meanwhile the `parentSessionKey` we
+ * capture on a task is the ORIGINAL mixed-case `ac2:did:key:z6MkkMu6…:default`.
+ *
+ * Comparing those two raw strings with `!==` never matched, so
+ * `discoverChildSessionKey` silently found nothing every poll and the child's
+ * result was never delivered. Folding both sides to lower-case before comparing
+ * mirrors the host normalization for `ac2` keys and fixes the match.
+ */
+function normalizeSessionKeyForMatch(key: string | undefined): string {
+  return (key ?? '').trim().toLowerCase();
+}
+
+/**
+ * Test whether a child entry's recorded owner (`spawnedBy` / `parentSessionKey`)
+ * refers to the requester `wantNormalized` (already lower-cased via
+ * {@link normalizeSessionKeyForMatch}).
+ *
+ * CRITICAL: the host does not store the owner as the bare requester session key.
+ * It namespaces it with the child's agent, i.e. it persists
+ * `agent:<agentId>:<requesterSessionKey>` (the failing run's diagnostics showed
+ * `want="ac2:did:key:z6mkk…:default"` but stored
+ * `owners=[agent:main:ac2:did:key:z6mkk…:default]`). So even after the
+ * lower-casing fix, a raw `===` never matched and discovery kept spinning.
+ *
+ * We therefore accept a match when the normalized owner equals `want` OR when
+ * stripping a single leading `agent:<agentId>:` namespace prefix yields `want`.
+ * Our requester keys are always `ac2:…` (never start with `agent:`), so the
+ * prefix strip is unambiguous.
+ */
+function ownerMatchesRequester(
+  ownerRaw: string | undefined,
+  wantNormalized: string,
+): boolean {
+  if (!wantNormalized) return false;
+  const owner = normalizeSessionKeyForMatch(ownerRaw);
+  if (!owner) return false;
+  if (owner === wantNormalized) return true;
+  const stripped = owner.replace(/^agent:[^:]+:/, '');
+  return stripped === wantNormalized;
+}
+
+/**
+ * Extract the agent id embedded in a child session key. Host child keys look
+ * like `agent:<agentId>:subagent:<uuid>` (or `agent:<agentId>:acp:<uuid>`); the
+ * agent id is the second `:`-delimited segment.
+ */
+function agentIdFromSessionKey(key: string | undefined): string | undefined {
+  if (!key) return undefined;
+  const match = /^agent:([^:]+):/.exec(key);
+  return match?.[1];
+}
+
+/**
+ * Resolve the on-disk session store path EXACTLY as the host does when it
+ * persists a sub-agent's timing/transcript (`persistSubagentSessionTiming`):
+ * `resolveStorePath(getRuntimeConfig().session?.store, { agentId })`.
+ *
+ * This must match the host, otherwise our reads look in the wrong directory.
+ * We previously passed `undefined` for the configured store, which silently
+ * resolves the DEFAULT store — so any deployment that sets a custom
+ * `session.store` in its OpenClaw config would never let us observe the child's
+ * completion status or read its result, and the completion poller would spin
+ * until it timed out. Reading the store from the same in-process runtime-config
+ * snapshot the host uses fixes that.
+ */
+function resolveChildStorePath(agentId?: string): string | undefined {
+  let configuredStore: string | undefined;
+  try {
+    const cfg = getRuntimeConfig() as { session?: { store?: string } } | undefined;
+    configuredStore = cfg?.session?.store;
+  } catch {
+    configuredStore = undefined;
+  }
+  return resolveStorePath(configuredStore, agentId ? { agentId } : {});
+}
+
+/** Terminal (finished) sub-agent run statuses persisted on the child entry. */
+const TERMINAL_STATUSES = new Set(['done', 'failed', 'killed', 'timeout']);
+
+/** A snapshot of a child sub-agent session's persisted run status. */
+export interface ChildSessionStatus {
+  /** True once the child's session entry exists in the store. */
+  exists: boolean;
+  /** True once the run has finished (terminal status or an `endedAt` stamp). */
+  ended: boolean;
+  /** The persisted run status, when written. */
+  status?: 'running' | 'done' | 'failed' | 'killed' | 'timeout';
+}
+
+/**
+ * Read a child sub-agent session's *persisted* run status from the session
+ * store. This is the reliable, gateway-independent completion signal: when a
+ * sub-agent run ends, the host writes `status`/`endedAt` onto the child's
+ * `SessionEntry` (see `persistSubagentSessionTiming` in the host runtime), even
+ * though its own announce/delivery path fails in our no-gateway pairing CLI.
+ *
+ * `readConsistency: 'latest'` forces a fresh read so we observe the completion
+ * write promptly rather than a cached in-memory snapshot.
+ */
+export function readChildSessionStatus(opts: {
+  childSessionKey?: string;
+  agentId?: string;
+}): ChildSessionStatus {
+  const sessionKey = opts.childSessionKey;
+  if (!sessionKey) return { exists: false, ended: false };
+  const agentId = opts.agentId ?? agentIdFromSessionKey(sessionKey);
+  try {
+    const storePath = resolveChildStorePath(agentId);
+    const entry = getSessionEntry({
+      sessionKey,
+      readConsistency: 'latest',
+      ...(agentId ? { agentId } : {}),
+      ...(storePath ? { storePath } : {}),
+    });
+    if (!entry) return { exists: false, ended: false };
+    const status = entry.status;
+    const ended =
+      (typeof status === 'string' && TERMINAL_STATUSES.has(status)) ||
+      typeof entry.endedAt === 'number';
+    return { exists: true, ended, ...(status ? { status } : {}) };
+  } catch {
+    return { exists: false, ended: false };
+  }
+}
+
+/**
+ * Discover a spawned child's session key by scanning the agent's session store
+ * for a sub-agent session whose `spawnedBy` equals the parent session key.
+ *
+ * This is the fallback used when the accepted `sessions_spawn` envelope never
+ * surfaced a `childSessionKey` to us (e.g. the reply dispatcher did not invoke
+ * `onToolResult` for the spawn, or wrapped the accepted payload in an
+ * unexpected shape). The host stamps the requester/parent session key onto every
+ * child entry's `spawnedBy`, so a match is precise to this exact conversation.
+ * When several children were spawned from the same parent we prefer the most
+ * recently started one that has not already been claimed (`excludeKeys`), so
+ * concurrent tasks on one thread don't collide.
+ */
+export function discoverChildSessionKey(opts: {
+  parentSessionKey?: string;
+  agentId?: string;
+  excludeKeys?: Iterable<string>;
+}): string | undefined {
+  const parentSessionKey = opts.parentSessionKey?.trim();
+  if (!parentSessionKey) return undefined;
+  const wantSpawnedBy = normalizeSessionKeyForMatch(parentSessionKey);
+  const exclude = new Set(opts.excludeKeys ?? []);
+  try {
+    const agentId = opts.agentId;
+    const storePath = resolveChildStorePath(agentId);
+    const entries = listSessionEntries({
+      ...(agentId ? { agentId } : {}),
+      ...(storePath ? { storePath } : {}),
+    });
+    let bestKey: string | undefined;
+    let bestAt = -1;
+    for (const summary of entries) {
+      const sessionKey = summary?.sessionKey;
+      const entry = summary?.entry as
+        | {
+            spawnedBy?: string;
+            parentSessionKey?: string;
+            startedAt?: number;
+            lastInteractionAt?: number;
+          }
+        | undefined;
+      if (!sessionKey || !entry) continue;
+      if (!SUBAGENT_SESSION_KEY_RE.test(sessionKey)) continue;
+      // The host records the requester on `spawnedBy` and/or `parentSessionKey`
+      // (both are checked by its own `sessionEntryIsOwnedByRequester`); match
+      // either, normalized to mirror the host's lower-casing of `ac2` keys and
+      // tolerating the `agent:<agentId>:` namespace prefix the host prepends.
+      const owner =
+        ownerMatchesRequester(entry.spawnedBy, wantSpawnedBy) ||
+        ownerMatchesRequester(entry.parentSessionKey, wantSpawnedBy);
+      if (!owner) continue;
+      if (exclude.has(sessionKey)) continue;
+      const at =
+        typeof entry.startedAt === 'number'
+          ? entry.startedAt
+          : typeof entry.lastInteractionAt === 'number'
+            ? entry.lastInteractionAt
+            : 0;
+      if (at >= bestAt) {
+        bestAt = at;
+        bestKey = sessionKey;
+      }
+    }
+    return bestKey;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Human-readable summary of the sub-agent child sessions currently in the store,
+ * used purely for diagnostics when `discoverChildSessionKey` fails to find a
+ * match. Reports how many sub-agent entries exist and (normalized) `spawnedBy` /
+ * `parentSessionKey` owners we saw, next to the owner we were looking for — so a
+ * single failing run makes any residual mismatch (store path, agent id, key
+ * shape) immediately obvious in the logs. Best-effort; never throws.
+ */
+export function describeSubagentCandidates(opts: {
+  parentSessionKey?: string;
+  agentId?: string;
+}): string {
+  const want = normalizeSessionKeyForMatch(opts.parentSessionKey);
+  try {
+    const agentId = opts.agentId;
+    const storePath = resolveChildStorePath(agentId);
+    const entries = listSessionEntries({
+      ...(agentId ? { agentId } : {}),
+      ...(storePath ? { storePath } : {}),
+    });
+    const owners: string[] = [];
+    let subagentCount = 0;
+    for (const summary of entries) {
+      const sessionKey = summary?.sessionKey;
+      if (!sessionKey || !SUBAGENT_SESSION_KEY_RE.test(sessionKey)) continue;
+      subagentCount += 1;
+      const entry = summary?.entry as
+        | { spawnedBy?: string; parentSessionKey?: string }
+        | undefined;
+      const owner = entry?.spawnedBy ?? entry?.parentSessionKey;
+      if (owner) owners.push(normalizeSessionKeyForMatch(owner));
+    }
+    const sample = owners.slice(0, 5).join(', ') || '(none)';
+    return `store=${storePath ?? '(default)'} subagentEntries=${subagentCount} want="${want}" owners=[${sample}]`;
+  } catch (err) {
+    return `diagnostics unavailable: ${err instanceof Error ? err.message : String(err)}`;
+  }
+}
+
+/**
+ * Fetch the child's final assistant text from its session transcript. Returns
+ * `undefined` when the session/text cannot be resolved (any failure is
+ * swallowed — the caller falls back to a lifecycle notice).
+ */
+export async function readChildResultText(opts: {
+  childSessionKey?: string;
+  agentId?: string;
+}): Promise<string | undefined> {
+  const sessionKey = opts.childSessionKey;
+  if (!sessionKey) return undefined;
+  const agentId = opts.agentId ?? agentIdFromSessionKey(sessionKey);
+
+  try {
+    const storePath = resolveChildStorePath(agentId);
+    const read = {
+      sessionKey,
+      readConsistency: 'latest' as const,
+      ...(agentId ? { agentId } : {}),
+      ...(storePath ? { storePath } : {}),
+    };
+
+    // Preferred: resolve the transcript file and read its latest assistant text.
+    const entry = getSessionEntry(read);
+    const sessionFile = entry?.sessionFile;
+    if (sessionFile) {
+      const latest = await readLatestAssistantTextFromSessionTranscript(sessionFile);
+      const text = latest?.text?.trim();
+      if (text) return text;
+    }
+
+    // Fallback: pull recent turns for the session key and take the last
+    // assistant message (this reader does not accept `readConsistency`).
+    const recent = await readRecentUserAssistantTextForSession({
+      sessionKey,
+      limit: 20,
+      ...(agentId ? { agentId } : {}),
+      ...(storePath ? { storePath } : {}),
+    });
+    for (let i = recent.length - 1; i >= 0; i -= 1) {
+      const item = recent[i];
+      if (item?.role === 'assistant') {
+        const text = item.text?.trim();
+        if (text) return text;
+      }
+    }
+  } catch {
+    // Any read failure → no text; the caller posts a lifecycle notice instead.
+  }
+  return undefined;
+}

--- a/packages/ac2-open-claw-reference/src/channel/task-card.ts
+++ b/packages/ac2-open-claw-reference/src/channel/task-card.ts
@@ -1,0 +1,62 @@
+/**
+ * Deliver a background-task ("`sessions_spawn`") card into a wallet thread.
+ *
+ * A task card is a self-contained sub-agent run: the spawning turn emits it as
+ * `running` (in `routing.ts`) and, when the child finishes, the completion path
+ * re-emits the SAME card id with a terminal `status` and the child's `result`
+ * text inline — so the wallet renders one card that flips from running to
+ * done/failed with the answer inside it, rather than a static "running…" card
+ * plus a disconnected reply bubble.
+ *
+ * This helper is the *completion*-side emitter (the spawn side lives inline in
+ * `routing.ts` where the turn already has a transport + requestId). It resolves
+ * the active session's control-frame surface (the dedicated `ac2-stream`
+ * channel when negotiated, else the main transport — see
+ * `resolveControlSendable`), emits the `task` frame over it, and persists the
+ * card to the thread's history so it survives a reconnect.
+ */
+
+import { sessionManager } from '../session/manager.js';
+import { recordTaskActivity } from '../identity/state.js';
+import { resolveControlSendable, sendTaskCard, type Ac2TaskCardStatus } from './stream.js';
+import { taskCardId, taskDisplayTitle, type Ac2Task } from './tasks.js';
+
+/**
+ * Emit/refresh a task card for `task` into `thid` with `status` and (optionally)
+ * the child's `result` text. Best-effort; never throws.
+ */
+export function emitTaskCardUpdate(params: {
+  thid: string;
+  task: Ac2Task;
+  status: Ac2TaskCardStatus;
+  result?: string;
+}): void {
+  const active = sessionManager.getActive();
+  if (!active) return;
+
+  const id = taskCardId(params.task.taskThid);
+  const title = taskDisplayTitle(params.task);
+  const prompt = params.task.task;
+  const card = {
+    id,
+    title,
+    status: params.status,
+    ...(prompt && prompt.length > 0 ? { prompt } : {}),
+    ...(params.result !== undefined ? { result: params.result } : {}),
+  };
+
+  // Re-emit the SAME card id so the wallet upserts the running card in place to
+  // its terminal state. Send over the dedicated stream channel when present,
+  // else over the main transport (the wallet parses STX control frames on
+  // either, and the spawning turn rendered the initial `running` card the same
+  // way). We must never downgrade to a raw `transport.send(result)` here: that
+  // posts a disconnected reply bubble and leaves the task card stuck `running`.
+  const control = resolveControlSendable(active);
+  if (control) {
+    sendTaskCard(control, params.thid, card);
+  }
+
+  if (active.requestId) {
+    recordTaskActivity(active.requestId, params.thid, card);
+  }
+}

--- a/packages/ac2-open-claw-reference/src/channel/tasks.ts
+++ b/packages/ac2-open-claw-reference/src/channel/tasks.ts
@@ -1,0 +1,252 @@
+/**
+ * Sub-agent ("background task") registry.
+ *
+ * The OpenClaw host runs each `sessions_spawn` child in its own isolated
+ * session (`agent:<agentId>:subagent:<uuid>`) on the `subagent` lane and, when
+ * the child finishes, delivers its result back to the requester session as a
+ * *separate* host-initiated turn — never inline through the spawning turn's
+ * reply stream. To surface that work in the wallet we mirror each child as a
+ * first-class "task" with a lifecycle (`running` → `completed`/`failed`) so its
+ * completion follow-up can be delivered back into the parent conversation.
+ *
+ * `taskThid` is a stable, human-friendly registry *key* (`task-<name|run>`); it
+ * is no longer a distinct wallet conversation. Background work is surfaced
+ * inline in the parent thread (the app renders it via a task indicator), so the
+ * completion is posted to `parentThid` — there is no dedicated `task-…` thread.
+ *
+ * This registry is intentionally in-memory and process-scoped (like
+ * `activeThreadByConnection` in `conversation.ts`): a single wallet owns a
+ * single DataChannel, so a module-level map is sufficient. Durable task history
+ * still flows through the normal per-thread persistence in `identity/state.ts`.
+ */
+
+/** Prefix for every synthetic background-task thread id. */
+export const TASK_THREAD_PREFIX = 'task-';
+
+/** Lifecycle of a tracked background task. */
+export type Ac2TaskStatus = 'running' | 'completed' | 'failed' | 'stopped';
+
+/** A single tracked sub-agent run. */
+export interface Ac2Task {
+  /** Registry key for this task (`task-<name|run>`); not a wallet conversation. */
+  taskThid: string;
+  /** The parent conversation `thid` the `sessions_spawn` tool call ran in; where
+   * the task card and its completion follow-up are shown. */
+  parentThid: string;
+  /** The full parent session key (`ac2:<controllerDid>:<thid>`) the spawn ran
+   * under. The host stamps this onto the child entry's `spawnedBy`, so it lets
+   * us discover the child session key when the accepted-spawn envelope did not
+   * surface it (see `discoverChildSessionKey`). */
+  parentSessionKey?: string;
+  /** The delegated task prompt (`sessions_spawn` `task` arg). */
+  task: string;
+  /** Host run id from the accepted spawn envelope, once known. */
+  runId?: string;
+  /** Host child session key from the accepted spawn envelope, once known. */
+  childSessionKey?: string;
+  /** Model-facing stable handle (`sessions_spawn` `taskName` arg). */
+  taskName?: string;
+  /** Human-readable label (`sessions_spawn` `label` arg). */
+  label?: string;
+  /** Target agent id when the child runs under another configured agent. */
+  agentId?: string;
+  /** Current lifecycle status. */
+  status: Ac2TaskStatus;
+  /** Latest visible result/announce text from the child, once delivered. */
+  resultText?: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+const tasksByThid = new Map<string, Ac2Task>();
+
+/** Sanitize a candidate label into a thread-id-safe slug. */
+function slug(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+}
+
+/**
+ * Derive a stable, human-friendly task thread id from the available handles.
+ * Prefers an explicit `taskName`, then a `label`, then a short `runId`, and
+ * finally a monotonic fallback so two anonymous spawns never collide.
+ */
+let anonSeq = 0;
+export function deriveTaskThid(opts: {
+  taskName?: string;
+  label?: string;
+  runId?: string;
+}): string {
+  const fromName = opts.taskName ? slug(opts.taskName) : '';
+  if (fromName) return `${TASK_THREAD_PREFIX}${fromName}`;
+  const fromLabel = opts.label ? slug(opts.label) : '';
+  if (fromLabel) return `${TASK_THREAD_PREFIX}${fromLabel}`;
+  const fromRun = opts.runId ? slug(opts.runId).slice(0, 12) : '';
+  if (fromRun) return `${TASK_THREAD_PREFIX}${fromRun}`;
+  anonSeq += 1;
+  return `${TASK_THREAD_PREFIX}${anonSeq}`;
+}
+
+/** True for any thread id this registry owns (a `task-…` thread). */
+export function isTaskThid(thid: string): boolean {
+  return thid.startsWith(TASK_THREAD_PREFIX);
+}
+
+/**
+ * Stable id for a task's wallet card. Both the spawning turn (which renders the
+ * initial `running` card) and the completion path (which flips it to
+ * `completed`/`failed`/`stopped` and attaches the result) derive the SAME id
+ * from `taskThid`, so the wallet upserts one card in place across its lifecycle
+ * instead of appending a second one on completion.
+ */
+export function taskCardId(taskThid: string): string {
+  return `task:${taskThid}`;
+}
+
+/**
+ * Register (or update) a task from a `sessions_spawn` observation. Idempotent
+ * on `taskThid`: a later call carrying the accepted `runId`/`childSessionKey`
+ * enriches the existing record instead of creating a duplicate.
+ */
+export function registerTask(input: {
+  parentThid: string;
+  task: string;
+  parentSessionKey?: string;
+  taskName?: string;
+  label?: string;
+  agentId?: string;
+  runId?: string;
+  childSessionKey?: string;
+}): Ac2Task {
+  const taskThid = deriveTaskThid({
+    ...(input.taskName !== undefined ? { taskName: input.taskName } : {}),
+    ...(input.label !== undefined ? { label: input.label } : {}),
+    ...(input.runId !== undefined ? { runId: input.runId } : {}),
+  });
+  const now = Date.now();
+  const existing = tasksByThid.get(taskThid);
+  const task: Ac2Task = existing
+    ? {
+        ...existing,
+        updatedAt: now,
+        ...(input.parentSessionKey !== undefined
+          ? { parentSessionKey: input.parentSessionKey }
+          : {}),
+        ...(input.runId !== undefined ? { runId: input.runId } : {}),
+        ...(input.childSessionKey !== undefined
+          ? { childSessionKey: input.childSessionKey }
+          : {}),
+        ...(input.agentId !== undefined ? { agentId: input.agentId } : {}),
+      }
+    : {
+        taskThid,
+        parentThid: input.parentThid,
+        task: input.task,
+        status: 'running',
+        createdAt: now,
+        updatedAt: now,
+        ...(input.parentSessionKey !== undefined
+          ? { parentSessionKey: input.parentSessionKey }
+          : {}),
+        ...(input.taskName !== undefined ? { taskName: input.taskName } : {}),
+        ...(input.label !== undefined ? { label: input.label } : {}),
+        ...(input.agentId !== undefined ? { agentId: input.agentId } : {}),
+        ...(input.runId !== undefined ? { runId: input.runId } : {}),
+        ...(input.childSessionKey !== undefined
+          ? { childSessionKey: input.childSessionKey }
+          : {}),
+      };
+  tasksByThid.set(taskThid, task);
+  return task;
+}
+
+/** Enrich an existing task in place with the accepted spawn envelope. */
+export function attachSpawnResult(
+  taskThid: string,
+  patch: { runId?: string; childSessionKey?: string; agentId?: string },
+): Ac2Task | undefined {
+  const existing = tasksByThid.get(taskThid);
+  if (!existing) return undefined;
+  const updated: Ac2Task = {
+    ...existing,
+    updatedAt: Date.now(),
+    ...(patch.runId !== undefined ? { runId: patch.runId } : {}),
+    ...(patch.childSessionKey !== undefined ? { childSessionKey: patch.childSessionKey } : {}),
+    ...(patch.agentId !== undefined ? { agentId: patch.agentId } : {}),
+  };
+  tasksByThid.set(taskThid, updated);
+  return updated;
+}
+
+/** A short, human-facing title for a task (label → name → derived id). */
+export function taskDisplayTitle(task: Ac2Task): string {
+  return (
+    task.label ??
+    task.taskName ??
+    `Task ${task.taskThid.slice(TASK_THREAD_PREFIX.length)}`
+  );
+}
+
+/** Look up a task by its synthetic thread id. */
+export function getTaskByThid(taskThid: string): Ac2Task | undefined {
+  return tasksByThid.get(taskThid);
+}
+
+/** Look up a task by host run id or child session key (announce correlation). */
+export function findTaskByRun(opts: {
+  runId?: string;
+  childSessionKey?: string;
+}): Ac2Task | undefined {
+  for (const task of tasksByThid.values()) {
+    if (opts.runId && task.runId === opts.runId) return task;
+    if (opts.childSessionKey && task.childSessionKey === opts.childSessionKey) return task;
+  }
+  return undefined;
+}
+
+/**
+ * Best-effort correlation for a completion announce that only tells us the
+ * parent thread it is being delivered into: return the most recently updated
+ * still-`running` task spawned from that parent.
+ */
+export function findPendingTaskForParent(parentThid: string): Ac2Task | undefined {
+  let best: Ac2Task | undefined;
+  for (const task of tasksByThid.values()) {
+    if (task.parentThid !== parentThid || task.status !== 'running') continue;
+    if (!best || task.updatedAt >= best.updatedAt) best = task;
+  }
+  return best;
+}
+
+/** Record a terminal result on a task. */
+export function markTaskResult(
+  taskThid: string,
+  status: Exclude<Ac2TaskStatus, 'running'>,
+  resultText?: string,
+): Ac2Task | undefined {
+  const existing = tasksByThid.get(taskThid);
+  if (!existing) return undefined;
+  const updated: Ac2Task = {
+    ...existing,
+    status,
+    updatedAt: Date.now(),
+    ...(resultText !== undefined ? { resultText } : {}),
+  };
+  tasksByThid.set(taskThid, updated);
+  return updated;
+}
+
+/** All tracked tasks, most-recently-updated first. */
+export function listTasks(): Ac2Task[] {
+  return Array.from(tasksByThid.values()).sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+/** Test/reset hook: drop all tracked tasks. */
+export function resetTasks(): void {
+  tasksByThid.clear();
+  anonSeq = 0;
+}

--- a/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
+++ b/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
@@ -4,6 +4,7 @@ import qrcode from 'qrcode-terminal';
 import { Ac2Client } from '@algorandfoundation/ac2-sdk';
 import { isValidAddress } from '@algorandfoundation/algokit-utils/common';
 import { resolveConfig, safeLog, type OpenClawApi } from '../runtime.js';
+import { readChannelStatus } from '../setup/config.js';
 import { BootstrapError, bootstrapAgentIdentity } from '../session/bootstrap.js';
 import type { ChannelContext } from '../session/contracts.js';
 import { sessionManager } from '../session/manager.js';
@@ -17,7 +18,8 @@ import {
   setConnectionIdentity,
   touchConnection,
 } from '../identity/state.js';
-import { normalizeDidKey } from '../identity/did.js';
+import { normalizeDidKey, resolveStableControllerDid } from '../identity/did.js';
+import { decideControllerBinding } from '../identity/binding.js';
 import {
   clearAgentIdentities,
   hasAgentIdentity,
@@ -29,23 +31,58 @@ import {
   replayConversationHistory,
   replayConversationList,
   routeInboundToAgent,
-  sendFinalize,
+  sendNotice,
   setActiveConversation,
   warmUpAgent,
 } from '../channel/index.js';
 
-/** Chat notice shown when the wallet has not granted the agent an identity. */
+/**
+ * Banner notice shown when the wallet has not granted the agent an identity
+ * yet. Surfaced only as a banner (not a chat message), so the wallet can also
+ * block new messages until an identity is granted. Kept short.
+ */
 const NO_IDENTITY_NOTICE =
-  "I don't have an identity yet. To work with you securely I need my own " +
-  'dedicated key — a `did:key` identity your wallet issues to me. It lets me ' +
-  'prove who I am on this channel and sign my own messages, and it is kept ' +
-  'separate from your personal accounts and keys (I never see or use those). ' +
-  'Until you grant one, I can chat with you but cannot perform signing-related ' +
-  'actions. When you are ready, approve the identity request in your wallet to ' +
-  'continue.';
+  "This agent has no identity yet and isn't registered to this wallet. Approve " +
+  'the identity request in your wallet to register and start chatting.';
+
+/**
+ * Banner notice shown when a *different* controller (wallet) connects to an
+ * agent that is already registered to another one. The agent refuses to be
+ * taken over: it will not reuse or regenerate its identity for the new wallet.
+ * To let a new wallet take over, the operator must clear the agent's keys
+ * (`ac2 forget`). Kept short — it is surfaced only as a banner, not a chat
+ * message.
+ */
+const CONTROLLER_LOCKED_NOTICE =
+  "This agent is already registered to another wallet and won't switch " +
+  'automatically. To let this wallet take over, the operator must clear the ' +
+  'agent keys on the server (`ac2 forget`).';
 
 const NODE_MODULE_LOAD_ERROR_CODES = new Set(['ERR_MODULE_NOT_FOUND', 'MODULE_NOT_FOUND']);
 const ROAMHQ_WRTC_PACKAGE_PATTERN = /@roamhq\/wrtc(?:-[a-z0-9-]+)?/i;
+
+/**
+ * Decide whether to seed the *stable* connection id from a freshly-minted
+ * Liquid Auth `requestId`.
+ *
+ * The Liquid Auth `requestId` is a one-shot pairing nonce: once a wallet has
+ * linked and the WebRTC session has been established, that same id can no
+ * longer be re-linked. We therefore let the provider mint a fresh `requestId`
+ * on every pairing cycle, but keep a single stable connection id — seeded from
+ * the very first pairing — to key on-disk persistence (identity, conversation
+ * history). Only seed it when one is not already persisted, so reconnects never
+ * rotate the connection id (and never orphan its history).
+ */
+export function shouldSeedConnectionId(
+  persistedConnectionId: string | undefined,
+  usedRequestId: unknown,
+): usedRequestId is string {
+  return (
+    (persistedConnectionId === undefined || persistedConnectionId.length === 0) &&
+    typeof usedRequestId === 'string' &&
+    usedRequestId.length > 0
+  );
+}
 
 export function isMissingWebRtcError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
@@ -92,12 +129,27 @@ export function buildAc2Command(api: OpenClawApi): unknown {
       const sub = tokens[0] ?? 'pair';
 
       if (sub === 'status') {
+        const channelStatus = readChannelStatus();
         const active = sessionManager.getActive();
-        const lines = ['Channel: ac2', `Online: ${active ? 'yes' : 'no'}`];
+        const lines = [
+          'Channel: ac2',
+          `Config: ${channelStatus.configPath}`,
+          `Plugin allow-listed: ${channelStatus.pluginAllowed ? 'yes' : 'no'}`,
+          `Plugin enabled: ${channelStatus.pluginEnabled ? 'yes' : 'no'}`,
+          `Bound to agent: ${channelStatus.bound ? 'yes' : 'no'}`,
+          `Ready: ${channelStatus.ready ? 'yes' : 'no'}`,
+          `Liquid Auth server: ${channelStatus.liquidAuthServer} (${channelStatus.liquidAuthServerSource})`,
+          `Online: ${active ? 'yes' : 'no'}`,
+        ];
         if (active) {
           lines.push(`Agent DID: ${active.agentDid}`);
           lines.push(`Controller DID: ${active.controllerDid}`);
           if (active.requestId) lines.push(`Connection: ${active.requestId}`);
+          if (active.locked) {
+            lines.push(
+              'Locked: yes (a different wallet is connecting; run `ac2 forget` to re-register)',
+            );
+          }
         }
         const connections = listConnections();
         lines.push(`Known connections: ${connections.length}`);
@@ -152,21 +204,43 @@ export function buildAc2Command(api: OpenClawApi): unknown {
         const startPairingCycle = async (): Promise<{
           pairing: import('@algorandfoundation/ac2-sdk/signaling').Ac2PairingInfo;
           connect: () => Promise<import('@algorandfoundation/ac2-sdk/signaling').Ac2PairedChannel>;
+          /** Whether the provider's persistent signaling socket is still live. */
+          isSignalingAlive: () => boolean;
+          /** Fully tear down the provider's signaling socket + peer. */
+          dispose: () => Promise<void>;
           qrString: string;
         }> => {
-          // Reuse a persisted requestId so the wallet reconnects to the same connection.
-          const persistedRequestId = loadAc2State().requestId;
+          // Reuse the persisted Liquid Auth requestId across pairing cycles so
+          // a previously-paired wallet can reconnect without re-running its
+          // FIDO2 passkey assertion — mirroring the debug app, which keeps a
+          // stable requestId and just renegotiates. The signaling server now
+          // supports reconnecting on the same requestId (presence + `auth`
+          // re-announce + an always-waiting `link`), so the id is no longer a
+          // one-shot nonce: the wallet remembers the requestId it authenticated
+          // for and re-links to it, and the server re-announces the wallet's
+          // `auth` so this offer side resolves and both peers just renegotiate
+          // the WebRTC session (no new passkey). On the very first pairing there
+          // is nothing persisted yet, so the provider mints a fresh id which is
+          // then seeded as the stable connection id (see `shouldSeedConnectionId`)
+          // and reused on every subsequent cycle.
+          const persistedConnectionId = loadAc2State().requestId;
           const { LiquidAuthChannelProvider } = await import('../providers/liquid-auth.js');
           const provider: import('@algorandfoundation/ac2-sdk/signaling').Ac2ChannelProvider =
             new LiquidAuthChannelProvider({
               origin,
-              ...(persistedRequestId ? { requestId: persistedRequestId } : {}),
+              ...(persistedConnectionId ? { requestId: persistedConnectionId } : {}),
             });
-          const handle = await provider.startPairing({
+          // Cast to surface the LiquidAuth provider's optional persistent-
+          // signaling lifecycle hooks (the base `Ac2ChannelProvider` return
+          // type omits them). Optional so any other provider still works.
+          const handle = (await provider.startPairing({
             timeoutMs: cfg.defaultTimeoutMs ?? 120_000,
-          });
+          })) as import('@algorandfoundation/ac2-sdk/signaling').Ac2PairingHandle & {
+            isSignalingAlive?(): boolean;
+            dispose?(): Promise<void>;
+          };
           const usedRequestId = handle.pairing.metadata?.['requestId'];
-          if (typeof usedRequestId === 'string' && usedRequestId.length > 0) {
+          if (shouldSeedConnectionId(persistedConnectionId, usedRequestId)) {
             saveAc2State({ requestId: usedRequestId });
           }
           const qr = await new Promise<string>((resolve) => {
@@ -174,7 +248,16 @@ export function buildAc2Command(api: OpenClawApi): unknown {
               resolve(rendered);
             });
           });
-          return { pairing: handle.pairing, connect: handle.connect, qrString: qr };
+          return {
+            pairing: handle.pairing,
+            connect: handle.connect,
+            // Fall back gracefully for providers that don't expose the optional
+            // persistent-signaling lifecycle hooks (e.g. an in-memory provider):
+            // treat signaling as never-reusable so the loop always rebuilds.
+            isSignalingAlive: () => handle.isSignalingAlive?.() ?? false,
+            dispose: () => handle.dispose?.() ?? Promise.resolve(),
+            qrString: qr,
+          };
         };
 
         const buildInvitationText = (
@@ -245,21 +328,71 @@ export function buildAc2Command(api: OpenClawApi): unknown {
             const connectedAccountDid =
               connectedAccount !== undefined
                 ? normalizeDidKey(`did:key:${connectedAccount}`)
-                : connected.peer?.did;
+                : connected.peer?.did !== undefined
+                  ? normalizeDidKey(connected.peer.did)
+                  : undefined;
 
             // Reuse a stored identity for this connection, otherwise bootstrap.
             const storedIdentity =
               (connectionRequestId
                 ? loadAc2State().connections?.[connectionRequestId]?.identity
                 : undefined) ?? loadAc2State().identity;
+            // The controller this agent install is already registered to (the
+            // first wallet that ever granted it an identity). A *different*
+            // controller must not be able to take over — see `decideControllerBinding`.
+            const boundControllerDid = loadAc2State().identity?.controllerDid
+              ? normalizeDidKey(loadAc2State().identity!.controllerDid)
+              : undefined;
+            const bindingDecision = decideControllerBinding({
+              boundControllerDid,
+              connectedAccountDid,
+              hasStoredIdentity: storedIdentity !== undefined,
+            });
             // Placeholders — overridden on a granted identity, else session goes active
             // with `identityGranted = false` so the agent can explain.
             let agentDid = 'did:ac2:agent';
             let controllerDid = connectedAccountDid ?? 'did:key:zAc2Controller';
             let identityGranted = true;
-            if (storedIdentity) {
+            let locked = false;
+            if (bindingDecision === 'locked') {
+              // A different wallet is connecting to an already-registered agent.
+              // Refuse the takeover: do NOT reuse the bound identity and do NOT
+              // bootstrap a fresh one. Route the (blocked) session under the
+              // foreign controller's own DID so nothing can touch the bound
+              // controller's OpenClaw session/context.
+              locked = true;
+              identityGranted = false;
+              controllerDid = connectedAccountDid ?? 'did:key:zAc2Controller';
+              safeLog(
+                api,
+                'warn',
+                `[ac2] Refusing controller ${connectedAccountDid} — agent is already registered ` +
+                  `to ${boundControllerDid}. Operator must clear keys (\`ac2 forget\`) to re-register.`,
+              );
+            } else if (bindingDecision === 'reuse' && storedIdentity) {
               ({ agentDid } = storedIdentity);
-              controllerDid = connectedAccountDid ?? storedIdentity.controllerDid;
+              // Anchor the session key (`ac2:<controllerDid>:<thid>`) to the
+              // identity bound at grant time so a presence-only reconnect —
+              // which may omit the wallet address and fall back to a
+              // differently-encoded peer DID — cannot rotate `controllerDid`
+              // and make the agent reload a different, empty OpenClaw session
+              // (i.e. "forget" the thread's context).
+              controllerDid = resolveStableControllerDid({
+                storedControllerDid: storedIdentity.controllerDid,
+                connectedAccountDid,
+              });
+              if (
+                connectedAccountDid !== undefined &&
+                connectedAccountDid !== storedIdentity.controllerDid
+              ) {
+                safeLog(
+                  api,
+                  'warn',
+                  `[ac2] linked account ${connectedAccountDid} differs from the granted ` +
+                    `controller ${storedIdentity.controllerDid}; keeping the granted identity ` +
+                    'to preserve conversation context.',
+                );
+              }
               // Migrate legacy plaintext material into the keystore.
               if (storedIdentity.material && !hasAgentIdentity(agentDid)) {
                 await recordAgentIdentity({
@@ -322,21 +455,6 @@ export function buildAc2Command(api: OpenClawApi): unknown {
                 }
               }
             }
-            sessionManager.setActive({
-              transport,
-              client,
-              controllerDid,
-              agentDid,
-              identityGranted,
-              ...(walletAddress ? { walletAddress } : {}),
-              ...(connectionRequestId ? { requestId: connectionRequestId } : {}),
-            });
-            safeLog(
-              api,
-              'info',
-              `[ac2] Channel paired and active. agentDid=${agentDid} controllerDid=${controllerDid}`,
-            );
-
             // Adapter to give `streamChannel` a `send` + `isOpen` surface.
             const streamSendable = streamTransport
               ? {
@@ -347,6 +465,26 @@ export function buildAc2Command(api: OpenClawApi): unknown {
               }
               : undefined;
             const controlSendable = streamSendable ?? transport;
+
+            sessionManager.setActive({
+              transport,
+              client,
+              controllerDid,
+              agentDid,
+              identityGranted,
+              locked,
+              // The stream control surface used by host-initiated outbound sends
+              // (e.g. sub-agent completion announces) to emit thread-scoped
+              // `finalize` frames instead of raw, thread-less transport writes.
+              ...(streamSendable ? { controlTransport: streamSendable } : {}),
+              ...(walletAddress ? { walletAddress } : {}),
+              ...(connectionRequestId ? { requestId: connectionRequestId } : {}),
+            });
+            safeLog(
+              api,
+              'info',
+              `[ac2] Channel paired and active. agentDid=${agentDid} controllerDid=${controllerDid}`,
+            );
 
             client.updateHandlers({
               'ac2/ConversationOpen': (msg) => {
@@ -379,17 +517,33 @@ export function buildAc2Command(api: OpenClawApi): unknown {
               },
             });
 
-            // Replay threads + default-thread history for reconnecting controllers.
-            replayConversationList(controlSendable, connectionRequestId);
-            replayConversationHistory(controlSendable, connectionRequestId, DEFAULT_THID);
+            if (locked) {
+              // A foreign wallet is locked out: surface a banner only (no chat
+              // message), and DO NOT replay the bound controller's history to
+              // it. Routing is also blocked below, so the agent never sees its
+              // messages.
+              sendNotice(controlSendable, {
+                code: 'controller_locked',
+                level: 'warning',
+                title: 'New wallet not registered',
+                text: CONTROLLER_LOCKED_NOTICE,
+              });
+            } else {
+              // Replay threads + default-thread history for reconnecting controllers.
+              replayConversationList(controlSendable, connectionRequestId);
+              replayConversationHistory(controlSendable, connectionRequestId, DEFAULT_THID);
 
-            if (!identityGranted) {
-              sendFinalize(
-                controlSendable,
-                DEFAULT_THID,
-                `ac2-noid-${Date.now()}`,
-                NO_IDENTITY_NOTICE,
-              );
+              if (!identityGranted) {
+                // Not registered (no identity granted yet): surface a banner
+                // only (no chat message). The wallet uses this code to block
+                // new messages until an identity is granted.
+                sendNotice(controlSendable, {
+                  code: 'identity_missing',
+                  level: 'warning',
+                  title: 'Not registered',
+                  text: NO_IDENTITY_NOTICE,
+                });
+              }
             }
 
             if (streamTransport) {
@@ -397,6 +551,17 @@ export function buildAc2Command(api: OpenClawApi): unknown {
                 const raw = event.data;
                 if (typeof raw === 'string' && raw.trim().length > 0) {
                   const active = sessionManager.getActive()!;
+                  // A locked (foreign-wallet) session never reaches the agent —
+                  // re-surface the lock notice instead of routing its messages.
+                  if (active.locked) {
+                    sendNotice(streamSendable!, {
+                      code: 'controller_locked',
+                      level: 'warning',
+                      title: 'New wallet not registered',
+                      text: CONTROLLER_LOCKED_NOTICE,
+                    });
+                    return;
+                  }
                   await routeInboundToAgent(
                     api,
                     raw,
@@ -409,6 +574,15 @@ export function buildAc2Command(api: OpenClawApi): unknown {
             }
             transport.onRawMessage?.(async (text: string) => {
               const active = sessionManager.getActive()!;
+              if (active.locked) {
+                sendNotice(streamSendable ?? transport, {
+                  code: 'controller_locked',
+                  level: 'warning',
+                  title: 'New wallet not registered',
+                  text: CONTROLLER_LOCKED_NOTICE,
+                });
+                return;
+              }
               await routeInboundToAgent(
                 api,
                 text,
@@ -433,15 +607,46 @@ export function buildAc2Command(api: OpenClawApi): unknown {
 
         void (async () => {
           let cycle = firstCycle;
-          // Re-pairing loop: re-render the QR after a dropped DataChannel.
+          // Re-pairing loop. After a dropped DataChannel there are two cases:
+          //
+          //  1. The signaling socket is STILL connected (the common case when
+          //     the wallet is simply reopened): keep it and re-arm `connect()`
+          //     on the SAME handle. The provider answers the returning wallet's
+          //     fresh offer in place, so we stay in the requestId room (no
+          //     presence churn) and the controller rejoins automatically — no
+          //     QR rescan, no manual "Reconnect". Mirrors the wallet, which
+          //     keeps its socket and just re-runs `peer()` on reconnect.
+          //
+          //  2. The signaling socket itself died (network/server outage): tear
+          //     the handle down and rebuild a fresh pairing cycle, re-rendering
+          //     the QR, with capped exponential backoff so a transient outage
+          //     self-heals.
           // eslint-disable-next-line no-constant-condition
           while (true) {
             await runConnectedSession(cycle.connect);
+
+            if (cycle.isSignalingAlive()) {
+              safeLog(
+                api,
+                'info',
+                '[ac2] Controller link dropped — signaling still connected; awaiting the wallet to re-link on the same session (no rescan needed).',
+              );
+              // Loop straight back to `runConnectedSession(cycle.connect)`,
+              // which re-arms the answer on the live socket.
+              continue;
+            }
+
             safeLog(
               api,
               'info',
-              '[ac2] DataChannel closed — waiting for the controller to re-link. Scan the QR code again.',
+              '[ac2] Signaling connection lost — rebuilding pairing. Scan the QR code again.',
             );
+            // Best-effort: drop the dead handle before replacing it.
+            try {
+              await cycle.dispose();
+            } catch {
+              // Already torn down; ignore.
+            }
             // Retry with capped exponential backoff instead of giving up: a
             // transient signaling-server/network outage should self-heal so
             // pairing resumes automatically once conditions improve.

--- a/packages/ac2-open-claw-reference/src/entry.ts
+++ b/packages/ac2-open-claw-reference/src/entry.ts
@@ -11,7 +11,8 @@ import { PLUGIN_ID, setActiveApi, setActiveRuntime, type OpenClawApi } from './r
 import { getToolPluginMetadata } from './session/contracts.js';
 import { sessionManager } from './session/manager.js';
 import { buildSignTool, buildCapabilitiesTool, buildX402FetchTool } from './tools/index.js';
-import { cmdSetup } from './setup/config.js';
+import { registerSubagentHooks } from './channel/subagent-hooks.js';
+import { cmdSetup, readChannelStatus } from './setup/config.js';
 import { listConnections } from './identity/state.js';
 
 const MANIFEST_DESCRIPTION =
@@ -43,7 +44,21 @@ function runAc2SlashCommand(ctx: { args?: string }): { text: string } {
 
   if (sub === 'status') {
     const active = sessionManager.getActive();
-    const lines = ['AC2 channel status', '', `Online: ${active ? 'yes' : 'no'}`];
+    const lines = ['AC2 channel status', ''];
+    try {
+      const channelStatus = readChannelStatus();
+      lines.push(
+        `Plugin allow-listed: ${channelStatus.pluginAllowed ? 'yes' : 'no'}`,
+        `Plugin enabled:      ${channelStatus.pluginEnabled ? 'yes' : 'no'}`,
+        `Bound to agent:      ${channelStatus.bound ? 'yes' : 'no'}`,
+        `Ready:               ${channelStatus.ready ? 'yes' : 'no'}`,
+        `Liquid Auth server:  ${channelStatus.liquidAuthServer} (${channelStatus.liquidAuthServerSource})`,
+        '',
+      );
+    } catch {
+      // config-derived readiness read is best-effort
+    }
+    lines.push(`Online: ${active ? 'yes' : 'no'}`);
     if (active) {
       lines.push(`Agent DID:      ${active.agentDid}`);
       lines.push(`Controller DID: ${active.controllerDid}`);
@@ -197,6 +212,10 @@ function registerFull(api: OpenClawApi): void {
   } catch (err) {
     console.error(`[${PLUGIN_ID}] registerTool failed: ${err}`);
   }
+  // Subscribe to the host's in-process sub-agent lifecycle hooks so background
+  // tasks report a reliable completion message even when the host's own
+  // announce/direct delivery cannot reach a threaded conversation.
+  registerSubagentHooks(api);
 }
 
 /** The bundled channel entry. */

--- a/packages/ac2-open-claw-reference/src/identity/binding.ts
+++ b/packages/ac2-open-claw-reference/src/identity/binding.ts
@@ -1,0 +1,72 @@
+/**
+ * Controller-binding policy for the AC2 agent.
+ *
+ * An OpenClaw agent install registers itself to the **first** controller
+ * (wallet) that grants it an identity, and stays bound to that controller. A
+ * *different* controller connecting afterwards — for example because the mobile
+ * wallet flushed its keystore and now presents a brand-new account key — must
+ * NOT be able to silently take over the agent (which would rotate the agent's
+ * identity, orphan the bound controller's conversation context, and hand a
+ * stranger the agent's tools). Instead the connection is *locked*: the agent
+ * neither reuses the bound identity nor bootstraps a fresh one, and asks the
+ * operator to clear the agent's keys under `~/.openclaw` (`ac2 forget`) before a
+ * new controller can register.
+ *
+ * This module holds only the pure decision so it can be unit-tested in
+ * isolation from the pairing/session machinery.
+ */
+
+/**
+ * Outcome of evaluating a connecting controller against the bound one.
+ *
+ * - `register` — no controller is bound yet (first run): bootstrap an identity
+ *   and bind to this controller.
+ * - `reuse` — the connecting controller is the bound one (or the live link did
+ *   not report an account, e.g. a presence-only reconnect): reuse the stored
+ *   identity and keep the session context.
+ * - `locked` — a *different* controller is connecting to an already-bound
+ *   agent: refuse the takeover and require operator action.
+ */
+export type ControllerBindingDecision = 'register' | 'reuse' | 'locked';
+
+export interface ControllerBindingParams {
+  /**
+   * Controller DID the agent is already bound to (normalized), or `undefined`
+   * when the agent has never been granted an identity.
+   */
+  boundControllerDid?: string | undefined;
+  /**
+   * Controller DID of the connecting wallet (normalized), or `undefined` when
+   * the live link did not report an account (e.g. a presence-only reconnect).
+   */
+  connectedAccountDid?: string | undefined;
+  /**
+   * Whether a stored identity is available to reuse for this connection
+   * (either the connection's own grant or the install-wide bound identity).
+   */
+  hasStoredIdentity: boolean;
+}
+
+/**
+ * Decide how to treat a connecting controller relative to the bound one.
+ *
+ * The foreign-controller check runs first and is deliberately strict: as soon
+ * as the agent is bound (`boundControllerDid` set) and the live link reports a
+ * *different* account, the connection is locked — even if a stored identity
+ * exists — so a new wallet can never reuse or overwrite the bound identity.
+ */
+export function decideControllerBinding(
+  params: ControllerBindingParams,
+): ControllerBindingDecision {
+  const { boundControllerDid, connectedAccountDid, hasStoredIdentity } = params;
+
+  if (
+    boundControllerDid !== undefined &&
+    connectedAccountDid !== undefined &&
+    connectedAccountDid !== boundControllerDid
+  ) {
+    return 'locked';
+  }
+
+  return hasStoredIdentity ? 'reuse' : 'register';
+}

--- a/packages/ac2-open-claw-reference/src/identity/did.ts
+++ b/packages/ac2-open-claw-reference/src/identity/did.ts
@@ -120,3 +120,34 @@ export function normalizeDidKey(value: string): string {
   if (!pk) return value;
   return publicKeyToDidKey(pk);
 }
+
+/**
+ * Resolve the canonical controller DID used to key the agent's session
+ * (`ac2:<controllerDid>:<thid>`), keeping it byte-identical across reconnects.
+ *
+ * The OpenClaw runtime persists each agent conversation on disk keyed by that
+ * session key, so the agent only "remembers" a thread when the key resolves to
+ * the same value on every (re)connect. A granted identity is therefore the
+ * anchor: its `controllerDid` was bound (and verified against the linked
+ * account) to this connection when the identity was granted, so we reuse it
+ * verbatim. Only when no identity has been granted yet do we fall back to the
+ * DID derived from the live link, then to the placeholder.
+ *
+ * Without this anchor a presence-only reconnect — which renegotiates the
+ * WebRTC session without a fresh Liquid Auth `link`, and so often omits the
+ * wallet address — would re-derive `controllerDid` from a differently-encoded
+ * peer DID, rotate the session key, and make the agent load a fresh, empty
+ * session (i.e. lose the thread's context).
+ */
+export function resolveStableControllerDid(params: {
+  storedControllerDid?: string | undefined;
+  connectedAccountDid?: string | undefined;
+  placeholder?: string | undefined;
+}): string {
+  return (
+    params.storedControllerDid ??
+    params.connectedAccountDid ??
+    params.placeholder ??
+    'did:key:zAc2Controller'
+  );
+}

--- a/packages/ac2-open-claw-reference/src/identity/state.ts
+++ b/packages/ac2-open-claw-reference/src/identity/state.ts
@@ -18,11 +18,11 @@ export interface PersistedIdentity {
 
 /** A single persisted message within a conversation thread. */
 export interface PersistedConversationMessage {
-  role: 'user' | 'agent' | 'tool';
-  /** Empty for `tool` entries. */
+  role: 'user' | 'agent' | 'tool' | 'task';
+  /** Empty for `tool`/`task` entries. */
   text: string;
   at: number;
-  /** Stable card id for `tool` entries (upsert key). */
+  /** Stable card id for `tool`/`task` entries (upsert key). */
   id?: string;
   /** Tool name for a `tool` entry (e.g. `exec`, `write`). */
   tool?: string;
@@ -30,6 +30,14 @@ export interface PersistedConversationMessage {
   command?: string;
   /** The (possibly truncated) tool output/result text, for a `tool` entry. */
   output?: string;
+  /** Display title for a `task` (background sub-agent) entry. */
+  title?: string;
+  /** Delegated task prompt for a `task` entry. */
+  prompt?: string;
+  /** Lifecycle status for a `task` entry (`running`/`completed`/`failed`/`stopped`). */
+  status?: string;
+  /** The child's final result text for a completed `task` entry. */
+  result?: string;
 }
 
 /** A conversation thread on a connection (keyed by AC2 `thid`). */
@@ -52,6 +60,15 @@ export interface PersistedConnection {
   requestId: string;
   /** Identity key the wallet granted the agent on this connection. */
   identity?: PersistedIdentity;
+  /**
+   * The signaling server session cookie (e.g. `connect.sid=...`) captured on
+   * this connection. Replaying it on subsequent launches lets the agent reuse
+   * the SAME server session across restarts instead of creating a fresh one
+   * each time. Without this the server accumulates stale sessions bound to the
+   * same requestId, which can shadow the live wallet session during the
+   * reconnect rendezvous and leave the agent waiting on a `link`.
+   */
+  sessionCookie?: string;
   /** Unix epoch (ms) the connection was first established. */
   createdAt: number;
   /** Unix epoch (ms) of the most recent activity on the connection. */
@@ -133,6 +150,28 @@ export function touchConnection(requestId: string): PersistedConnection {
   connections[requestId] = connection;
   saveAc2State({ connections, activeRequestId: requestId, requestId });
   return connection;
+}
+
+/** The persisted signaling session cookie for a `requestId`, if any. */
+export function getSessionCookie(requestId: string): string | undefined {
+  return loadAc2State().connections?.[requestId]?.sessionCookie;
+}
+
+/**
+ * Persist the signaling session cookie for a `requestId` so the agent reuses
+ * the same server session on the next launch. A no-op when the cookie is
+ * unchanged, to avoid rewriting the state file on every reconnect.
+ */
+export function setSessionCookie(requestId: string, sessionCookie: string): void {
+  const state = loadAc2State();
+  const connections = { ...state.connections };
+  const now = Date.now();
+  const existing = connections[requestId];
+  if (existing?.sessionCookie === sessionCookie) return;
+  connections[requestId] = existing
+    ? { ...existing, sessionCookie, lastActiveAt: now }
+    : { requestId, createdAt: now, lastActiveAt: now, conversations: {}, sessionCookie };
+  saveAc2State({ connections, activeRequestId: requestId, requestId });
 }
 
 /** Persist the identity granted on a connection. */
@@ -228,6 +267,65 @@ export function recordToolActivity(
       ...(tool.name ? { tool: tool.name } : {}),
       ...(tool.command ? { command: tool.command } : {}),
       ...(tool.output !== undefined ? { output: tool.output } : {}),
+    });
+  }
+  const conversation: PersistedConversation = { ...existing, updatedAt: now, messages };
+  conversations[thid] = conversation;
+  connections[requestId] = { ...connection, lastActiveAt: now, conversations };
+  saveAc2State({ connections, activeRequestId: requestId, requestId });
+  return conversation;
+}
+
+/**
+ * Upsert a durable background-task (`sessions_spawn`) card on a thread (keyed by
+ * `id`). The spawning turn records it `running`; the completion path re-records
+ * the same `id` with a terminal `status` and the child's `result` text, so a
+ * fresh device restoring history replays exactly one task card in its final
+ * state (mirrors `recordToolActivity`).
+ */
+export function recordTaskActivity(
+  requestId: string,
+  thid: string,
+  task: { id: string; title?: string; prompt?: string; status?: string; result?: string },
+): PersistedConversation {
+  const state = loadAc2State();
+  const connections = { ...state.connections };
+  const now = Date.now();
+  const connection: PersistedConnection = connections[requestId] ?? {
+    requestId,
+    createdAt: now,
+    lastActiveAt: now,
+    conversations: {},
+  };
+  const conversations = { ...connection.conversations };
+  const existing = conversations[thid] ?? {
+    thid,
+    createdAt: now,
+    updatedAt: now,
+    messages: [] as PersistedConversationMessage[],
+  };
+  const messages = [...existing.messages];
+  const idx = messages.findIndex((m) => m.role === 'task' && m.id === task.id);
+  if (idx !== -1) {
+    const prev = messages[idx]!;
+    messages[idx] = {
+      ...prev,
+      at: now,
+      ...(task.title !== undefined ? { title: task.title } : {}),
+      ...(task.prompt !== undefined ? { prompt: task.prompt } : {}),
+      ...(task.status !== undefined ? { status: task.status } : {}),
+      ...(task.result !== undefined ? { result: task.result } : {}),
+    };
+  } else {
+    messages.push({
+      role: 'task',
+      text: '',
+      at: now,
+      id: task.id,
+      ...(task.title !== undefined ? { title: task.title } : {}),
+      ...(task.prompt !== undefined ? { prompt: task.prompt } : {}),
+      ...(task.status !== undefined ? { status: task.status } : {}),
+      ...(task.result !== undefined ? { result: task.result } : {}),
     });
   }
   const conversation: PersistedConversation = { ...existing, updatedAt: now, messages };

--- a/packages/ac2-open-claw-reference/src/index.ts
+++ b/packages/ac2-open-claw-reference/src/index.ts
@@ -38,11 +38,45 @@ export {
   clearActiveConversation,
   resolveAc2SessionConversation,
   resolveAc2OutboundSessionRoute,
+  buildAc2SessionKey,
+  routeInboundToAgent,
+  classifyAgentError,
   replayConversationList,
   replayConversationHistory,
+  deriveTaskThid,
+  isTaskThid,
+  registerTask,
+  attachSpawnResult,
+  taskDisplayTitle,
+  taskCardId,
+  getTaskByThid,
+  findTaskByRun,
+  findPendingTaskForParent,
+  markTaskResult,
+  listTasks,
+  resetTasks,
+  TASK_THREAD_PREFIX,
+  emitTaskCardUpdate,
+  registerSubagentHooks,
+  handleSubagentSpawned,
+  handleSubagentEnded,
+  resetSubagentHooksRegistration,
+  watchTaskCompletion,
+  resetTaskWatchers,
+  subagentPolling,
+  readChildResultText,
+  readChildSessionStatus,
+  discoverChildSessionKey,
+  describeSubagentCandidates,
+  sendTaskCard,
+  type Ac2AgentError,
   type Ac2MediaSourceParams,
   type Ac2SessionConversation,
   type Ac2OutboundSessionRoute,
+  type Ac2Task,
+  type Ac2TaskStatus,
+  type Ac2TaskCardStatus,
+  type ChildSessionStatus,
 } from './channel/index.js';
 export { buildAc2Command } from './cli/index.js';
 export { buildSignTool, buildCapabilitiesTool, buildX402FetchTool } from './tools/index.js';
@@ -61,7 +95,12 @@ export {
   type X402PaymentContext,
   type X402PaymentSelection,
 } from './x402/index.js';
-export type { LiquidAuthChannelProviderOptions } from './providers/liquid-auth.js';
+export type {
+  LiquidAuthChannelProviderOptions,
+  LiquidAuthPairingHandle,
+  PresenceResult,
+  PresenceSocket,
+} from './providers/liquid-auth.js';
 export async function loadLiquidAuthChannelProvider(): Promise<
   typeof import('./providers/liquid-auth.js')
 > {

--- a/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
+++ b/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
@@ -16,6 +16,7 @@ import type {
 import { rtcDataChannelTransport, type Ac2Transport } from '@algorandfoundation/ac2-sdk/transport';
 import qrcode from 'qrcode-terminal';
 import { normalizeDidKey } from '../identity/did.js';
+import { getSessionCookie, setSessionCookie } from '../identity/state.js';
 
 // @ts-ignore - compiled JS in node_modules
 import { SignalClient } from '@algorandfoundation/liquid-client/signal';
@@ -409,6 +410,278 @@ export function withSignalingHealthGuard<T>(
   });
 }
 
+/**
+ * Presence detection for a `requestId`, handled outside `SignalClient` on the
+ * signaling socket. The Liquid Auth server exposes a dedicated `presence`
+ * websocket event: emitting `{ requestId }` returns an ack `{ requestId,
+ * deviceCount, online }`, and the same shape is broadcast to the room whenever
+ * a peer joins/leaves. This lets a (potentially offline) peer detect whether
+ * there is anyone connected for a `requestId` before attempting to reconnect.
+ */
+export interface PresenceResult {
+  requestId: string;
+  /** Number of devices currently connected for the `requestId`. */
+  deviceCount: number;
+  /** Convenience flag: `deviceCount > 0`. */
+  online: boolean;
+}
+
+/** Minimal socket surface the presence helpers rely on (socket.io-client). */
+export interface PresenceSocket {
+  emit: (event: string, ...args: any[]) => unknown;
+  on?: (event: string, listener: (...args: any[]) => void) => unknown;
+  off?: (event: string, listener: (...args: any[]) => void) => unknown;
+}
+
+export const AC2_PRESENCE_EVENT = 'presence';
+const AC2_DEFAULT_PRESENCE_TIMEOUT_MS = 10000;
+
+/**
+ * Grace window after our OWN signaling socket (re)connects during which a low
+ * device count is treated as an untrustworthy recount artifact rather than the
+ * peer going offline. When the signaling server restarts, our socket briefly
+ * drops and reconnects and the server re-counts the room from scratch — the
+ * still-present wallet may not have re-registered yet, so presence momentarily
+ * reads a single device. Suppressing presence-driven teardown for this window
+ * (while a live data channel already proves the peer is there) avoids tearing
+ * down a healthy p2p connection on a mere signaling blip. A genuine departure
+ * outlives the window and is acted on as soon as it elapses.
+ */
+const AC2_SIGNALING_STABLE_GRACE_MS = 5000;
+
+/**
+ * Coerce an arbitrary presence payload into a well-formed `PresenceResult`,
+ * tolerating a missing/partial ack from an older server. Falls back to the
+ * queried `requestId` and derives `online` from `deviceCount` when absent.
+ */
+export function normalizePresence(requestId: string, data: unknown): PresenceResult {
+  const record = (data ?? {}) as Record<string, unknown>;
+  const deviceCount =
+    typeof record.deviceCount === 'number' && Number.isFinite(record.deviceCount)
+      ? record.deviceCount
+      : 0;
+  const online = typeof record.online === 'boolean' ? record.online : deviceCount > 0;
+  const resolvedRequestId =
+    typeof record.requestId === 'string' && record.requestId.length > 0
+      ? record.requestId
+      : requestId;
+  return { requestId: resolvedRequestId, deviceCount, online };
+}
+
+/**
+ * Query how many devices are connected for `requestId` by emitting the
+ * `presence` event and awaiting the server ack. Rejects on an empty
+ * `requestId` or if no ack arrives within `timeoutMs`.
+ */
+export function queryPresence(
+  socket: PresenceSocket,
+  requestId: string,
+  opts: { timeoutMs?: number } = {},
+): Promise<PresenceResult> {
+  const timeoutMs = opts.timeoutMs ?? AC2_DEFAULT_PRESENCE_TIMEOUT_MS;
+  return new Promise<PresenceResult>((resolve, reject) => {
+    if (typeof requestId !== 'string' || requestId.length === 0) {
+      reject(new Error('[ac2-open-claw] presence query requires a non-empty requestId'));
+      return;
+    }
+
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(
+        new Error(
+          `[ac2-open-claw] timed out waiting for presence ack for ${requestId} (${timeoutMs}ms)`,
+        ),
+      );
+    }, timeoutMs);
+
+    try {
+      socket.emit(AC2_PRESENCE_EVENT, { requestId }, (data: unknown) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(normalizePresence(requestId, data));
+      });
+    } catch (err) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err as Error);
+    }
+  });
+}
+
+/**
+ * Subscribe to server-broadcast `presence` updates. Returns an unsubscribe
+ * function. Safe to call against a socket that lacks `on`/`off` (no-op).
+ */
+export function subscribeToPresence(
+  socket: PresenceSocket,
+  handler: (presence: PresenceResult) => void,
+): () => void {
+  const listener = (data: unknown): void => {
+    const record = (data ?? {}) as Record<string, unknown>;
+    const requestId = typeof record.requestId === 'string' ? record.requestId : '';
+    handler(normalizePresence(requestId, data));
+  };
+  socket.on?.(AC2_PRESENCE_EVENT, listener);
+  return () => {
+    socket.off?.(AC2_PRESENCE_EVENT, listener);
+  };
+}
+
+/**
+ * Convenience wrapper for the reconnect decision: resolves `true` when at
+ * least one device is connected for `requestId`. Swallows query errors and
+ * timeouts into `false` so an offline client simply declines to reconnect.
+ */
+export async function hasPeerPresence(
+  socket: PresenceSocket,
+  requestId: string,
+  opts?: { timeoutMs?: number },
+): Promise<boolean> {
+  try {
+    const presence = await queryPresence(socket, requestId, opts);
+    return presence.online;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Decide whether a `presence` broadcast means the linked wallet has gone away
+ * and the session should be torn down so the caller can await a fresh link.
+ *
+ * Mirrors the Liquid Auth demo app's offer-side reset: only AFTER a wallet has
+ * actually linked (`peerLinked`) does a drop back to a single device (just this
+ * agent) indicate the wallet went offline. Before the first link a single
+ * device is the normal "still awaiting the wallet" state and must NOT trigger
+ * teardown; an already-closed session never re-triggers.
+ *
+ * Presence is the FAST signal that the peer left: when the wallet app closes,
+ * its socket disconnects and the server broadcasts a drop to a single device
+ * almost immediately, whereas the WebRTC data channel can take much longer to
+ * notice the peer is gone. So we tear down on a presence drop even once the
+ * control data channel is live (`connected`) — this is what lets the agent
+ * re-arm and be waiting with a fresh offer-listener BEFORE the wallet reopens,
+ * instead of stalling until the heartbeat watchdog fires.
+ *
+ * The one exception is "the signaling server was lost while we are connected":
+ * a presence drop caused by OUR OWN signaling socket dropping/reconnecting is a
+ * transient recount artifact, not a real departure, and the live data channel
+ * already proves the peer is still there. That case is flagged by
+ * `signalingStable === false` (see `AC2_SIGNALING_STABLE_GRACE_MS`), and while
+ * it holds a presence drop on a live connection is ignored; a genuinely gone
+ * peer is then caught either once signaling restabilizes or by the heartbeat
+ * watchdog / control-transport `onClose`. Before the channel is live there is
+ * no p2p connection to trust, so a linked peer dropping to a single device is
+ * always acted on regardless of signaling stability.
+ *
+ * Teardown must also stand down while a (re)negotiation is already in flight
+ * and not yet connected (`negotiating && !connected`): that armed
+ * `SignalClient.peer(...)` — parked awaiting the wallet's re-link/offer — IS
+ * the "awaiting the wallet" state a teardown would otherwise re-create, and
+ * tearing it down is actively destructive. `teardownPeer` nulls the
+ * SignalClient's `peerClient` underneath the pending `peer()`, so when the
+ * wallet came back and the handshake resumed it crashed with
+ * `TypeError: Cannot set properties of undefined (setting 'onicecandidate')`
+ * (torn down while parked in `link()`) or `Cannot read properties of
+ * undefined (reading 'setRemoteDescription')` (torn down while awaiting the
+ * offer), failing the wallet's first re-link attempt. Once `connected` the
+ * negotiation has resolved, so the fast presence path above applies as usual.
+ */
+export function shouldTeardownOnPresence(
+  presence: PresenceResult,
+  state: {
+    peerLinked: boolean;
+    closed: boolean;
+    connected: boolean;
+    signalingStable: boolean;
+    negotiating: boolean;
+  },
+): boolean {
+  if (!state.peerLinked || state.closed) return false;
+  if (presence.deviceCount > 1) return false;
+  // A negotiation is already armed and waiting for the wallet — there is
+  // nothing stale to tear down, and doing so would null the SignalClient's
+  // `peerClient` under the in-flight `peer()` (crashing the handshake the
+  // moment the wallet re-links). Leave the armed negotiation in place.
+  if (state.negotiating && !state.connected) return false;
+  // The peer appears offline. On a LIVE connection only trust the drop when our
+  // own signaling link is stable — otherwise it is a signaling-server blip, not
+  // a real departure.
+  if (state.connected && !state.signalingStable) return false;
+  return true;
+}
+
+/**
+ * Parse a raw `set-cookie` response header into a `Cookie` request-header
+ * value (`name=value; name2=value2`). Accepts either an array of cookie
+ * strings (Node's typical shape) or a single comma-joined string, splitting
+ * only at genuine cookie boundaries so `Expires=...,` dates are not mangled.
+ */
+export function cookiePairsFromSetCookie(
+  setCookie: string | string[] | null | undefined,
+): string | undefined {
+  if (!setCookie) return undefined;
+  const entries = Array.isArray(setCookie)
+    ? setCookie
+    : String(setCookie).split(/,(?=[^;,]+?=)/);
+  const pairs = entries
+    .map((entry) => entry.split(';')[0]?.trim())
+    .filter((pair): pair is string => Boolean(pair && pair.includes('=')));
+  return pairs.length > 0 ? pairs.join('; ') : undefined;
+}
+
+/**
+ * Persist the signaling server's session cookie so the agent reuses the SAME
+ * server session across restarts (like a browser would). Reusing one session
+ * avoids leaving stale sessions bound to this `requestId` on the server, which
+ * would otherwise shadow the live wallet session during the reconnect
+ * rendezvous and leave the agent "waiting on a link".
+ *
+ * The cookie is captured from the polling handshake response, persisted to
+ * disk for the next launch, and mirrored into the manager's `extraHeaders` so
+ * in-process reconnects resend it too. Best-effort throughout: cookie handling
+ * is a reconnect optimization and must never break pairing.
+ */
+function attachSessionCookiePersistence(socket: any, requestId: string): void {
+  const capture = (): void => {
+    try {
+      const transport = socket?.io?.engine?.transport;
+      const xhr = transport?.pollXhr?.xhr;
+      if (!xhr || typeof xhr.getResponseHeader !== 'function') return;
+      const cookie = cookiePairsFromSetCookie(xhr.getResponseHeader('set-cookie'));
+      if (!cookie) return;
+      if (socket.io) {
+        socket.io.opts = socket.io.opts ?? {};
+        socket.io.opts.extraHeaders = { ...(socket.io.opts.extraHeaders ?? {}), cookie };
+      }
+      setSessionCookie(requestId, cookie);
+    } catch {
+      // best-effort
+    }
+  };
+  const bind = (): void => {
+    try {
+      const transport = socket?.io?.engine?.transport;
+      if (transport && typeof transport.on === 'function') {
+        transport.on('pollComplete', capture);
+      }
+    } catch {
+      // best-effort
+    }
+  };
+  // A reconnect spins up a fresh engine/transport, so (re)bind on every open.
+  try {
+    socket?.io?.on?.('open', bind);
+  } catch {
+    // best-effort
+  }
+  bind();
+}
+
 export interface LiquidAuthChannelProviderOptions {
   /** Liquid Auth signaling server origin. */
   origin?: string;
@@ -418,12 +691,35 @@ export interface LiquidAuthChannelProviderOptions {
   includeStreamChannel?: boolean;
   /** Milliseconds without inbound heartbeat traffic before closing. */
   heartbeatTimeoutMs?: number;
+  /**
+   * Optional presence listener. When provided, server-broadcast `presence`
+   * updates for the `requestId` are forwarded here so the caller can track how
+   * many devices are connected (and decide whether reconnecting is worthwhile).
+   * Handled outside `SignalClient`, directly on the signaling socket.
+   */
+  onPresence?: (presence: PresenceResult) => void;
+}
+
+/**
+ * `Ac2PairingHandle` extended with this provider's persistent-signaling
+ * lifecycle hooks. Kept local (rather than relying on the optional members on
+ * the SDK's `Ac2PairingHandle`) so the reference package compiles against the
+ * currently-published SDK regardless of whether those optional members are
+ * present in the consumed type. Callers can consult `isSignalingAlive()` after
+ * a peer drop to re-arm `connect()` on the SAME live socket, and `dispose()` to
+ * fully tear the socket down when abandoning the handle.
+ */
+export interface LiquidAuthPairingHandle extends Ac2PairingHandle {
+  /** Whether the persistent signaling socket is still connected. */
+  isSignalingAlive(): boolean;
+  /** Fully tear down the persistent signaling socket + peer. Idempotent. */
+  dispose(): Promise<void>;
 }
 
 export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
   constructor(private readonly defaults: LiquidAuthChannelProviderOptions = {}) { }
 
-  async startPairing(opts: Ac2StartPairingOptions = {}): Promise<Ac2PairingHandle> {
+  async startPairing(opts: Ac2StartPairingOptions = {}): Promise<LiquidAuthPairingHandle> {
     await ensureWebRtcPolyfill();
 
     const origin = this.defaults.origin ?? 'https://debug.liquidauth.com';
@@ -434,16 +730,228 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
       resolveHeartbeatTimeoutMs(process.env['AC2_HEARTBEAT_TIMEOUT_MS']);
 
     // Build the signaling socket from the Node-native `socket.io-client` and
-    // pass it to `SignalClient` via its `{ socket }` option.
+    // pass it to `SignalClient` via its `{ socket }` option. Replay any
+    // previously captured server session cookie so the agent reuses the same
+    // session across restarts (see `attachSessionCookiePersistence`), which is
+    // what lets the reconnect rendezvous find the live wallet session instead
+    // of a stale duplicate.
+    const persistedCookie = getSessionCookie(requestId);
     const socket = createSocketIoClient(origin, {
       autoConnect: true,
+      ...(persistedCookie ? { extraHeaders: { cookie: persistedCookie } } : {}),
     });
+    attachSessionCookiePersistence(socket, requestId);
 
     const client = new SignalClient(origin, { socket: socket as any });
 
-    // Capture the wallet account from the Liquid Auth `link` response.
+    // Session lifecycle state, declared up-front so the presence subscription
+    // below can drive teardown once a wallet has linked. `peerLinked` is sticky
+    // across reconnects (the wallet stays authenticated on the same requestId);
+    // `closed`/`connected` are per-negotiation and reset at the start of each
+    // `connect()` so the SAME signaling socket can be reused for the next peer
+    // session (see `teardownPeer`).
+    let peerLinked = false;
+    let closed = false;
+    // Set once the control DataChannel is actually live. A live data channel is
+    // the source of truth for the p2p connection and survives signaling-server
+    // loss: a presence drop while `connected` is trusted only when our own
+    // signaling link is stable (see `shouldTeardownOnPresence` /
+    // `signalingStable` below), otherwise it is a signaling-server blip and the
+    // heartbeat watchdog / control-transport `onClose` remain authoritative.
+    let connected = false;
+    // Guards against overlapping `connect()` calls re-arming the answer flow on
+    // the same socket concurrently (`SignalClient.peer` cannot run twice at
+    // once).
+    let negotiating = false;
+
+    // Health of OUR OWN signaling link. A presence drop to a single device only
+    // means the peer really left if the drop was NOT caused by our signaling
+    // socket itself dropping/reconnecting. We start optimistic (the socket is
+    // connecting) and mark it unstable on a `disconnect`, restoring stability
+    // only after a grace window past the next `connect` so the server has time
+    // to re-count the still-present wallet in the room. This is what makes
+    // "close on peer offline, but NOT on a signaling-server loss while we are
+    // connected" a precise, non-racy decision.
+    let signalingStable = true;
+    let signalingGraceTimer: ReturnType<typeof setTimeout> | undefined;
+    const markSignalingUnstable = (): void => {
+      signalingStable = false;
+      if (signalingGraceTimer) {
+        clearTimeout(signalingGraceTimer);
+        signalingGraceTimer = undefined;
+      }
+    };
+    const markSignalingStableSoon = (): void => {
+      if (signalingGraceTimer) clearTimeout(signalingGraceTimer);
+      signalingGraceTimer = setTimeout(() => {
+        signalingStable = true;
+        signalingGraceTimer = undefined;
+      }, AC2_SIGNALING_STABLE_GRACE_MS);
+      // Don't keep the event loop alive just for the grace timer.
+      (signalingGraceTimer as { unref?: () => void }).unref?.();
+    };
+    socket.on?.('disconnect', markSignalingUnstable);
+    socket.on?.('connect', markSignalingStableSoon);
+    // The socket auto-connects; if it is already up, arm the initial grace.
+    if ((socket as { connected?: boolean }).connected) markSignalingStableSoon();
+    else markSignalingUnstable();
+
+    // Per-negotiation peer state. Hoisted to the pairing scope (rather than
+    // living inside `connect()`) so `teardownPeer` can tear down ONLY the p2p
+    // peer between attempts while the signaling socket stays connected.
+    let heartbeat: ReturnType<typeof setInterval> | undefined;
+    let controlChannel: any;
+    let streamChannel: any;
+    let heartbeatChannel: any;
+    let onDataChannel: ((channel: any) => void) | undefined;
+
+    // Forward-declared so the presence subscription and the reactive re-offer
+    // listener (both bound once, below) can trigger teardown before `connect()`
+    // assigns the real implementation. Reassigned inside `connect()`.
+    let close: () => Promise<void> = async () => {
+      /* assigned in connect() */
+    };
+
+    /**
+     * Tear down ONLY the p2p peer + its data channels and detach the
+     * per-negotiation signaling listeners, KEEPING the signaling socket (and
+     * its presence subscription) connected. This mirrors the wallet's
+     * `clearTransport`: closing the leaked `RTCPeerConnection` is required so
+     * the peer no longer treats the old session as active, and detaching the
+     * SDK's per-negotiation listeners stops them accumulating (double-applied
+     * candidates / data-channel events) when the same socket is reused for the
+     * next `client.peer(...)`. Idempotent and safe to call before the first
+     * negotiation.
+     */
+    const teardownPeer = (): void => {
+      if (heartbeat) {
+        clearInterval(heartbeat);
+        heartbeat = undefined;
+      }
+      closeRtcDataChannel(heartbeatChannel);
+      closeRtcDataChannel(streamChannel);
+      closeRtcDataChannel(controlChannel);
+      heartbeatChannel = undefined;
+      streamChannel = undefined;
+      controlChannel = undefined;
+      try {
+        (client as any).peerClient?.close?.();
+      } catch {
+        // Already closed; ignore.
+      }
+      // Allow a fresh `client.peer(...)` on the reused SignalClient (it refuses
+      // to run while a peer/requestId is still in progress).
+      (client as any).peerClient = undefined;
+      // Detach the listeners the SDK's `peer()` adds per negotiation so reusing
+      // this socket doesn't accumulate duplicate handlers. The persistent
+      // presence + signaling-stability listeners (bound once below) are left
+      // attached: they must survive to detect the wallet leaving/returning on
+      // the live socket.
+      try {
+        if (onDataChannel) client.off('data-channel', onDataChannel);
+        else client.off('data-channel');
+      } catch {
+        // Best-effort.
+      }
+      onDataChannel = undefined;
+      const s = ((client as any).socket ?? socket) as {
+        off?: (event: string) => void;
+      };
+      try {
+        s?.off?.('offer-candidate');
+        s?.off?.('answer-candidate');
+        s?.off?.('answer-description');
+      } catch {
+        // Best-effort.
+      }
+    };
+
+    /**
+     * Fully tear down the persistent signaling socket (and peer). Used only
+     * when the pairing handle is abandoned or a hard signaling failure means
+     * the socket can no longer be reused — NOT on an ordinary peer drop, which
+     * keeps the socket alive for a fast in-place re-link.
+     */
+    const fullTeardown = (): void => {
+      teardownPeer();
+      if (signalingGraceTimer) {
+        clearTimeout(signalingGraceTimer);
+        signalingGraceTimer = undefined;
+      }
+      signalingStable = false;
+      try {
+        socket.off?.('disconnect', markSignalingUnstable);
+        socket.off?.('connect', markSignalingStableSoon);
+      } catch {
+        // Best-effort.
+      }
+      try {
+        client.close(true);
+      } catch {
+        // Already closed; ignore.
+      }
+      try {
+        (socket as { close?: () => void }).close?.();
+      } catch {
+        // Already closed; ignore.
+      }
+    };
+
+    // Presence is handled outside SignalClient, directly on the socket. Track
+    // how many devices are connected for this requestId — used to detect
+    // whether a peer is available before/after pairing (the "should an offline
+    // client even attempt to reconnect?" decision).
+    const onPresence = this.defaults.onPresence;
+    subscribeToPresence(socket as unknown as PresenceSocket, (presence) => {
+      if (presence.requestId && presence.requestId !== requestId) return;
+      // eslint-disable-next-line no-console
+      console.log(
+        `[ac2-open-claw] presence for ${presence.requestId}: ${presence.deviceCount} device(s), online=${presence.online}`,
+      );
+      onPresence?.(presence);
+      // Presence-driven teardown. A drop back to a single device (just this
+      // agent) after the wallet has linked means the peer went offline — this
+      // is the FAST path that closes the session immediately when the phone is
+      // closed, instead of waiting out the heartbeat. Crucially, it now fires
+      // even while the control data channel is `connected`, so the agent tears
+      // the stale peer down and re-arms `connect()` — leaving a fresh offer
+      // listener armed on the SAME socket — BEFORE the wallet reopens. When the
+      // phone comes back and re-sends its offer, the agent answers it in place:
+      // no QR rescan, no manual Reconnect, no timeout.
+      //
+      // Two exceptions, both handled inside `shouldTeardownOnPresence`:
+      //  - a presence drop caused by OUR OWN signaling socket dropping/
+      //    reconnecting (a signaling-server loss while we stay connected) is a
+      //    transient recount artifact, not a departure (`signalingStable`);
+      //  - a drop while a (re)negotiation is already armed and waiting
+      //    (`negotiating && !connected`) must NOT tear down: the pending
+      //    `SignalClient.peer(...)` is exactly what answers the returning
+      //    wallet, and nulling its `peerClient` mid-handshake crashed the
+      //    re-link with `onicecandidate`/`setRemoteDescription`-on-undefined
+      //    TypeErrors.
+      if (
+        shouldTeardownOnPresence(presence, {
+          peerLinked,
+          closed,
+          connected,
+          signalingStable,
+          negotiating,
+        })
+      ) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[ac2-open-claw] peer went offline (presence: ${presence.deviceCount} device(s)) — tearing down to await re-link.`,
+        );
+        void close();
+      }
+    });
+
+    // Capture the wallet account from the Liquid Auth `link` response. The
+    // `link-message` also marks the wallet as linked, arming the presence-driven
+    // teardown above (a later drop to a single device means the wallet left).
     let linkedWallet: string | undefined;
     client.on('link-message', (data: { wallet?: string; credId?: string } | undefined) => {
+      peerLinked = true;
       if (data && typeof data.wallet === 'string' && data.wallet.length > 0) {
         linkedWallet = data.wallet;
       }
@@ -523,184 +1031,205 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
       metadata: { origin, requestId },
     };
 
-    let heartbeat: ReturnType<typeof setInterval> | undefined;
-    let closed = false;
+    const connect = async (): Promise<Ac2PairedChannel> => {
+      // Serialize (re)negotiations: the SDK's `SignalClient.peer` cannot run
+      // twice concurrently on one socket.
+      if (negotiating) {
+        throw new Error('[ac2-open-claw] connect() called while a negotiation is already in flight');
+      }
+      negotiating = true;
+      try {
+        // Reuse the SAME signaling socket for every attempt: tear down only the
+        // previous p2p peer (if any) and reset the per-negotiation flags so a
+        // returning wallet is answered in place, without re-authenticating or
+        // dropping out of the requestId room. No-op on the first call.
+        teardownPeer();
+        closed = false;
+        connected = false;
 
-    // Forward-declare so the heartbeat interval (defined inside `connect`)
-    // can call it on liveness timeout.
-    let close: () => Promise<void> = async () => {
-      /* assigned in connect() */
+        // `peer(...)` resolves with the primary channel; the rest arrive via
+        // `'data-channel'`. Track the collector so `teardownPeer` can detach
+        // exactly this listener before the next attempt re-registers its own.
+        onDataChannel = (channel: any): void => {
+          if (channel.label === AC2_CONTROL_LABEL) controlChannel = channel;
+          else if (channel.label === AC2_STREAM_LABEL) streamChannel = channel;
+          else if (channel.label === AC2_HEARTBEAT_LABEL) heartbeatChannel = channel;
+        };
+        client.on('data-channel', onDataChannel);
+
+        type DataChannelInit = { ordered?: boolean };
+        const dataChannels: Record<string, DataChannelInit> = {
+          [AC2_CONTROL_LABEL]: { ordered: true },
+          ...(includeStream ? { [AC2_STREAM_LABEL]: { ordered: true } } : {}),
+          [AC2_HEARTBEAT_LABEL]: { ordered: true },
+        };
+        // Bounded by sustained signaling-socket disconnection, not a flat
+        // deadline: `peer(...)`'s offer/answer/candidate exchange waits on the
+        // human scanning the QR and approving in their wallet, which can take
+        // minutes. Only a real, sustained network/ping-timeout failure (the
+        // socket staying down longer than the reconnect grace period) should
+        // tear this down — not the human simply taking their time. A genuine
+        // failure here means the socket itself is unusable, so fully tear it
+        // down (the caller then builds a fresh pairing handle).
+        const primary: any = await withSignalingHealthGuard(
+          client.peer(requestId, 'offer', AC2_ICE_CONFIG, { dataChannels }),
+          socket,
+          {
+            deadSocketTimeoutMs: AC2_DEFAULT_SIGNAL_DEAD_TIMEOUT_MS,
+            ...(opts.signal ? { signal: opts.signal } : {}),
+            onFailure: () => {
+              fullTeardown();
+            },
+          },
+        );
+        controlChannel = controlChannel ?? primary;
+
+        if (controlChannel.label !== AC2_CONTROL_LABEL) {
+          throw new Error(
+            `[ac2-open-claw] Expected control channel labeled "${AC2_CONTROL_LABEL}", got "${controlChannel.label}". ` +
+              `The Controller app must use the latest liquid-auth-js with ac2-v1 support.`,
+          );
+        }
+
+        // Brief grace period so the app attaches handlers before resolve.
+        await new Promise((resolve) => setTimeout(resolve, 500));
+
+        const { transport, emitClose } = closeAwareTransport(
+          rtcDataChannelTransport(controlChannel),
+        );
+
+        if (!transport.isOpen) {
+          await new Promise<void>((resolve, reject) => {
+            const timeout = setTimeout(
+              () => reject(new Error('Timeout waiting for DataChannel to open')),
+              10000,
+            );
+            transport.onOpen(() => {
+              clearTimeout(timeout);
+              resolve();
+            });
+            transport.onError((err) => {
+              clearTimeout(timeout);
+              reject(err);
+            });
+          });
+        }
+
+        // The control data channel is now live. Mark the p2p connection as the
+        // source of truth so presence-driven teardown stands down (see the
+        // presence subscription): from here a signaling-server blip must NOT
+        // tear down the connection — only the heartbeat watchdog / `onClose`
+        // may.
+        connected = true;
+
+        // Bidirectional keep-alive: each side pings on its own timer AND replies
+        // PONG to the peer's pings. `lastInboundAt` is updated on any inbound
+        // frame (PING or PONG); the interval below declares the peer dead if no
+        // inbound traffic arrives within `heartbeatTimeoutMs` and triggers
+        // `close()` so the control transport's `onClose` propagates upstream.
+        //
+        // The heartbeat channel is optional and mobile controllers can suspend
+        // it while backgrounded. Only enforce the timeout when the heartbeat
+        // channel is present and open; the WebRTC/control close handlers remain
+        // authoritative for peers that really go away.
+        let lastInboundAt = Date.now();
+
+        if (heartbeatChannel) {
+          heartbeatChannel.onmessage = (ev: { data: unknown }) => {
+            lastInboundAt = Date.now();
+            if (ev?.data === AC2_HEARTBEAT_PING && heartbeatChannel.readyState === 'open') {
+              try {
+                heartbeatChannel.send(AC2_HEARTBEAT_PONG);
+              } catch {
+                // Channel closing between check and send; ignore.
+              }
+            }
+          };
+        }
+
+        heartbeat = setInterval(() => {
+          if (!heartbeatChannel || heartbeatChannel.readyState !== 'open') return;
+
+          if (Date.now() - lastInboundAt > heartbeatTimeoutMs) {
+            // eslint-disable-next-line no-console
+            console.warn(
+              `[ac2] Heartbeat timeout (${heartbeatTimeoutMs}ms with no inbound) — closing channel.`,
+            );
+            void close();
+            return;
+          }
+          try {
+            if (heartbeatChannel && heartbeatChannel.readyState === 'open') {
+              heartbeatChannel.send(AC2_HEARTBEAT_PING);
+            }
+          } catch {
+            // Channel closed between checks; ignore.
+          }
+        }, AC2_HEARTBEAT_MS);
+
+        // Peer-only close: tear down the p2p peer + channels and notify the
+        // consumer (via `emitClose`), but KEEP the signaling socket connected so
+        // the caller can immediately re-arm `connect()` and answer a returning
+        // wallet in place. A truly dead socket is handled separately by
+        // `fullTeardown` (health-guard `onFailure`) / `dispose`.
+        close = async (): Promise<void> => {
+          if (closed) return;
+          closed = true;
+          connected = false;
+          teardownPeer();
+          emitClose();
+        };
+
+        const channel: Ac2PairedChannel = {
+          transport,
+          ...(streamChannel !== undefined ? { streamChannel } : {}),
+          // Heartbeat is intentionally out-of-band: the `ac2-heartbeat`
+          // DataChannel is still negotiated and pinged inside this provider
+          // (see the `setInterval` above) for liveness, but it is NOT exposed
+          // on the returned `Ac2PairedChannel`. Consumers that need to detect
+          // a dead peer should rely on the control transport's `onClose` /
+          // signaling-engine close events rather than a dedicated channel —
+          // and the SDK's public `Ac2PairedChannel` shape stays in sync with
+          // `@algorandfoundation/ac2-sdk` (no `heartbeatChannel?` field).
+          // Bind the real connected wallet (normalized to canonical `did:key:z…`).
+          ...(linkedWallet !== undefined
+            ? {
+                peer: {
+                  did: normalizeDidKey(`did:key:${linkedWallet}`),
+                  wallet: linkedWallet,
+                },
+              }
+            : {}),
+          close,
+        };
+        return channel;
+      } finally {
+        negotiating = false;
+      }
     };
 
-    const connect = async (): Promise<Ac2PairedChannel> => {
-      // `peer(...)` resolves with the primary channel; the rest arrive via `'data-channel'`.
-      let controlChannel: any;
-      let streamChannel: any;
-      let heartbeatChannel: any;
-      client.on('data-channel', (channel: any) => {
-        if (channel.label === AC2_CONTROL_LABEL) controlChannel = channel;
-        else if (channel.label === AC2_STREAM_LABEL) streamChannel = channel;
-        else if (channel.label === AC2_HEARTBEAT_LABEL) heartbeatChannel = channel;
-      });
-
-      type DataChannelInit = { ordered?: boolean };
-      const dataChannels: Record<string, DataChannelInit> = {
-        [AC2_CONTROL_LABEL]: { ordered: true },
-        ...(includeStream ? { [AC2_STREAM_LABEL]: { ordered: true } } : {}),
-        [AC2_HEARTBEAT_LABEL]: { ordered: true },
-      };
-      // Bounded by sustained signaling-socket disconnection, not a flat
-      // deadline: `peer(...)`'s offer/answer/candidate exchange waits on the
-      // human scanning the QR and approving in their wallet, which can take
-      // minutes. Only a real, sustained network/ping-timeout failure (the
-      // socket staying down longer than the reconnect grace period) should
-      // tear this down — not the human simply taking their time.
-      const primary: any = await withSignalingHealthGuard(
-        client.peer(requestId, 'offer', AC2_ICE_CONFIG, { dataChannels }),
-        socket,
-        {
-          deadSocketTimeoutMs: AC2_DEFAULT_SIGNAL_DEAD_TIMEOUT_MS,
-          ...(opts.signal ? { signal: opts.signal } : {}),
-          onFailure: () => {
-            try {
-              (client as any).peerClient?.close?.();
-            } catch {
-              // Best-effort cleanup.
-            }
-            try {
-              client.close(true);
-            } catch {
-              // Already closed; ignore.
-            }
-            try {
-              (socket as { close?: () => void }).close?.();
-            } catch {
-              // Already closed; ignore.
-            }
-          },
-        },
-      );
-      controlChannel = controlChannel ?? primary;
-
-      if (controlChannel.label !== AC2_CONTROL_LABEL) {
-        throw new Error(
-          `[ac2-open-claw] Expected control channel labeled "${AC2_CONTROL_LABEL}", got "${controlChannel.label}". ` +
-          `The Controller app must use the latest liquid-auth-js with ac2-v1 support.`,
-        );
+    // Whether the persistent signaling socket is still connected. The caller
+    // consults this after a peer drop to decide between re-arming `connect()`
+    // on this SAME socket (fast in-place re-link, no presence churn) versus
+    // building a fresh pairing handle.
+    const isSignalingAlive = (): boolean => {
+      try {
+        return (socket as { connected?: boolean }).connected === true;
+      } catch {
+        return false;
       }
+    };
 
-      // Brief grace period so the app attaches handlers before resolve.
-      await new Promise((resolve) => setTimeout(resolve, 500));
-
-      const { transport, emitClose } = closeAwareTransport(rtcDataChannelTransport(controlChannel));
-
-      if (!transport.isOpen) {
-        await new Promise<void>((resolve, reject) => {
-          const timeout = setTimeout(
-            () => reject(new Error('Timeout waiting for DataChannel to open')),
-            10000,
-          );
-          transport.onOpen(() => {
-            clearTimeout(timeout);
-            resolve();
-          });
-          transport.onError((err) => {
-            clearTimeout(timeout);
-            reject(err);
-          });
-        });
-      }
-
-      // Bidirectional keep-alive: each side pings on its own timer AND replies
-      // PONG to the peer's pings. `lastInboundAt` is updated on any inbound
-      // frame (PING or PONG); the interval below declares the peer dead if no
-      // inbound traffic arrives within `heartbeatTimeoutMs` and triggers
-      // `close()` so the control transport's `onClose` propagates upstream.
-      //
-      // The heartbeat channel is optional and mobile controllers can suspend
-      // it while backgrounded. Only enforce the timeout when the heartbeat
-      // channel is present and open; the WebRTC/control close handlers remain
-      // authoritative for peers that really go away.
-      let lastInboundAt = Date.now();
-
-      if (heartbeatChannel) {
-        heartbeatChannel.onmessage = (ev: { data: unknown }) => {
-          lastInboundAt = Date.now();
-          if (ev?.data === AC2_HEARTBEAT_PING && heartbeatChannel.readyState === 'open') {
-            try {
-              heartbeatChannel.send(AC2_HEARTBEAT_PONG);
-            } catch {
-              // Channel closing between check and send; ignore.
-            }
-          }
-        };
-      }
-
-      heartbeat = setInterval(() => {
-        if (!heartbeatChannel || heartbeatChannel.readyState !== 'open') return;
-
-        if (Date.now() - lastInboundAt > heartbeatTimeoutMs) {
-          // eslint-disable-next-line no-console
-          console.warn(
-            `[ac2] Heartbeat timeout (${heartbeatTimeoutMs}ms with no inbound) — closing channel.`,
-          );
-          void close();
-          return;
-        }
-        try {
-          if (heartbeatChannel && heartbeatChannel.readyState === 'open') {
-            heartbeatChannel.send(AC2_HEARTBEAT_PING);
-          }
-        } catch {
-          // Channel closed between checks; ignore.
-        }
-      }, AC2_HEARTBEAT_MS);
-
-      close = async (): Promise<void> => {
-        if (closed) return;
-        closed = true;
-        if (heartbeat) {
-          clearInterval(heartbeat);
-          heartbeat = undefined;
-        }
-        closeRtcDataChannel(heartbeatChannel);
-        closeRtcDataChannel(streamChannel);
-        closeRtcDataChannel(controlChannel);
-        emitClose();
-        try {
-          client.close(true);
-        } catch {
-          // Already closed; ignore.
-        }
-      };
-
-      const channel: Ac2PairedChannel = {
-        transport,
-        ...(streamChannel !== undefined ? { streamChannel } : {}),
-        // Heartbeat is intentionally out-of-band: the `ac2-heartbeat`
-        // DataChannel is still negotiated and pinged inside this provider
-        // (see the `setInterval` above) for liveness, but it is NOT exposed
-        // on the returned `Ac2PairedChannel`. Consumers that need to detect
-        // a dead peer should rely on the control transport's `onClose` /
-        // signaling-engine close events rather than a dedicated channel —
-        // and the SDK's public `Ac2PairedChannel` shape stays in sync with
-        // `@algorandfoundation/ac2-sdk` (no `heartbeatChannel?` field).
-        // Bind the real connected wallet (normalized to canonical `did:key:z…`).
-        ...(linkedWallet !== undefined
-          ? {
-            peer: {
-              did: normalizeDidKey(`did:key:${linkedWallet}`),
-              wallet: linkedWallet,
-            },
-          }
-          : {}),
-        close,
-      };
-      return channel;
+    // Fully tear down the persistent signaling socket + peer. Idempotent; used
+    // when the caller abandons this handle (e.g. before replacing it).
+    const dispose = async (): Promise<void> => {
+      closed = true;
+      connected = false;
+      fullTeardown();
     };
 
     await waitForConnect;
 
-    return { pairing, connect };
+    return { pairing, connect, isSignalingAlive, dispose };
   }
 }

--- a/packages/ac2-open-claw-reference/src/runtime.ts
+++ b/packages/ac2-open-claw-reference/src/runtime.ts
@@ -40,16 +40,36 @@ export function getActiveRuntime(): any {
   return activeRuntime;
 }
 
-/** Resolve effective config from `api.config` + `api.pluginConfig`. */
+/**
+ * Resolve effective config from `channels.<id>` + `plugins.entries.<id>.config`
+ * + `api.pluginConfig`, then apply the `AC2_LIQUID_AUTH_SERVER` env override.
+ *
+ * `liquidAuthServer` is documented on the `channels.ac2` config surface (the
+ * one `ac2 setup` writes and `ac2 status` reads), so it must be read from
+ * there — not just from `plugins.entries.ac2.config` — otherwise the pairing
+ * flow silently falls back to the default server and ignores the configured
+ * URL. The `AC2_LIQUID_AUTH_SERVER` env var overrides it at runtime, matching
+ * the channel runtime and the documented behaviour.
+ */
 export function resolveConfig(api: OpenClawApi): ResolvedConfig {
   const fromPluginConfig = (api.pluginConfig ?? {}) as ResolvedConfig;
   const cfg = api.config as unknown as
     | {
         plugins?: { entries?: Record<string, { config?: ResolvedConfig }> };
+        channels?: Record<string, Partial<ResolvedConfig>>;
       }
     | undefined;
+  const fromChannel = (cfg?.channels?.[CHANNEL_ID] ?? {}) as Partial<ResolvedConfig>;
   const fromConfig = cfg?.plugins?.entries?.[PLUGIN_ID]?.config ?? ({} as ResolvedConfig);
-  return { ...fromConfig, ...fromPluginConfig };
+  const resolved: ResolvedConfig = { ...fromChannel, ...fromConfig, ...fromPluginConfig };
+
+  const envServer =
+    typeof process !== 'undefined' ? process.env?.['AC2_LIQUID_AUTH_SERVER']?.trim() : undefined;
+  if (envServer) {
+    resolved.liquidAuthServer = envServer;
+  }
+
+  return resolved;
 }
 
 /** Log through the host logger and the console (best-effort). */

--- a/packages/ac2-open-claw-reference/src/session/channel-runtime.ts
+++ b/packages/ac2-open-claw-reference/src/session/channel-runtime.ts
@@ -69,6 +69,17 @@ export async function runAc2Channel(
     const { transport, streamChannel: streamTransport } = paired;
     const client = new Ac2Client(transport);
 
+    // Control-frame surface used by host-initiated outbound sends (e.g.
+    // sub-agent completion announces) to emit thread-scoped `finalize` frames.
+    const streamSendable = streamTransport
+      ? {
+          send: (payload: string) => streamTransport.send(payload),
+          get isOpen() {
+            return streamTransport.readyState === 'open';
+          },
+        }
+      : undefined;
+
     // Agent → wallet (prefer `ac2-stream` when present).
     const sendChat = async (text: string): Promise<void> => {
       if (streamTransport && streamTransport.readyState === 'open') {
@@ -113,6 +124,8 @@ export async function runAc2Channel(
         client,
         controllerDid,
         agentDid,
+        identityGranted: true,
+        ...(streamSendable ? { controlTransport: streamSendable } : {}),
         ...(walletAddress !== undefined ? { walletAddress } : {}),
       });
       context.logger?.info('[ac2-open-claw] channel connected; tools are live');
@@ -120,6 +133,22 @@ export async function runAc2Channel(
       context.logger?.error(
         `[ac2-open-claw] identity bootstrap failed; signing tools stay disabled: ${(err as Error).message}`,
       );
+      // The transport is up and the wallet is chatting, so the channel IS
+      // connected — register the session anyway (with `identityGranted: false`)
+      // instead of leaving it inactive. Otherwise `sessionManager.getActive()`
+      // stays null and the channel/tools report "registered but not online" /
+      // `no_active_session` even while the user is actively chatting. Signing
+      // stays gated on `identityGranted` (see `signFlow`), so the agent can
+      // explain and keep chatting until the wallet grants an identity.
+      manager.setActive({
+        transport,
+        client,
+        controllerDid: paired.peer?.did ?? 'did:key:zAc2Controller',
+        agentDid: 'did:ac2:agent',
+        identityGranted: false,
+        ...(streamSendable ? { controlTransport: streamSendable } : {}),
+        ...(walletAddress !== undefined ? { walletAddress } : {}),
+      });
       try {
         await sendChat(NO_IDENTITY_NOTICE);
       } catch (sendErr) {

--- a/packages/ac2-open-claw-reference/src/session/manager.ts
+++ b/packages/ac2-open-claw-reference/src/session/manager.ts
@@ -2,10 +2,19 @@
 
 import type { Ac2Client } from '@algorandfoundation/ac2-sdk';
 import type { Ac2Transport } from '@algorandfoundation/ac2-sdk/transport';
+import type { Sendable } from '../channel/stream.js';
 
 export interface ActiveSession {
   readonly transport: Ac2Transport;
   readonly client: Ac2Client;
+  /**
+   * The `ac2-stream` control-frame surface (the stream DataChannel), when the
+   * wallet negotiated one. Host-initiated outbound sends (e.g. a sub-agent
+   * completion announce delivered through the channel's `message`/`outbound`
+   * adapters) use this to emit thread-scoped `finalize` frames instead of a
+   * raw, thread-less transport write. Falls back to `transport` when absent.
+   */
+  readonly controlTransport?: Sendable;
   /** Controller (wallet) DID, from `KeyResponse.from` during bootstrap. */
   readonly controllerDid: string;
   /** Agent DID, derived from the bootstrap `KeyResponse.public_key`. */
@@ -16,6 +25,13 @@ export interface ActiveSession {
   readonly walletAddress?: string;
   /** True once the wallet granted the agent an identity (bootstrap `KeyRequest`). */
   readonly identityGranted?: boolean;
+  /**
+   * True when a *different* controller connected to an agent already bound to
+   * another one. The session stays open only to explain the lock — inbound
+   * messages are NOT routed to the agent, and no identity is granted — until
+   * the operator clears the agent's keys under `~/.openclaw` (`ac2 forget`).
+   */
+  readonly locked?: boolean;
 }
 
 export class SessionManager {

--- a/packages/ac2-open-claw-reference/tests/binding.test.ts
+++ b/packages/ac2-open-claw-reference/tests/binding.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+
+import { decideControllerBinding } from '../src/identity/binding.js';
+
+/**
+ * An agent install registers to the first controller (wallet) that grants it an
+ * identity and stays bound to it. `decideControllerBinding` enforces that a
+ * *different* controller cannot silently take the agent over: it must be locked
+ * out until the operator clears the agent's keys under `~/.openclaw`.
+ */
+describe('decideControllerBinding — first-controller lock', () => {
+  const BOUND = 'did:key:zBoundController';
+  const OTHER = 'did:key:zOtherController';
+
+  it('registers when no controller is bound yet (first run)', () => {
+    expect(
+      decideControllerBinding({
+        boundControllerDid: undefined,
+        connectedAccountDid: BOUND,
+        hasStoredIdentity: false,
+      }),
+    ).toBe('register');
+  });
+
+  it('reuses the identity when the bound controller reconnects', () => {
+    expect(
+      decideControllerBinding({
+        boundControllerDid: BOUND,
+        connectedAccountDid: BOUND,
+        hasStoredIdentity: true,
+      }),
+    ).toBe('reuse');
+  });
+
+  it('reuses on a presence-only reconnect that omits the account', () => {
+    expect(
+      decideControllerBinding({
+        boundControllerDid: BOUND,
+        connectedAccountDid: undefined,
+        hasStoredIdentity: true,
+      }),
+    ).toBe('reuse');
+  });
+
+  it('locks out a different controller connecting to a bound agent', () => {
+    expect(
+      decideControllerBinding({
+        boundControllerDid: BOUND,
+        connectedAccountDid: OTHER,
+        hasStoredIdentity: true,
+      }),
+    ).toBe('locked');
+  });
+
+  it('locks even if the foreign controller would otherwise have no stored identity', () => {
+    // The foreign check runs before the reuse/register fallback, so a new
+    // wallet can never bootstrap a fresh identity on a bound agent.
+    expect(
+      decideControllerBinding({
+        boundControllerDid: BOUND,
+        connectedAccountDid: OTHER,
+        hasStoredIdentity: false,
+      }),
+    ).toBe('locked');
+  });
+});

--- a/packages/ac2-open-claw-reference/tests/cli-command.test.ts
+++ b/packages/ac2-open-claw-reference/tests/cli-command.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isMissingWebRtcError } from '../src/cli/ac2-command.js';
+import { isMissingWebRtcError, shouldSeedConnectionId } from '../src/cli/ac2-command.js';
 
 function moduleLoadError(code: 'ERR_MODULE_NOT_FOUND' | 'MODULE_NOT_FOUND', message: string): Error {
   const err = new Error(message) as Error & { code: string };
@@ -52,5 +52,25 @@ describe('ac2 command WebRTC error handling', () => {
     expect(
       isMissingWebRtcError(moduleLoadError('MODULE_NOT_FOUND', "Cannot find module 'socket.io-client'")),
     ).toBe(false);
+  });
+});
+
+describe('shouldSeedConnectionId', () => {
+  it('seeds the stable connection id from the first pairing when none is persisted', () => {
+    expect(shouldSeedConnectionId(undefined, 'req-fresh')).toBe(true);
+    expect(shouldSeedConnectionId('', 'req-fresh')).toBe(true);
+  });
+
+  it('never re-seeds once a stable connection id already exists (reconnect keeps the id)', () => {
+    // The whole point of the fix: a reconnect mints a *fresh* Liquid Auth
+    // requestId, but the persisted connection id must stay put so history and
+    // identity are not orphaned.
+    expect(shouldSeedConnectionId('stable-connection-id', 'req-fresh')).toBe(false);
+  });
+
+  it('does not seed when the freshly-minted requestId is missing or blank', () => {
+    expect(shouldSeedConnectionId(undefined, undefined)).toBe(false);
+    expect(shouldSeedConnectionId(undefined, '')).toBe(false);
+    expect(shouldSeedConnectionId(undefined, 42)).toBe(false);
   });
 });

--- a/packages/ac2-open-claw-reference/tests/did.test.ts
+++ b/packages/ac2-open-claw-reference/tests/did.test.ts
@@ -4,6 +4,7 @@ import {
   extractEd25519PublicKey,
   normalizeDidKey,
   publicKeyToDidKey,
+  resolveStableControllerDid,
 } from '../src/identity/did.js';
 
 // A genuine W3C did:key ed25519 example. We derive the public-key bytes from
@@ -54,5 +55,56 @@ describe('did:key normalization', () => {
   it('leaves non-key placeholders untouched', () => {
     expect(normalizeDidKey('did:key:zAc2Controller')).toBe('did:key:zAc2Controller');
     expect(extractEd25519PublicKey('did:key:zAc2Controller')).toBeUndefined();
+  });
+});
+
+/**
+ * The agent's OpenClaw session is keyed by `ac2:<controllerDid>:<thid>`, and
+ * that transcript is persisted on disk — so a reconnect only restores the
+ * thread's context when `controllerDid` resolves to the same value every time.
+ * `resolveStableControllerDid` anchors it to the granted identity so a
+ * presence-only reconnect (which may omit the wallet / carry a differently
+ * encoded peer DID) can never rotate the key and "forget" the conversation.
+ */
+describe('resolveStableControllerDid — reconnect session-key stability', () => {
+  const GRANTED = CANONICAL_DID;
+
+  it('anchors to the granted identity even when the live link omits the account', () => {
+    expect(
+      resolveStableControllerDid({ storedControllerDid: GRANTED, connectedAccountDid: undefined }),
+    ).toBe(GRANTED);
+  });
+
+  it('keeps the granted identity even if the live link reports a different account', () => {
+    // A presence-only reconnect must not rebind the routing key to a new DID.
+    expect(
+      resolveStableControllerDid({
+        storedControllerDid: GRANTED,
+        connectedAccountDid: 'did:key:zSomeOtherAccount',
+      }),
+    ).toBe(GRANTED);
+  });
+
+  it('falls back to the live account before any identity is granted', () => {
+    expect(
+      resolveStableControllerDid({
+        storedControllerDid: undefined,
+        connectedAccountDid: GRANTED,
+      }),
+    ).toBe(GRANTED);
+  });
+
+  it('falls back to an explicit placeholder when nothing is known', () => {
+    expect(
+      resolveStableControllerDid({
+        storedControllerDid: undefined,
+        connectedAccountDid: undefined,
+        placeholder: 'did:key:zPlaceholder',
+      }),
+    ).toBe('did:key:zPlaceholder');
+  });
+
+  it('uses the default placeholder when none is provided', () => {
+    expect(resolveStableControllerDid({})).toBe('did:key:zAc2Controller');
   });
 });

--- a/packages/ac2-open-claw-reference/tests/liquid-auth-provider.test.ts
+++ b/packages/ac2-open-claw-reference/tests/liquid-auth-provider.test.ts
@@ -5,6 +5,7 @@ import {
   awaitSignalConnect,
   closeAwareTransport,
   closeRtcDataChannel,
+  cookiePairsFromSetCookie,
   resolveHeartbeatTimeoutMs,
   withSignalingHealthGuard,
 } from '../src/providers/liquid-auth.js';
@@ -377,6 +378,43 @@ describe('LiquidAuthChannelProvider heartbeat timeout', () => {
   it('falls back for invalid or too-small overrides', () => {
     expect(resolveHeartbeatTimeoutMs('not-a-number')).toBe(50_000);
     expect(resolveHeartbeatTimeoutMs('39999')).toBe(50_000);
+  });
+});
+
+describe('cookiePairsFromSetCookie', () => {
+  it('returns undefined for missing headers', () => {
+    expect(cookiePairsFromSetCookie(undefined)).toBeUndefined();
+    expect(cookiePairsFromSetCookie(null)).toBeUndefined();
+    expect(cookiePairsFromSetCookie('')).toBeUndefined();
+  });
+
+  it('extracts the name=value pair from a single set-cookie string', () => {
+    expect(cookiePairsFromSetCookie('connect.sid=s%3Aabc.def; Path=/; HttpOnly; SameSite=Lax')).toBe(
+      'connect.sid=s%3Aabc.def',
+    );
+  });
+
+  it('joins multiple cookies from an array of set-cookie strings', () => {
+    expect(
+      cookiePairsFromSetCookie([
+        'connect.sid=abc; Path=/; HttpOnly',
+        'other=xyz; Path=/; Secure',
+      ]),
+    ).toBe('connect.sid=abc; other=xyz');
+  });
+
+  it('splits a comma-joined header without mangling Expires dates', () => {
+    // A single cookie whose Expires attribute contains a comma must not be
+    // split into two "cookies"; only the name=value pair is kept anyway.
+    expect(
+      cookiePairsFromSetCookie(
+        'connect.sid=abc; Expires=Wed, 21 Oct 2026 07:28:00 GMT; Path=/',
+      ),
+    ).toBe('connect.sid=abc');
+  });
+
+  it('splits two comma-joined cookies at their boundary', () => {
+    expect(cookiePairsFromSetCookie('a=1; Path=/, b=2; Path=/')).toBe('a=1; b=2');
   });
 });
 

--- a/packages/ac2-open-claw-reference/tests/liquid-auth-reconnect.test.ts
+++ b/packages/ac2-open-claw-reference/tests/liquid-auth-reconnect.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Regression tests for the "keep the signaling socket alive across reconnects"
+ * behavior. The mobile wallet keeps ONE signaling socket and just re-runs its
+ * WebRTC offer when it reopens; the agent must mirror that — an ordinary peer
+ * drop must tear down ONLY the p2p peer and KEEP the signaling socket connected
+ * so the caller can re-arm `connect()` and answer the returning wallet in place
+ * (no presence churn, no QR rescan, no manual Reconnect). Only a genuinely dead
+ * socket (`dispose`) fully tears the signaling connection down.
+ *
+ * The Liquid Auth `SignalClient` and the `socket.io-client` factory are mocked
+ * so `startPairing`/`connect` can run headless: the fakes let us assert exactly
+ * which teardown calls happen on `close()` vs `dispose()`.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const H = vi.hoisted(() => {
+  const clientCloseSpy = vi.fn<(disconnect?: boolean) => void>();
+  const socketCloseSpy = vi.fn<() => void>();
+  const socketDisconnectSpy = vi.fn<() => void>();
+  const state = {
+    lastSocket: null as any,
+    lastClient: null as any,
+    peerCalls: 0,
+    peerCloseSpies: [] as Array<ReturnType<typeof vi.fn>>,
+    // When set, the fake `peer()` parks on this promise after creating its
+    // `peerClient` — mimicking the real SDK awaiting the wallet's link/offer —
+    // so tests can interleave events with an in-flight negotiation.
+    peerGate: null as Promise<void> | null,
+  };
+  return { clientCloseSpy, socketCloseSpy, socketDisconnectSpy, state };
+});
+
+vi.mock('socket.io-client', () => ({
+  io: (_url: string, _opts: unknown) => {
+    const listeners: Record<string, Array<(...args: any[]) => void>> = {};
+    const socket = {
+      connected: true,
+      // `attachSessionCookiePersistence` pokes `socket.io?.engine?.transport`;
+      // an empty object keeps its optional-chaining guards happy.
+      io: {} as any,
+      on(ev: string, fn: (...args: any[]) => void) {
+        (listeners[ev] ??= []).push(fn);
+      },
+      off(ev: string, fn?: (...args: any[]) => void) {
+        if (!fn) delete listeners[ev];
+        else listeners[ev] = (listeners[ev] ?? []).filter((f) => f !== fn);
+      },
+      emit(ev: string, ...args: any[]) {
+        for (const fn of [...(listeners[ev] ?? [])]) fn(...args);
+      },
+      close() {
+        this.connected = false;
+        H.socketCloseSpy();
+      },
+      disconnect() {
+        this.connected = false;
+        H.socketDisconnectSpy();
+      },
+    };
+    H.state.lastSocket = socket;
+    return socket;
+  },
+}));
+
+vi.mock('@algorandfoundation/liquid-client/signal', () => {
+  class FakeSignalClient {
+    socket: any;
+    peerClient: any;
+    authenticated = false;
+    requestId: string | undefined;
+    private _listeners: Record<string, Array<(...args: any[]) => void>> = {};
+
+    static generateRequestId(): string {
+      return 'req-test';
+    }
+
+    constructor(_url: string, opts: { socket: any }) {
+      this.socket = opts.socket;
+      H.state.lastClient = this;
+      // Mirror the real SDK: a socket `connect` surfaces as a client `connect`
+      // (this is what `awaitSignalConnect` waits on).
+      this.socket.on('connect', () => this.emit('connect'));
+    }
+
+    on(ev: string, fn: (...args: any[]) => void): void {
+      (this._listeners[ev] ??= []).push(fn);
+    }
+
+    off(ev: string, fn?: (...args: any[]) => void): void {
+      if (!fn) delete this._listeners[ev];
+      else this._listeners[ev] = (this._listeners[ev] ?? []).filter((f) => f !== fn);
+    }
+
+    emit(ev: string, ...args: any[]): void {
+      for (const fn of [...(this._listeners[ev] ?? [])]) fn(...args);
+    }
+
+    deepLink(id: string): string {
+      return `liquid://example/?requestId=${id}`;
+    }
+
+    close(disconnect = false): void {
+      H.clientCloseSpy(disconnect);
+      if (disconnect) this.socket.disconnect();
+    }
+
+    async peer(
+      _requestId: string,
+      _type: string,
+      _config: unknown,
+      opts: { dataChannels: Record<string, unknown> },
+    ): Promise<any> {
+      H.state.peerCalls += 1;
+      const peerCloseSpy = vi.fn();
+      this.peerClient = { close: peerCloseSpy };
+      H.state.peerCloseSpies.push(peerCloseSpy);
+      if (H.state.peerGate) {
+        // Park like the real `peer()` does while awaiting the wallet's
+        // link/offer, then dereference `peerClient` exactly like the real SDK
+        // (`this.peerClient.onicecandidate = …`) — a teardown that nulled it
+        // mid-flight reproduces the production TypeError.
+        await H.state.peerGate;
+        if (!this.peerClient) {
+          throw new TypeError("Cannot set properties of undefined (setting 'onicecandidate')");
+        }
+      }
+      const channels: Record<string, any> = {};
+      for (const label of Object.keys(opts?.dataChannels ?? {})) {
+        const ch = {
+          label,
+          readyState: 'open' as const,
+          onopen: null,
+          onclose: null,
+          onerror: null,
+          onmessage: null,
+          send() {},
+          close() {
+            (this as any).readyState = 'closed';
+          },
+        };
+        channels[label] = ch;
+        // The real SDK surfaces every negotiated channel via `data-channel`.
+        this.emit('data-channel', ch);
+      }
+      return channels['ac2-v1'];
+    }
+  }
+  return { SignalClient: FakeSignalClient };
+});
+
+// Import AFTER the mocks are registered.
+const { LiquidAuthChannelProvider } = await import('../src/providers/liquid-auth.js');
+
+async function startAndConnect(): Promise<{
+  handle: Awaited<ReturnType<InstanceType<typeof LiquidAuthChannelProvider>['startPairing']>>;
+  paired: Awaited<
+    ReturnType<
+      Awaited<ReturnType<InstanceType<typeof LiquidAuthChannelProvider>['startPairing']>>['connect']
+    >
+  >;
+}> {
+  const provider = new LiquidAuthChannelProvider({ origin: 'https://example.test' });
+  const handlePromise = provider.startPairing({ timeoutMs: 5_000 });
+  // The socket is created after `ensureWebRtcPolyfill()`; once it exists, emit
+  // `connect` so `startPairing`'s `await waitForConnect` resolves.
+  await vi.waitFor(() => {
+    expect(H.state.lastSocket).toBeTruthy();
+  });
+  H.state.lastSocket.emit('connect');
+  const handle = await handlePromise;
+  const paired = await handle.connect();
+  return { handle, paired };
+}
+
+describe('LiquidAuthChannelProvider — socket-preserving reconnect', () => {
+  beforeEach(() => {
+    // A polyfilled WebRTC global short-circuits the native `@roamhq/wrtc` import.
+    (globalThis as any).RTCPeerConnection ??= class {};
+    H.clientCloseSpy.mockClear();
+    H.socketCloseSpy.mockClear();
+    H.socketDisconnectSpy.mockClear();
+    H.state.lastSocket = null;
+    H.state.lastClient = null;
+    H.state.peerCalls = 0;
+    H.state.peerCloseSpies = [];
+    H.state.peerGate = null;
+  });
+
+  it('close() tears down ONLY the peer and keeps the signaling socket connected', async () => {
+    const { handle, paired } = await startAndConnect();
+    expect(H.state.peerCalls).toBe(1);
+
+    await paired.close();
+
+    // Peer torn down…
+    expect(H.state.peerCloseSpies[0]).toHaveBeenCalledTimes(1);
+    // …but the signaling socket is left ALIVE for an in-place re-link.
+    expect(H.clientCloseSpy).not.toHaveBeenCalled();
+    expect(H.socketDisconnectSpy).not.toHaveBeenCalled();
+    expect(H.socketCloseSpy).not.toHaveBeenCalled();
+    expect(handle.isSignalingAlive?.()).toBe(true);
+  });
+
+  it('surfaces a control-transport close to the consumer without dropping the socket', async () => {
+    const { handle, paired } = await startAndConnect();
+    let closed = 0;
+    paired.transport.onClose(() => {
+      closed += 1;
+    });
+
+    await paired.close();
+
+    expect(closed).toBe(1); // consumer notified (session loop wakes up)…
+    expect(handle.isSignalingAlive?.()).toBe(true); // …socket still usable.
+  });
+
+  it('connect() is re-runnable on the SAME socket (answers a returning wallet in place)', async () => {
+    const { handle, paired } = await startAndConnect();
+    await paired.close();
+
+    // Re-arm on the same live socket — no new socket is created.
+    const socketBefore = H.state.lastSocket;
+    const paired2 = await handle.connect();
+
+    expect(H.state.peerCalls).toBe(2);
+    expect(H.state.lastSocket).toBe(socketBefore);
+    expect(paired2.transport).toBeDefined();
+    expect(handle.isSignalingAlive?.()).toBe(true);
+
+    await paired2.close();
+  });
+
+  it('dispose() fully tears down the signaling socket', async () => {
+    const { handle, paired } = await startAndConnect();
+    await paired.close();
+
+    await handle.dispose?.();
+
+    expect(H.clientCloseSpy).toHaveBeenCalledWith(true);
+    expect(H.socketCloseSpy).toHaveBeenCalled();
+    expect(handle.isSignalingAlive?.()).toBe(false);
+  });
+
+  it('tears down a LIVE connection (peer-only) when presence reports the peer went offline', async () => {
+    const { handle, paired } = await startAndConnect();
+    // The wallet linked, arming presence-driven teardown.
+    H.state.lastClient.emit('link-message', { wallet: 'W' });
+    let closed = 0;
+    paired.transport.onClose(() => {
+      closed += 1;
+    });
+
+    // The phone closed: the server broadcasts a drop to a single device while
+    // our own signaling link is still healthy — a real departure.
+    H.state.lastSocket.emit('presence', {
+      requestId: 'req-test',
+      deviceCount: 1,
+      online: true,
+    });
+
+    await vi.waitFor(() => {
+      expect(H.state.peerCloseSpies[0]).toHaveBeenCalledTimes(1);
+    });
+    // Consumer is notified so the re-pair loop wakes and re-arms…
+    expect(closed).toBe(1);
+    // …but the signaling socket is KEPT alive for an in-place re-link.
+    expect(H.clientCloseSpy).not.toHaveBeenCalled();
+    expect(H.socketDisconnectSpy).not.toHaveBeenCalled();
+    expect(handle.isSignalingAlive?.()).toBe(true);
+  });
+
+  it('does NOT tear down an in-flight re-link negotiation on a presence drop', async () => {
+    // Regression for the production crash: the wallet linked once, the session
+    // dropped, and `connect()` was re-armed — parked inside `peer()` awaiting
+    // the wallet's return. A presence broadcast still reporting a single
+    // device then invoked the (stale) close, whose `teardownPeer` nulled
+    // `SignalClient.peerClient` under the pending handshake; when the wallet
+    // re-linked, `peer()` resumed and crashed with
+    // "Cannot set properties of undefined (setting 'onicecandidate')" /
+    // "Cannot read properties of undefined (reading 'setRemoteDescription')",
+    // failing the wallet's first re-link attempt (`[ac2] Pairing failed`).
+    const { handle, paired } = await startAndConnect();
+    H.state.lastClient.emit('link-message', { wallet: 'W' });
+    await paired.close();
+
+    // Re-arm on the same socket, holding the negotiation in flight (the wallet
+    // is still away).
+    let releaseWallet!: () => void;
+    H.state.peerGate = new Promise<void>((resolve) => {
+      releaseWallet = resolve;
+    });
+    const reconnect = handle.connect();
+    await vi.waitFor(() => {
+      expect(H.state.peerCalls).toBe(2);
+    });
+
+    // The server still reports just this agent — the drop must NOT tear down
+    // the armed negotiation (it is exactly what answers the returning wallet).
+    H.state.lastSocket.emit('presence', {
+      requestId: 'req-test',
+      deviceCount: 1,
+      online: true,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(H.state.peerCloseSpies[1]).not.toHaveBeenCalled();
+    expect(H.state.lastClient.peerClient).toBeTruthy();
+
+    // The wallet returns: the parked handshake resolves in place — no TypeError.
+    releaseWallet();
+    H.state.peerGate = null;
+    const paired2 = await reconnect;
+    expect(paired2.transport).toBeDefined();
+    expect(handle.isSignalingAlive?.()).toBe(true);
+    await paired2.close();
+  });
+
+  it('does NOT tear down a live connection when a presence drop coincides with a signaling blip', async () => {
+    const { handle, paired } = await startAndConnect();
+    H.state.lastClient.emit('link-message', { wallet: 'W' });
+    let closed = 0;
+    paired.transport.onClose(() => {
+      closed += 1;
+    });
+
+    // OUR OWN signaling socket blips (server restart) — signaling is now
+    // unstable, so a transient recount to a single device is an artifact, not a
+    // departure, and must not restart a healthy p2p connection.
+    H.state.lastSocket.emit('disconnect');
+    H.state.lastSocket.emit('presence', {
+      requestId: 'req-test',
+      deviceCount: 1,
+      online: true,
+    });
+
+    // Give any async close a tick to (not) happen.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(H.state.peerCloseSpies[0]).not.toHaveBeenCalled();
+    expect(closed).toBe(0);
+    expect(handle.isSignalingAlive?.()).toBe(true);
+  });
+});

--- a/packages/ac2-open-claw-reference/tests/plugin.test.ts
+++ b/packages/ac2-open-claw-reference/tests/plugin.test.ts
@@ -33,6 +33,9 @@ import {
   sessionManager,
   resolveAc2SessionConversation,
   resolveAc2OutboundSessionRoute,
+  buildAc2SessionKey,
+  routeInboundToAgent,
+  classifyAgentError,
   AC2_MEDIA_SOURCE_PARAMS,
   getToolPluginMetadata,
   pluginManifest as plugin,
@@ -603,7 +606,7 @@ describe('ac2 plugin', () => {
       }
     });
 
-    it('keeps the channel open (no_active_session) and notifies the user when the wallet rejects the bootstrap KeyRequest', async () => {
+    it('keeps the channel open (active but identity-less) and notifies the user when the wallet rejects the bootstrap KeyRequest', async () => {
       const peerRaw: string[] = [];
       const provider = new (class extends InMemoryChannelProvider {
         protected override onPairingPrepared(peerTransport: Ac2Transport): void {
@@ -625,8 +628,8 @@ describe('ac2 plugin', () => {
               ),
             );
           });
-          // Capture the chat-surface notice the agent sends after a failed
-          // bootstrap.
+          // Capture the banner notice the agent pushes after a failed
+          // bootstrap (surfaced as a `notice` control frame, not a chat message).
           peerTransport.onRawMessage?.((msg) => {
             peerRaw.push(msg);
           });
@@ -648,15 +651,34 @@ describe('ac2 plugin', () => {
       // Let the bootstrap round-trip + the no-identity notice flow.
       await new Promise((resolve) => setTimeout(resolve, 100));
 
-      // A rejected bootstrap is non-fatal: the session is never activated
-      // (tools keep seeing `no_active_session`), but the channel stays open
-      // so the user can still converse.
-      expect(manager.getActive()).toBeNull();
+      // A rejected bootstrap is non-fatal: the transport is up and the wallet
+      // is chatting, so the channel IS connected. The session is registered as
+      // active with `identityGranted: false` (instead of being left inactive,
+      // which used to make the channel/tools report "registered but not online"
+      // while the user was actively chatting). Signing stays locked until the
+      // wallet grants an identity, and no agent DID is surfaced.
+      const active = manager.getActive();
+      expect(active).not.toBeNull();
+      expect(active!.identityGranted).toBe(false);
+
       const caps = capabilitiesFlow({}, { manager });
-      expect(caps.status).toBe('no_active_session');
+      expect(caps.status).toBe('ok');
+      expect(caps.session.connected).toBe(true);
       expect(caps.agent.did).toBeNull();
 
-      // The user is told (over the chat surface) that an identity is needed.
+      // Signing is still gated on the missing identity.
+      const signOutcome = await signFlow(
+        {
+          description: 'should be locked — no identity granted',
+          payload_base64: Buffer.from('x').toString('base64'),
+        },
+        {},
+        { manager },
+      );
+      expect(signOutcome.status).toBe('rejected');
+      if (signOutcome.status === 'rejected') expect(signOutcome.reason).toBe('no_identity');
+
+      // The user is told (via a `notice` banner frame) that an identity is needed.
       expect(peerRaw.some((m) => m.toLowerCase().includes('identity'))).toBe(true);
 
       // Aborting ends the still-open channel cleanly (it does not throw).
@@ -836,6 +858,313 @@ describe('ac2 plugin', () => {
       expect(
         resolveAc2OutboundSessionRoute({ target: `${did}:default`, from: 'a' }).sessionKey,
       ).toBe(`ac2:${did}`);
+    });
+  });
+
+  describe('canonical session key (buildAc2SessionKey)', () => {
+    const did = 'did:key:zStubController';
+
+    it('collapses the default thread (and empty/undefined) to the bare base key', () => {
+      expect(buildAc2SessionKey(did)).toBe(`ac2:${did}`);
+      expect(buildAc2SessionKey(did, 'default')).toBe(`ac2:${did}`);
+      expect(buildAc2SessionKey(did, '')).toBe(`ac2:${did}`);
+    });
+
+    it('suffixes an explicit (non-default) thread', () => {
+      expect(buildAc2SessionKey(did, 'thread-7')).toBe(`ac2:${did}:thread-7`);
+    });
+
+    it('matches the outbound route for the same controller + thread', () => {
+      expect(buildAc2SessionKey(did)).toBe(
+        resolveAc2OutboundSessionRoute({ target: did, from: 'did:key:zAgent' }).sessionKey,
+      );
+      expect(buildAc2SessionKey(did, 'thread-7')).toBe(
+        resolveAc2OutboundSessionRoute({ target: did, from: 'did:key:zAgent', threadId: 'thread-7' })
+          .sessionKey,
+      );
+    });
+  });
+
+  describe('inbound session-key consistency (routeInboundToAgent)', () => {
+    /**
+     * Capture the `SessionKey` the plugin hands the host reply dispatcher on an
+     * inbound turn. The host persists the agent's conversation under exactly
+     * this key, so it MUST match the canonical outbound key — otherwise the
+     * default-thread conversation is split across `ac2:<did>` and
+     * `ac2:<did>:default` and the agent "forgets" the thread on reconnect.
+     */
+    interface RecordedInbound {
+      storePath?: string;
+      sessionKey?: string;
+      createIfMissing?: boolean;
+      ctxSessionKey?: string;
+      ctxAgentId?: string;
+    }
+
+    interface Captured {
+      sessionKey?: string;
+      /** Inbound-session records the plugin asked the host to persist. */
+      recorded: RecordedInbound[];
+      /** `resolveStorePath` invocations: `[store, opts]`. */
+      storePathCalls: Array<{ store?: string | undefined; agentId?: string | undefined }>;
+      /** True once dispatch ran; asserts recording happened BEFORE dispatch. */
+      dispatchedAfterRecord?: boolean;
+    }
+
+    /**
+     * Build a host `api` double that captures both the `SessionKey` handed to
+     * the reply dispatcher AND the inbound-session record the plugin persists
+     * first. `withSession` toggles the `channel.session` surface so we can also
+     * prove the plugin degrades gracefully on a runtime that lacks it.
+     */
+    function makeCapturingApi(opts?: {
+      withSession?: boolean;
+      agentId?: string;
+    }): { api: any; captured: Captured } {
+      const withSession = opts?.withSession ?? true;
+      const agentId = opts?.agentId;
+      const captured: Captured = { recorded: [], storePathCalls: [] };
+      const channel: any = {
+        routing: {
+          resolveAgentRoute(_params: unknown): { agentId: string } | undefined {
+            return agentId !== undefined ? { agentId } : undefined;
+          },
+        },
+        reply: {
+          dispatchReplyWithBufferedBlockDispatcher(this: unknown, args: any): void {
+            captured.sessionKey = args?.ctx?.SessionKey;
+            captured.dispatchedAfterRecord = captured.recorded.length > 0;
+            // Settle the turn immediately with no assistant text.
+            args?.dispatcherOptions?.onIdle?.();
+          },
+        },
+      };
+      if (withSession) {
+        channel.session = {
+          resolveStorePath(store?: string, o?: { agentId?: string }): string {
+            captured.storePathCalls.push({ store, agentId: o?.agentId });
+            return `/tmp/openclaw/agents/${o?.agentId ?? 'main'}/sessions/sessions.json`;
+          },
+          async recordInboundSession(params: any): Promise<void> {
+            captured.recorded.push({
+              storePath: params?.storePath,
+              sessionKey: params?.sessionKey,
+              createIfMissing: params?.createIfMissing,
+              ctxSessionKey: params?.ctx?.SessionKey,
+              ctxAgentId: params?.ctx?.AgentId,
+            });
+          },
+        };
+      }
+      const api = {
+        config: {},
+        logger: { info(): void {}, warn(): void {}, error(): void {} },
+        runtime: { channel },
+      };
+      return { api, captured };
+    }
+
+    const noopTransport = { isOpen: true, send(): void {} } as unknown as Ac2Transport;
+
+    it('keys a default-thread turn to the bare base key (matches the outbound route)', async () => {
+      const did = 'did:key:zInboundController';
+      const { api, captured } = makeCapturingApi();
+      await routeInboundToAgent(api, 'hello', noopTransport, did);
+      const outbound = resolveAc2OutboundSessionRoute({ target: did, from: 'did:key:zAgent' });
+      expect(captured.sessionKey).toBe(`ac2:${did}`);
+      expect(captured.sessionKey).toBe(outbound.sessionKey);
+    });
+
+    it('suffixes an explicit thread and matches the outbound route for that thread', async () => {
+      const did = 'did:key:zInboundController';
+      const { api, captured } = makeCapturingApi();
+      const frame = JSON.stringify({ thid: 'thread-7', body: { content: 'hi' } });
+      await routeInboundToAgent(api, frame, noopTransport, did);
+      const outbound = resolveAc2OutboundSessionRoute({
+        target: did,
+        from: 'did:key:zAgent',
+        threadId: 'thread-7',
+      });
+      expect(captured.sessionKey).toBe(`ac2:${did}:thread-7`);
+      expect(captured.sessionKey).toBe(outbound.sessionKey);
+    });
+
+    /**
+     * The buffered reply dispatcher only mirrors the assistant reply into an
+     * already-recorded session entry; it does not create the durable
+     * per-`SessionKey` entry the host reloads after a shutdown. The plugin must
+     * therefore call `recordInboundSession` (createIfMissing) BEFORE dispatch,
+     * under the same key — otherwise the agent "forgets" the conversation on
+     * every OpenClaw restart even though the key is stable.
+     */
+    it('records the inbound session (createIfMissing) before dispatch, under the same key', async () => {
+      const did = 'did:key:zInboundController';
+      const { api, captured } = makeCapturingApi({ agentId: 'main' });
+      await routeInboundToAgent(api, 'hello', noopTransport, did);
+      expect(captured.recorded).toHaveLength(1);
+      const rec = captured.recorded[0]!;
+      expect(rec.sessionKey).toBe(`ac2:${did}`);
+      // Persisted under the exact key the dispatcher used.
+      expect(rec.sessionKey).toBe(captured.sessionKey);
+      expect(rec.ctxSessionKey).toBe(captured.sessionKey);
+      expect(rec.createIfMissing).toBe(true);
+      // Recording precedes dispatch so the entry exists when the run persists.
+      expect(captured.dispatchedAfterRecord).toBe(true);
+    });
+
+    it('resolves the store path (and ctx.AgentId) with the resolved route agent', async () => {
+      const did = 'did:key:zInboundController';
+      const { api, captured } = makeCapturingApi({ agentId: 'support' });
+      await routeInboundToAgent(api, 'hello', noopTransport, did);
+      expect(captured.storePathCalls).toHaveLength(1);
+      expect(captured.storePathCalls[0]!.agentId).toBe('support');
+      expect(captured.recorded[0]!.storePath).toBe(
+        '/tmp/openclaw/agents/support/sessions/sessions.json',
+      );
+      // ctx.AgentId anchors the dispatcher's own store lookup to the same agent.
+      expect(captured.recorded[0]!.ctxAgentId).toBe('support');
+    });
+
+    it('still dispatches when the runtime lacks a session surface (older hosts)', async () => {
+      const did = 'did:key:zInboundController';
+      const { api, captured } = makeCapturingApi({ withSession: false });
+      await routeInboundToAgent(api, 'hello', noopTransport, did);
+      expect(captured.recorded).toHaveLength(0);
+      expect(captured.sessionKey).toBe(`ac2:${did}`);
+    });
+  });
+
+  describe('classifyAgentError', () => {
+    it('classifies quota / rate-limit / billing failures as quota_exceeded', () => {
+      const quotaCases: unknown[] = [
+        'You have exceeded your monthly quota',
+        new Error('Rate limit reached for requests'),
+        'rate_limit_exceeded',
+        'RateLimitError: slow down',
+        'HTTP 429 Too Many Requests',
+        'insufficient_quota',
+        'Your account has insufficient funds',
+        'insufficient credit remaining',
+        'You are out of credit',
+        'billing hard limit reached',
+        'Payment Required',
+      ];
+      for (const raw of quotaCases) {
+        expect(classifyAgentError(raw).code).toBe('quota_exceeded');
+      }
+    });
+
+    it('classifies everything else as a generic agent_error', () => {
+      expect(classifyAgentError(new Error('network timeout')).code).toBe('agent_error');
+      expect(classifyAgentError('some random failure').code).toBe('agent_error');
+      expect(classifyAgentError(undefined).code).toBe('agent_error');
+      expect(classifyAgentError(null).code).toBe('agent_error');
+    });
+
+    it('never leaks the raw error text into the client-facing message', () => {
+      const raw = 'internal stacktrace secret-token quota exceeded at provider.ts:42';
+      const classified = classifyAgentError(raw);
+      expect(classified.code).toBe('quota_exceeded');
+      expect(classified.text).not.toContain('secret-token');
+      expect(classified.text).not.toContain('provider.ts');
+      expect(classified.text.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('agent-error reply (routeInboundToAgent)', () => {
+    const did = 'did:key:zErrController';
+
+    /** A wallet transport that records every control frame the plugin sends. */
+    function makeCapturingTransport(): { transport: Ac2Transport; frames: any[] } {
+      const frames: any[] = [];
+      const transport = {
+        isOpen: true,
+        send(payload: string): void {
+          // Control frames are STX (\u0002) + JSON; ignore anything else.
+          if (typeof payload === 'string' && payload.startsWith('\u0002')) {
+            try {
+              frames.push(JSON.parse(payload.slice(1)));
+            } catch {
+              // not a control frame we care about
+            }
+          }
+        },
+      } as unknown as Ac2Transport;
+      return { transport, frames };
+    }
+
+    /**
+     * A host `api` double whose reply dispatcher fails the turn: either by
+     * invoking the dispatcher's `onError` callback (the common provider-error
+     * path) or by throwing synchronously (exercising the outer `catch`).
+     */
+    function makeErroringApi(opts: { error: unknown; throwSync?: boolean }): any {
+      return {
+        config: {},
+        logger: { info(): void {}, warn(): void {}, error(): void {} },
+        runtime: {
+          channel: {
+            reply: {
+              dispatchReplyWithBufferedBlockDispatcher(this: unknown, args: any): void {
+                if (opts.throwSync) throw opts.error;
+                args?.dispatcherOptions?.onError?.(opts.error);
+              },
+            },
+          },
+        },
+      };
+    }
+
+    const finals = (frames: any[]): any[] => frames.filter((f) => f?.t === 'finalize');
+    const notices = (frames: any[]): any[] => frames.filter((f) => f?.t === 'notice');
+    const discards = (frames: any[]): any[] => frames.filter((f) => f?.t === 'discard');
+
+    it('delivers a quota-specific error reply + error notice instead of a silent discard', async () => {
+      const err = new Error('Provider rejected request: 429 insufficient_quota');
+      const { transport, frames } = makeCapturingTransport();
+      await routeInboundToAgent(makeErroringApi({ error: err }), 'hello', transport, did);
+
+      const finalized = finals(frames);
+      expect(finalized).toHaveLength(1);
+      expect(finalized[0]!.thid).toBe('default');
+      // The client gets the canned, quota-aware message — never the raw error.
+      expect(finalized[0]!.text).toBe(classifyAgentError(err).text);
+      expect(finalized[0]!.text).not.toContain('insufficient_quota');
+      // The turn is NOT silently discarded.
+      expect(discards(frames)).toHaveLength(0);
+
+      const noticed = notices(frames);
+      expect(noticed).toHaveLength(1);
+      expect(noticed[0]!.code).toBe('quota_exceeded');
+      expect(noticed[0]!.level).toBe('error');
+    });
+
+    it('delivers a generic error reply for a non-quota agent failure', async () => {
+      const err = new Error('upstream connection reset');
+      const { transport, frames } = makeCapturingTransport();
+      await routeInboundToAgent(makeErroringApi({ error: err }), 'hello', transport, did);
+
+      const finalized = finals(frames);
+      expect(finalized).toHaveLength(1);
+      expect(finalized[0]!.text).toBe(classifyAgentError(err).text);
+      expect(discards(frames)).toHaveLength(0);
+      expect(notices(frames)[0]!.code).toBe('agent_error');
+    });
+
+    it('also reports an error message when the dispatch call itself throws', async () => {
+      const err = new Error('rate limit exceeded');
+      const { transport, frames } = makeCapturingTransport();
+      await routeInboundToAgent(
+        makeErroringApi({ error: err, throwSync: true }),
+        'hello',
+        transport,
+        did,
+      );
+      const finalized = finals(frames);
+      expect(finalized).toHaveLength(1);
+      expect(finalized[0]!.text).toBe(classifyAgentError(err).text);
+      expect(notices(frames)[0]!.code).toBe('quota_exceeded');
+      expect(discards(frames)).toHaveLength(0);
     });
   });
 

--- a/packages/ac2-open-claw-reference/tests/presence.test.ts
+++ b/packages/ac2-open-claw-reference/tests/presence.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  AC2_PRESENCE_EVENT,
+  hasPeerPresence,
+  normalizePresence,
+  queryPresence,
+  shouldTeardownOnPresence,
+  subscribeToPresence,
+} from '../src/providers/liquid-auth.js';
+
+type Ack = (data: unknown) => void;
+
+/** Minimal socket.io-like mock capturing the presence emit + broadcasts. */
+function createFakeSocket() {
+  const listeners = new Map<string, Set<(...args: any[]) => void>>();
+  let lastEmit: { event: string; payload: unknown; ack?: Ack | undefined } | undefined;
+  return {
+    lastEmit: () => lastEmit,
+    emit(event: string, payload: unknown, ack?: Ack) {
+      lastEmit = { event, payload, ack };
+    },
+    on(event: string, listener: (...args: any[]) => void) {
+      (listeners.get(event) ?? listeners.set(event, new Set()).get(event)!).add(listener);
+    },
+    off(event: string, listener: (...args: any[]) => void) {
+      listeners.get(event)?.delete(listener);
+    },
+    broadcast(event: string, ...args: any[]) {
+      listeners.get(event)?.forEach((l) => l(...args));
+    },
+    listenerCount(event: string) {
+      return listeners.get(event)?.size ?? 0;
+    },
+  };
+}
+
+describe('normalizePresence', () => {
+  it('passes through a well-formed payload', () => {
+    expect(
+      normalizePresence('req-1', { requestId: 'req-1', deviceCount: 2, online: true }),
+    ).toEqual({ requestId: 'req-1', deviceCount: 2, online: true });
+  });
+
+  it('derives online from deviceCount and falls back to the queried id', () => {
+    expect(normalizePresence('req-2', { deviceCount: 3 })).toEqual({
+      requestId: 'req-2',
+      deviceCount: 3,
+      online: true,
+    });
+    expect(normalizePresence('req-3', {})).toEqual({
+      requestId: 'req-3',
+      deviceCount: 0,
+      online: false,
+    });
+  });
+
+  it('tolerates a null/undefined payload', () => {
+    expect(normalizePresence('req-4', null)).toEqual({
+      requestId: 'req-4',
+      deviceCount: 0,
+      online: false,
+    });
+  });
+});
+
+describe('queryPresence', () => {
+  it('emits the presence event and resolves with the server ack', async () => {
+    const socket = createFakeSocket();
+    const pending = queryPresence(socket, 'req-1');
+    const emit = socket.lastEmit();
+    expect(emit?.event).toBe(AC2_PRESENCE_EVENT);
+    expect(emit?.payload).toEqual({ requestId: 'req-1' });
+    emit?.ack?.({ requestId: 'req-1', deviceCount: 2, online: true });
+    await expect(pending).resolves.toEqual({ requestId: 'req-1', deviceCount: 2, online: true });
+  });
+
+  it('rejects on an empty requestId without emitting', async () => {
+    const socket = createFakeSocket();
+    await expect(queryPresence(socket, '')).rejects.toThrow(/non-empty requestId/);
+    expect(socket.lastEmit()).toBeUndefined();
+  });
+
+  it('rejects when no ack arrives within the timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const socket = createFakeSocket();
+      const pending = queryPresence(socket, 'req-1', { timeoutMs: 5_000 });
+      const assertion = expect(pending).rejects.toThrow(/timed out waiting for presence ack/);
+      await vi.advanceTimersByTimeAsync(5_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects if the socket emit throws', async () => {
+    const socket = {
+      emit: () => {
+        throw new Error('socket down');
+      },
+    };
+    await expect(queryPresence(socket as any, 'req-1')).rejects.toThrow('socket down');
+  });
+});
+
+describe('subscribeToPresence', () => {
+  it('forwards normalized broadcasts and unsubscribes cleanly', () => {
+    const socket = createFakeSocket();
+    const seen: unknown[] = [];
+    const unsubscribe = subscribeToPresence(socket, (p) => seen.push(p));
+
+    socket.broadcast(AC2_PRESENCE_EVENT, { requestId: 'req-1', deviceCount: 1, online: true });
+    socket.broadcast(AC2_PRESENCE_EVENT, { requestId: 'req-1', deviceCount: 0 });
+
+    expect(seen).toEqual([
+      { requestId: 'req-1', deviceCount: 1, online: true },
+      { requestId: 'req-1', deviceCount: 0, online: false },
+    ]);
+
+    unsubscribe();
+    expect(socket.listenerCount(AC2_PRESENCE_EVENT)).toBe(0);
+  });
+
+  it('is a no-op against a socket without on/off', () => {
+    const unsubscribe = subscribeToPresence({ emit: () => {} }, () => {});
+    expect(() => unsubscribe()).not.toThrow();
+  });
+});
+
+describe('shouldTeardownOnPresence', () => {
+  it('tears down once a linked wallet drops back to a single device (no negotiation armed)', () => {
+    expect(
+      shouldTeardownOnPresence(
+        { requestId: 'req-1', deviceCount: 1, online: true },
+        {
+          peerLinked: true,
+          closed: false,
+          connected: false,
+          signalingStable: true,
+          negotiating: false,
+        },
+      ),
+    ).toBe(true);
+    // Zero devices (both gone) also counts as the peer being offline.
+    expect(
+      shouldTeardownOnPresence(
+        { requestId: 'req-1', deviceCount: 0, online: false },
+        {
+          peerLinked: true,
+          closed: false,
+          connected: false,
+          signalingStable: true,
+          negotiating: false,
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it('does NOT tear down while a re-link negotiation is already armed and waiting', () => {
+    // Regression: a presence drop during an in-flight `connect()` used to call
+    // the (stale) close and null `SignalClient.peerClient` under the pending
+    // `peer()`, crashing the handshake the moment the wallet re-linked with
+    // "Cannot set properties of undefined (setting 'onicecandidate')" /
+    // "Cannot read properties of undefined (reading 'setRemoteDescription')".
+    // The armed negotiation IS the awaiting-the-wallet state; leave it alone.
+    expect(
+      shouldTeardownOnPresence(
+        { requestId: 'req-1', deviceCount: 1, online: true },
+        {
+          peerLinked: true,
+          closed: false,
+          connected: false,
+          signalingStable: true,
+          negotiating: true,
+        },
+      ),
+    ).toBe(false);
+    expect(
+      shouldTeardownOnPresence(
+        { requestId: 'req-1', deviceCount: 0, online: false },
+        {
+          peerLinked: true,
+          closed: false,
+          connected: false,
+          signalingStable: false,
+          negotiating: true,
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it('still tears down a LIVE connection during the brief connected-while-negotiating window', () => {
+    // `connected` flips true just before `connect()` returns (and resets
+    // `negotiating`); a real presence drop in that window is still acted on.
+    expect(
+      shouldTeardownOnPresence(
+        { requestId: 'req-1', deviceCount: 1, online: true },
+        {
+          peerLinked: true,
+          closed: false,
+          connected: true,
+          signalingStable: true,
+          negotiating: true,
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it('does not tear down while the wallet is still present (2+ devices)', () => {
+    expect(
+      shouldTeardownOnPresence(
+        { requestId: 'req-1', deviceCount: 2, online: true },
+        {
+          peerLinked: true,
+          closed: false,
+          connected: true,
+          signalingStable: true,
+          negotiating: false,
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it('does not tear down before the first link (single device is normal)', () => {
+    expect(
+      shouldTeardownOnPresence(
+        { requestId: 'req-1', deviceCount: 1, online: true },
+        {
+          peerLinked: false,
+          closed: false,
+          connected: false,
+          signalingStable: true,
+          negotiating: true,
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it('never re-triggers once already closed', () => {
+    expect(
+      shouldTeardownOnPresence(
+        { requestId: 'req-1', deviceCount: 0, online: false },
+        {
+          peerLinked: true,
+          closed: true,
+          connected: true,
+          signalingStable: true,
+          negotiating: false,
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it('tears down a LIVE connection when the peer goes offline and signaling is stable', () => {
+    // The phone closed: the server broadcasts a drop to a single device while
+    // our own signaling link is healthy. This is a real departure — close now
+    // (and re-arm) rather than waiting out the heartbeat.
+    expect(
+      shouldTeardownOnPresence(
+        { requestId: 'req-1', deviceCount: 1, online: true },
+        {
+          peerLinked: true,
+          closed: false,
+          connected: true,
+          signalingStable: true,
+          negotiating: false,
+        },
+      ),
+    ).toBe(true);
+    expect(
+      shouldTeardownOnPresence(
+        { requestId: 'req-1', deviceCount: 0, online: false },
+        {
+          peerLinked: true,
+          closed: false,
+          connected: true,
+          signalingStable: true,
+          negotiating: false,
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it('does NOT tear down a live connection on a presence drop caused by a signaling-server loss', () => {
+    // Our own signaling socket dropped/reconnected (`signalingStable === false`)
+    // so a transient low device count is a recount artifact, not a departure.
+    // The live data channel already proves the peer is there; leave it alone.
+    expect(
+      shouldTeardownOnPresence(
+        { requestId: 'req-1', deviceCount: 1, online: true },
+        {
+          peerLinked: true,
+          closed: false,
+          connected: true,
+          signalingStable: false,
+          negotiating: false,
+        },
+      ),
+    ).toBe(false);
+    expect(
+      shouldTeardownOnPresence(
+        { requestId: 'req-1', deviceCount: 0, online: false },
+        {
+          peerLinked: true,
+          closed: false,
+          connected: true,
+          signalingStable: false,
+          negotiating: false,
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it('still tears down between negotiations even if signaling is unstable (no live channel to trust)', () => {
+    // Before the control channel is live there is no p2p connection to protect,
+    // so a linked peer dropping to a single device is acted on — as long as no
+    // negotiation is armed (an armed one must be left waiting; see above).
+    expect(
+      shouldTeardownOnPresence(
+        { requestId: 'req-1', deviceCount: 1, online: true },
+        {
+          peerLinked: true,
+          closed: false,
+          connected: false,
+          signalingStable: false,
+          negotiating: false,
+        },
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('hasPeerPresence', () => {
+  it('resolves true when at least one device is connected', async () => {
+    const socket = createFakeSocket();
+    const pending = hasPeerPresence(socket, 'req-1');
+    socket.lastEmit()?.ack?.({ requestId: 'req-1', deviceCount: 1, online: true });
+    await expect(pending).resolves.toBe(true);
+  });
+
+  it('resolves false when nobody is connected', async () => {
+    const socket = createFakeSocket();
+    const pending = hasPeerPresence(socket, 'req-1');
+    socket.lastEmit()?.ack?.({ requestId: 'req-1', deviceCount: 0, online: false });
+    await expect(pending).resolves.toBe(false);
+  });
+
+  it('swallows query errors into false', async () => {
+    await expect(hasPeerPresence({ emit: () => {} }, '')).resolves.toBe(false);
+  });
+});

--- a/packages/ac2-open-claw-reference/tests/resolve-config.test.ts
+++ b/packages/ac2-open-claw-reference/tests/resolve-config.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { resolveConfig, type OpenClawApi } from '../src/runtime.js';
+
+/**
+ * `resolveConfig` must surface the `liquidAuthServer` documented on the
+ * `channels.ac2` config surface (the one `ac2 setup` writes and `ac2 status`
+ * reads) and honour the `AC2_LIQUID_AUTH_SERVER` env override at runtime —
+ * otherwise pairing silently ignores the configured URL and falls back to the
+ * default server.
+ */
+describe('resolveConfig — liquidAuthServer resolution', () => {
+  let prevServer: string | undefined;
+
+  beforeEach(() => {
+    prevServer = process.env['AC2_LIQUID_AUTH_SERVER'];
+    delete process.env['AC2_LIQUID_AUTH_SERVER'];
+  });
+
+  afterEach(() => {
+    if (prevServer === undefined) delete process.env['AC2_LIQUID_AUTH_SERVER'];
+    else process.env['AC2_LIQUID_AUTH_SERVER'] = prevServer;
+  });
+
+  it('reads liquidAuthServer from channels.ac2 config', () => {
+    const api = {
+      config: { channels: { ac2: { liquidAuthServer: 'https://from-channel.test' } } },
+    } as unknown as OpenClawApi;
+    expect(resolveConfig(api).liquidAuthServer).toBe('https://from-channel.test');
+  });
+
+  it('lets plugins.entries.ac2.config override the channel value', () => {
+    const api = {
+      config: {
+        channels: { ac2: { liquidAuthServer: 'https://from-channel.test' } },
+        plugins: { entries: { ac2: { config: { liquidAuthServer: 'https://from-entry.test' } } } },
+      },
+    } as unknown as OpenClawApi;
+    expect(resolveConfig(api).liquidAuthServer).toBe('https://from-entry.test');
+  });
+
+  it('AC2_LIQUID_AUTH_SERVER env overrides the configured value', () => {
+    process.env['AC2_LIQUID_AUTH_SERVER'] = 'https://from-env.test';
+    const api = {
+      config: { channels: { ac2: { liquidAuthServer: 'https://from-channel.test' } } },
+    } as unknown as OpenClawApi;
+    expect(resolveConfig(api).liquidAuthServer).toBe('https://from-env.test');
+  });
+
+  it('ignores a blank AC2_LIQUID_AUTH_SERVER env value', () => {
+    process.env['AC2_LIQUID_AUTH_SERVER'] = '   ';
+    const api = {
+      config: { channels: { ac2: { liquidAuthServer: 'https://from-channel.test' } } },
+    } as unknown as OpenClawApi;
+    expect(resolveConfig(api).liquidAuthServer).toBe('https://from-channel.test');
+  });
+
+  it('returns undefined liquidAuthServer when nothing is configured', () => {
+    const api = { config: {} } as unknown as OpenClawApi;
+    expect(resolveConfig(api).liquidAuthServer).toBeUndefined();
+  });
+});

--- a/packages/ac2-open-claw-reference/tests/state.test.ts
+++ b/packages/ac2-open-claw-reference/tests/state.test.ts
@@ -6,12 +6,15 @@ import { join } from 'node:path';
 import {
   ensureConversation,
   getConnection,
+  getSessionCookie,
   listConnections,
   listConversations,
   loadAc2State,
   recordConversationMessage,
+  recordTaskActivity,
   recordToolActivity,
   setConnectionIdentity,
+  setSessionCookie,
   touchConnection,
 } from '../src/identity/state.js';
 import { replayConversationHistory, replayConversationList } from '../src/index.js';
@@ -223,6 +226,59 @@ describe('conversation restore (control-frame replay)', () => {
       output: 'a\nb',
     });
   });
+
+  it('replayConversationHistory replays background-task cards with their status/result', () => {
+    recordTaskActivity('req-1', 'thread-a', {
+      id: 'task:task-research',
+      title: 'Weather research',
+      prompt: 'research the weather API',
+      status: 'completed',
+      result: 'It is sunny.',
+    });
+
+    const { sent, transport } = transportSpy();
+    replayConversationHistory(transport, 'req-1', 'thread-a');
+
+    const frame = parseControlFrame(sent[0]!);
+    expect(frame.t).toBe('history');
+    const task = frame.messages.find((m: any) => m.role === 'task');
+    expect(task).toMatchObject({
+      role: 'task',
+      id: 'task:task-research',
+      title: 'Weather research',
+      prompt: 'research the weather API',
+      status: 'completed',
+      result: 'It is sunny.',
+    });
+  });
+});
+
+describe('session-cookie persistence', () => {
+  it('returns undefined when no cookie has been stored', () => {
+    expect(getSessionCookie('req-1')).toBeUndefined();
+  });
+
+  it('persists and reads back a session cookie scoped to a connection', () => {
+    setSessionCookie('req-1', 'connect.sid=abc');
+    expect(getSessionCookie('req-1')).toBe('connect.sid=abc');
+    // Survives a reload from disk and does not leak across connections.
+    expect(loadAc2State().connections?.['req-1']?.sessionCookie).toBe('connect.sid=abc');
+    expect(getSessionCookie('req-2')).toBeUndefined();
+  });
+
+  it('overwrites the cookie on a later capture (rolling session)', () => {
+    setSessionCookie('req-1', 'connect.sid=old');
+    setSessionCookie('req-1', 'connect.sid=new');
+    expect(getSessionCookie('req-1')).toBe('connect.sid=new');
+  });
+
+  it('preserves existing connection data when storing a cookie', () => {
+    recordConversationMessage('req-1', 'thread-a', { role: 'user', text: 'hi', at: 1 });
+    setSessionCookie('req-1', 'connect.sid=abc');
+    expect(getSessionCookie('req-1')).toBe('connect.sid=abc');
+    // The conversation history is untouched by the cookie write.
+    expect(listConversations('req-1')).toHaveLength(1);
+  });
 });
 
 describe('tool-activity persistence', () => {
@@ -242,5 +298,51 @@ describe('tool-activity persistence', () => {
     );
     expect(tools).toHaveLength(1);
     expect(tools[0]).toMatchObject({ id: 'tool-1', command: 'ls', output: 'file-a' });
+  });
+});
+
+describe('background-task-card persistence', () => {
+  it('records a new task entry (running) on a thread', () => {
+    recordTaskActivity('req-1', 'thread-a', {
+      id: 'task:task-x',
+      title: 'Do x',
+      prompt: 'do x',
+      status: 'running',
+    });
+    const convo = getConnection('req-1')?.conversations['thread-a'];
+    const task = convo?.messages.find((m) => m.role === 'task');
+    expect(task).toMatchObject({
+      id: 'task:task-x',
+      title: 'Do x',
+      prompt: 'do x',
+      status: 'running',
+    });
+  });
+
+  it('upserts the same task id in place (running → completed + result)', () => {
+    recordTaskActivity('req-1', 'thread-a', {
+      id: 'task:task-x',
+      title: 'Do x',
+      prompt: 'do x',
+      status: 'running',
+    });
+    // Completion re-records the same id with a terminal status + result; the
+    // earlier title/prompt must be preserved (merge only supplied fields).
+    recordTaskActivity('req-1', 'thread-a', {
+      id: 'task:task-x',
+      status: 'completed',
+      result: 'x is done',
+    });
+    const tasks = (getConnection('req-1')?.conversations['thread-a']?.messages ?? []).filter(
+      (m) => m.role === 'task',
+    );
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toMatchObject({
+      id: 'task:task-x',
+      title: 'Do x',
+      prompt: 'do x',
+      status: 'completed',
+      result: 'x is done',
+    });
   });
 });

--- a/packages/ac2-open-claw-reference/tests/subagent-hooks-realtext.test.ts
+++ b/packages/ac2-open-claw-reference/tests/subagent-hooks-realtext.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Ac2Transport } from '@algorandfoundation/ac2-sdk/transport';
+
+// Mock the transcript reader so a completed run yields a known "real" answer,
+// letting us assert the hook delivers the child's actual result (not the
+// lifecycle notice) into the parent thread.
+const mocks = vi.hoisted(() => ({
+  readChildResultText: vi.fn(),
+  readChildSessionStatus: vi.fn(() => ({ exists: false, ended: false })),
+  discoverChildSessionKey: vi.fn(() => undefined),
+  describeSubagentCandidates: vi.fn(() => 'diag'),
+}));
+vi.mock('../src/channel/subagent-result.js', () => ({
+  readChildResultText: mocks.readChildResultText,
+  readChildSessionStatus: mocks.readChildSessionStatus,
+  discoverChildSessionKey: mocks.discoverChildSessionKey,
+  describeSubagentCandidates: mocks.describeSubagentCandidates,
+}));
+
+import {
+  registerTask,
+  getTaskByThid,
+  resetTasks,
+  handleSubagentEnded,
+  sessionManager,
+} from '../src/index.js';
+
+const CONTROLLER = 'did:key:zStubController';
+
+interface Frame {
+  t: string;
+  thid?: string;
+  text?: string;
+  status?: string;
+  result?: string;
+}
+
+describe('subagent_ended delivers the child result text', () => {
+  const controlSent: string[] = [];
+
+  beforeEach(() => {
+    resetTasks();
+    controlSent.length = 0;
+    mocks.readChildResultText.mockReset();
+    sessionManager.setActive({
+      transport: { isOpen: true, send: () => {} } as unknown as Ac2Transport,
+      client: {} as never,
+      controllerDid: CONTROLLER,
+      agentDid: 'did:ac2:agent',
+      controlTransport: { isOpen: true, send: (p: string) => controlSent.push(p) },
+    });
+  });
+
+  afterEach(() => {
+    sessionManager.clearActive();
+  });
+
+  it('posts the real answer text into the parent thread on success', async () => {
+    mocks.readChildResultText.mockResolvedValue('Here are the 3 findings you asked for.');
+    const task = registerTask({
+      parentThid: 'thread-7',
+      task: 'do research',
+      taskName: 'research',
+      runId: 'run-1',
+      childSessionKey: 'agent:main:subagent:abc',
+    });
+
+    await handleSubagentEnded(
+      { targetSessionKey: 'agent:main:subagent:abc', outcome: 'ok', runId: 'run-1' },
+      { runId: 'run-1', childSessionKey: 'agent:main:subagent:abc' },
+    );
+
+    const frame = JSON.parse(controlSent[0]!.slice(1)) as Frame;
+    expect(frame.t).toBe('task');
+    expect(frame.thid).toBe('thread-7');
+    expect(frame.status).toBe('completed');
+    expect(frame.result).toBe('Here are the 3 findings you asked for.');
+    expect(getTaskByThid(task.taskThid)?.resultText).toBe(
+      'Here are the 3 findings you asked for.',
+    );
+    // The reader is queried with the task's authoritative child identifiers.
+    expect(mocks.readChildResultText).toHaveBeenCalledWith(
+      expect.objectContaining({ childSessionKey: 'agent:main:subagent:abc' }),
+    );
+  });
+
+  it('does not query the transcript for a failed run', async () => {
+    registerTask({
+      parentThid: 'thread-7',
+      task: 'flaky',
+      taskName: 'flaky',
+      runId: 'run-2',
+      childSessionKey: 'agent:main:subagent:def',
+    });
+
+    await handleSubagentEnded(
+      { targetSessionKey: 'agent:main:subagent:def', outcome: 'error', error: 'boom', runId: 'run-2' },
+      { runId: 'run-2', childSessionKey: 'agent:main:subagent:def' },
+    );
+
+    const frame = JSON.parse(controlSent[0]!.slice(1)) as Frame;
+    expect(frame.t).toBe('task');
+    expect(frame.status).toBe('failed');
+    expect(frame.result).toContain('failed');
+    expect(mocks.readChildResultText).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ac2-open-claw-reference/tests/subagent-hooks.test.ts
+++ b/packages/ac2-open-claw-reference/tests/subagent-hooks.test.ts
@@ -1,0 +1,432 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { Ac2Transport } from '@algorandfoundation/ac2-sdk/transport';
+import {
+  registerTask,
+  getTaskByThid,
+  findTaskByRun,
+  markTaskResult,
+  resetTasks,
+  handleSubagentSpawned,
+  handleSubagentEnded,
+  registerSubagentHooks,
+  resetSubagentHooksRegistration,
+  watchTaskCompletion,
+  resetTaskWatchers,
+  subagentPolling,
+  sessionManager,
+} from '../src/index.js';
+
+/** Snapshot of the default poller wiring, restored after each poller test. */
+const DEFAULT_POLLING = { ...subagentPolling };
+/** Flush the microtask/timer queue so a fire-and-forget watcher can settle. */
+const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 20));
+
+const STX = '\u0002';
+const CONTROLLER = 'did:key:zStubController';
+
+interface Frame {
+  t: string;
+  thid?: string;
+  mid?: string;
+  text?: string;
+  id?: string;
+  title?: string;
+  status?: string;
+  prompt?: string;
+  result?: string;
+}
+
+describe('sub-agent lifecycle hooks (background-task completion)', () => {
+  const controlSent: string[] = [];
+  const baseSent: string[] = [];
+
+  function frames(): Frame[] {
+    return controlSent.map((raw) => JSON.parse(raw.slice(1)) as Frame);
+  }
+
+  beforeEach(() => {
+    resetTasks();
+    resetSubagentHooksRegistration();
+    resetTaskWatchers();
+    Object.assign(subagentPolling, DEFAULT_POLLING);
+    controlSent.length = 0;
+    baseSent.length = 0;
+    // Activate WITHOUT a requestId so we exercise the wire (control frames) and
+    // task lifecycle without touching on-disk persistence.
+    const transport = {
+      isOpen: true,
+      send: (payload: string) => baseSent.push(payload),
+    } as unknown as Ac2Transport;
+    sessionManager.setActive({
+      transport,
+      client: {} as never,
+      controllerDid: CONTROLLER,
+      agentDid: 'did:ac2:agent',
+      controlTransport: {
+        isOpen: true,
+        send: (payload: string) => controlSent.push(payload),
+      },
+    });
+  });
+
+  afterEach(() => {
+    sessionManager.clearActive();
+  });
+
+  it('posts a completion message into the parent thread on success', async () => {
+    const task = registerTask({
+      parentThid: 'thread-7',
+      task: 'do research',
+      taskName: 'research',
+      runId: 'run-1',
+      childSessionKey: 'child-1',
+    });
+
+    await handleSubagentEnded(
+      { targetSessionKey: 'child-1', outcome: 'ok', runId: 'run-1' },
+      { runId: 'run-1', childSessionKey: 'child-1' },
+    );
+
+    const f = frames();
+    // A single self-contained task card into the parent thread (no dedicated
+    // task-… thread). The child's transcript is unavailable in this test, so we
+    // fall back to the lifecycle notice as the card's result text.
+    expect(f).toHaveLength(1);
+    expect(f[0]!.t).toBe('task');
+    expect(f[0]!.thid).toBe('thread-7');
+    expect(f[0]!.status).toBe('completed');
+    expect(f[0]!.result).toContain('finished');
+    expect(f[0]!.result).toContain('research');
+    expect(controlSent[0]!.startsWith(STX)).toBe(true);
+
+    // The task is flipped to completed with the notice as its result text.
+    expect(getTaskByThid(task.taskThid)?.status).toBe('completed');
+  });
+
+  it('reports a failure (with error text) and marks the task failed', async () => {
+    const task = registerTask({
+      parentThid: 'thread-7',
+      task: 'flaky job',
+      taskName: 'flaky',
+      runId: 'run-2',
+      childSessionKey: 'child-2',
+    });
+
+    await handleSubagentEnded(
+      { targetSessionKey: 'child-2', outcome: 'error', error: 'boom', runId: 'run-2' },
+      { runId: 'run-2', childSessionKey: 'child-2' },
+    );
+
+    const f = frames();
+    expect(f).toHaveLength(1);
+    expect(f[0]!.t).toBe('task');
+    expect(f[0]!.thid).toBe('thread-7');
+    expect(f[0]!.status).toBe('failed');
+    expect(f[0]!.result).toContain('failed');
+    expect(f[0]!.result).toContain('boom');
+    expect(getTaskByThid(task.taskThid)?.status).toBe('failed');
+  });
+
+  it('reports a killed run as stopped', async () => {
+    const task = registerTask({
+      parentThid: 'thread-7',
+      task: 'long job',
+      taskName: 'long',
+      runId: 'run-3',
+      childSessionKey: 'child-3',
+    });
+
+    await handleSubagentEnded(
+      { targetSessionKey: 'child-3', reason: 'killed', runId: 'run-3' },
+      { runId: 'run-3', childSessionKey: 'child-3' },
+    );
+
+    const f = frames();
+    expect(f[0]!.t).toBe('task');
+    expect(f[0]!.status).toBe('stopped');
+    expect(f[0]!.result).toContain('stopped');
+    expect(getTaskByThid(task.taskThid)?.status).toBe('stopped');
+  });
+
+  it('ignores internal reset/deleted lifecycle churn', async () => {
+    const task = registerTask({
+      parentThid: 'thread-7',
+      task: 'noop',
+      taskName: 'noop',
+      runId: 'run-4',
+      childSessionKey: 'child-4',
+    });
+
+    await handleSubagentEnded(
+      { targetSessionKey: 'child-4', reason: 'reset', runId: 'run-4' },
+      { runId: 'run-4', childSessionKey: 'child-4' },
+    );
+
+    expect(controlSent).toHaveLength(0);
+    expect(getTaskByThid(task.taskThid)?.status).toBe('running');
+  });
+
+  it('does not double-post when the task was already reconciled', async () => {
+    const task = registerTask({
+      parentThid: 'thread-7',
+      task: 'done already',
+      taskName: 'dupe',
+      runId: 'run-5',
+      childSessionKey: 'child-5',
+    });
+    // Simulate deliverAgentText having already completed it.
+    await handleSubagentEnded(
+      { targetSessionKey: 'child-5', outcome: 'ok', runId: 'run-5' },
+      { runId: 'run-5', childSessionKey: 'child-5' },
+    );
+    controlSent.length = 0;
+    // A second (duplicate) end event must be a no-op.
+    await handleSubagentEnded(
+      { targetSessionKey: 'child-5', outcome: 'ok', runId: 'run-5' },
+      { runId: 'run-5', childSessionKey: 'child-5' },
+    );
+    expect(controlSent).toHaveLength(0);
+    expect(getTaskByThid(task.taskThid)?.status).toBe('completed');
+  });
+
+  it('binds the authoritative runId/childSessionKey on spawn correlation', () => {
+    // Routing registered the task from the tool call, but without ids yet.
+    registerTask({ parentThid: 'thread-7', task: 'pending job', taskName: 'pending' });
+
+    handleSubagentSpawned(
+      { requester: { threadId: 'thread-7' }, agentId: 'agent-x', label: 'pending' },
+      { runId: 'run-9', childSessionKey: 'child-9' },
+    );
+
+    const bound = findTaskByRun({ runId: 'run-9' });
+    expect(bound?.taskThid).toBe('task-pending');
+    expect(bound?.childSessionKey).toBe('child-9');
+    expect(bound?.agentId).toBe('agent-x');
+  });
+
+  it('falls back to a raw transport write when no control channel exists', async () => {
+    sessionManager.clearActive();
+    const transport = {
+      isOpen: true,
+      send: (payload: string) => baseSent.push(payload),
+    } as unknown as Ac2Transport;
+    sessionManager.setActive({
+      transport,
+      client: {} as never,
+      controllerDid: CONTROLLER,
+      agentDid: 'did:ac2:agent',
+    });
+    registerTask({
+      parentThid: 'thread-7',
+      task: 'plain',
+      taskName: 'plain',
+      runId: 'run-6',
+      childSessionKey: 'child-6',
+    });
+
+    await handleSubagentEnded(
+      { targetSessionKey: 'child-6', outcome: 'ok', runId: 'run-6' },
+      { runId: 'run-6', childSessionKey: 'child-6' },
+    );
+
+    expect(controlSent).toHaveLength(0);
+    expect(baseSent).toHaveLength(1);
+    expect(baseSent[0]).toContain('finished');
+  });
+
+  it('delivers an untracked completion to the thread from the requester key', async () => {
+    // No registerTask(): simulate the spawn tool-result/spawned-hook binding
+    // being missed, so findTaskByRun returns nothing. The completion must still
+    // be delivered, routed via the requester session key's thread.
+    await handleSubagentEnded(
+      { targetSessionKey: 'agent:main:subagent:abc', outcome: 'ok', runId: 'run-untracked' },
+      {
+        runId: 'run-untracked',
+        childSessionKey: 'agent:main:subagent:abc',
+        requesterSessionKey: `ac2:${CONTROLLER}:thread-42`,
+      },
+    );
+
+    const f = frames();
+    expect(f).toHaveLength(1);
+    expect(f[0]!.t).toBe('finalize');
+    expect(f[0]!.thid).toBe('thread-42');
+    // Transcript is unavailable in this test → lifecycle notice fallback.
+    expect(f[0]!.text).toContain('finished');
+  });
+
+  it('routes an untracked default-thread completion to the default thread', async () => {
+    await handleSubagentEnded(
+      { targetSessionKey: 'agent:main:subagent:def', outcome: 'ok', runId: 'run-default' },
+      {
+        runId: 'run-default',
+        childSessionKey: 'agent:main:subagent:def',
+        requesterSessionKey: `ac2:${CONTROLLER}:default`,
+      },
+    );
+
+    const f = frames();
+    expect(f).toHaveLength(1);
+    expect(f[0]!.thid).toBe('default');
+    expect(f[0]!.text).toContain('finished');
+  });
+
+  it('skips untracked completions whose requester is not this channel', async () => {
+    await handleSubagentEnded(
+      { targetSessionKey: 'agent:main:subagent:ghi', outcome: 'ok', runId: 'run-foreign' },
+      {
+        runId: 'run-foreign',
+        childSessionKey: 'agent:main:subagent:ghi',
+        requesterSessionKey: 'discord:guild:123:channel:456',
+      },
+    );
+
+    expect(controlSent).toHaveLength(0);
+    expect(baseSent).toHaveLength(0);
+  });
+
+  it('polls a spawned task to completion and delivers the child result', async () => {
+    const task = registerTask({
+      parentThid: 'thread-9',
+      task: 'crunch numbers',
+      taskName: 'crunch',
+      runId: 'run-poll-1',
+      childSessionKey: 'agent:main:subagent:poll1',
+    });
+
+    subagentPolling.intervalMs = 1;
+    subagentPolling.readStatus = () => ({ exists: true, ended: true, status: 'done' });
+    subagentPolling.readResult = async () => 'The answer is 42.';
+
+    watchTaskCompletion(task.taskThid);
+    await flush();
+
+    const f = frames();
+    expect(f).toHaveLength(1);
+    expect(f[0]!.t).toBe('task');
+    expect(f[0]!.thid).toBe('thread-9');
+    expect(f[0]!.status).toBe('completed');
+    expect(f[0]!.result).toBe('The answer is 42.');
+    expect(getTaskByThid(task.taskThid)?.status).toBe('completed');
+  });
+
+  it('discovers the child session by spawnedBy when the spawn key was not captured', async () => {
+    const task = registerTask({
+      parentThid: 'thread-disc',
+      parentSessionKey: 'ac2:did:key:zStubController:thread-disc',
+      task: 'no key captured',
+      taskName: 'discover',
+      runId: 'run-disc',
+      // NOTE: no childSessionKey — the accepted-spawn envelope never surfaced it.
+    });
+
+    let discoverArgs: unknown;
+    subagentPolling.intervalMs = 1;
+    subagentPolling.discover = (opts) => {
+      discoverArgs = opts;
+      return 'agent:main:subagent:discovered';
+    };
+    subagentPolling.readStatus = () => ({ exists: true, ended: true, status: 'done' });
+    subagentPolling.readResult = async () => 'recovered answer';
+
+    watchTaskCompletion(task.taskThid);
+    await flush();
+
+    expect(discoverArgs).toMatchObject({
+      parentSessionKey: 'ac2:did:key:zStubController:thread-disc',
+    });
+    const f = frames();
+    expect(f).toHaveLength(1);
+    expect(f[0]!.t).toBe('task');
+    expect(f[0]!.thid).toBe('thread-disc');
+    expect(f[0]!.result).toBe('recovered answer');
+    // The discovered key is recorded on the task for later correlation.
+    expect(getTaskByThid(task.taskThid)?.childSessionKey).toBe('agent:main:subagent:discovered');
+    expect(getTaskByThid(task.taskThid)?.status).toBe('completed');
+  });
+
+  it('keeps polling while the child runs, then delivers once it ends', async () => {
+    const task = registerTask({
+      parentThid: 'thread-10',
+      task: 'long job',
+      taskName: 'poll2',
+      runId: 'run-poll-2',
+      childSessionKey: 'agent:main:subagent:poll2',
+    });
+
+    let calls = 0;
+    subagentPolling.intervalMs = 1;
+    subagentPolling.readStatus = () => {
+      calls += 1;
+      return calls < 3
+        ? { exists: true, ended: false, status: 'running' }
+        : { exists: true, ended: true, status: 'done' };
+    };
+    subagentPolling.readResult = async () => 'done result';
+
+    watchTaskCompletion(task.taskThid);
+    await flush();
+
+    expect(calls).toBeGreaterThanOrEqual(3);
+    const f = frames();
+    expect(f).toHaveLength(1);
+    expect(f[0]!.result).toBe('done result');
+    expect(getTaskByThid(task.taskThid)?.status).toBe('completed');
+  });
+
+  it('delivers a lifecycle notice (not result text) for a failed run', async () => {
+    const task = registerTask({
+      parentThid: 'thread-11',
+      task: 'flaky job',
+      taskName: 'poll3',
+      runId: 'run-poll-3',
+      childSessionKey: 'agent:main:subagent:poll3',
+    });
+
+    subagentPolling.intervalMs = 1;
+    subagentPolling.readStatus = () => ({ exists: true, ended: true, status: 'failed' });
+    subagentPolling.readResult = async () => 'should not be read for a failure';
+
+    watchTaskCompletion(task.taskThid);
+    await flush();
+
+    const f = frames();
+    expect(f).toHaveLength(1);
+    expect(f[0]!.status).toBe('failed');
+    expect(f[0]!.result).toContain('failed');
+    expect(getTaskByThid(task.taskThid)?.status).toBe('failed');
+  });
+
+  it('does nothing when the task was already reconciled', async () => {
+    const task = registerTask({
+      parentThid: 'thread-12',
+      task: 'already done',
+      taskName: 'poll4',
+      childSessionKey: 'agent:main:subagent:poll4',
+    });
+    markTaskResult(task.taskThid, 'completed', 'already delivered');
+
+    subagentPolling.intervalMs = 1;
+    subagentPolling.readStatus = () => ({ exists: true, ended: true, status: 'done' });
+    subagentPolling.readResult = async () => 'unexpected';
+
+    watchTaskCompletion(task.taskThid);
+    await flush();
+
+    expect(controlSent).toHaveLength(0);
+    expect(baseSent).toHaveLength(0);
+  });
+
+  it('registers both lifecycle hooks on the plugin api via api.on', () => {
+    const registered: string[] = [];
+    const api = {
+      on: (hookName: string) => {
+        registered.push(hookName);
+      },
+    } as unknown as Parameters<typeof registerSubagentHooks>[0];
+
+    registerSubagentHooks(api);
+    expect(registered).toContain('subagent_spawned');
+    expect(registered).toContain('subagent_ended');
+  });
+});

--- a/packages/ac2-open-claw-reference/tests/subagent-result.test.ts
+++ b/packages/ac2-open-claw-reference/tests/subagent-result.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the host session-store readers so we can exercise `readChildResultText`
+// deterministically without a real on-disk agent store.
+const mocks = vi.hoisted(() => ({
+  getSessionEntry: vi.fn(),
+  listSessionEntries: vi.fn(() => [] as unknown[]),
+  readLatest: vi.fn(),
+  readRecent: vi.fn(),
+  resolveStorePath: vi.fn(() => '/tmp/store'),
+}));
+
+vi.mock('openclaw/plugin-sdk/session-store-runtime', () => ({
+  getSessionEntry: mocks.getSessionEntry,
+  listSessionEntries: mocks.listSessionEntries,
+  readLatestAssistantTextFromSessionTranscript: mocks.readLatest,
+  readRecentUserAssistantTextForSession: mocks.readRecent,
+  resolveStorePath: mocks.resolveStorePath,
+}));
+
+vi.mock('openclaw/plugin-sdk/config-runtime', () => ({
+  getRuntimeConfig: () => ({}),
+}));
+
+import { discoverChildSessionKey, readChildResultText } from '../src/channel/subagent-result.js';
+
+describe('readChildResultText (child transcript reader)', () => {
+  beforeEach(() => {
+    mocks.getSessionEntry.mockReset();
+    mocks.readLatest.mockReset();
+    mocks.readRecent.mockReset();
+    mocks.resolveStorePath.mockReset();
+    mocks.resolveStorePath.mockReturnValue('/tmp/store');
+  });
+
+  it('returns undefined without a child session key', async () => {
+    expect(await readChildResultText({})).toBeUndefined();
+    expect(mocks.getSessionEntry).not.toHaveBeenCalled();
+  });
+
+  it('reads the latest assistant text via the transcript file and derives agentId', async () => {
+    mocks.getSessionEntry.mockReturnValue({ sessionFile: '/tmp/store/child.jsonl' });
+    mocks.readLatest.mockResolvedValue({ text: '  the real answer  ' });
+
+    const text = await readChildResultText({
+      childSessionKey: 'agent:main:subagent:abc-123',
+    });
+
+    expect(text).toBe('the real answer');
+    // agentId parsed from the child session key.
+    expect(mocks.getSessionEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionKey: 'agent:main:subagent:abc-123', agentId: 'main' }),
+    );
+    expect(mocks.readLatest).toHaveBeenCalledWith('/tmp/store/child.jsonl');
+    expect(mocks.readRecent).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the most recent assistant turn when no transcript file', async () => {
+    mocks.getSessionEntry.mockReturnValue(undefined);
+    mocks.readRecent.mockResolvedValue([
+      { role: 'user', text: 'do it' },
+      { role: 'assistant', text: 'first' },
+      { role: 'assistant', text: 'final answer' },
+    ]);
+
+    const text = await readChildResultText({ childSessionKey: 'child:x', agentId: 'a1' });
+    expect(text).toBe('final answer');
+  });
+
+  it('returns undefined (swallows errors) when the readers throw', async () => {
+    mocks.getSessionEntry.mockImplementation(() => {
+      throw new Error('store unavailable');
+    });
+    const text = await readChildResultText({ childSessionKey: 'agent:main:subagent:z' });
+    expect(text).toBeUndefined();
+  });
+
+  it('returns undefined when neither reader yields assistant text', async () => {
+    mocks.getSessionEntry.mockReturnValue({ sessionFile: '/tmp/store/child.jsonl' });
+    mocks.readLatest.mockResolvedValue(undefined);
+    mocks.readRecent.mockResolvedValue([{ role: 'user', text: 'only user' }]);
+
+    const text = await readChildResultText({ childSessionKey: 'agent:main:subagent:z' });
+    expect(text).toBeUndefined();
+  });
+});
+
+describe('discoverChildSessionKey (spawnedBy owner match)', () => {
+  beforeEach(() => {
+    mocks.listSessionEntries.mockReset();
+    mocks.resolveStorePath.mockReset();
+    mocks.resolveStorePath.mockReturnValue('/tmp/store');
+  });
+
+  // The host lower-cases `ac2` session keys when it stores them, so a child's
+  // `spawnedBy` is the lower-cased requester key while our task keeps the
+  // original mixed-case DID. Discovery must match case-insensitively.
+  it('matches a lower-cased stored spawnedBy against a mixed-case parent key', () => {
+    mocks.listSessionEntries.mockReturnValue([
+      {
+        sessionKey: 'agent:main:subagent:child-1',
+        entry: {
+          spawnedBy: 'ac2:did:key:z6mkkmu6h9us:default',
+          startedAt: 100,
+        },
+      },
+    ]);
+
+    const key = discoverChildSessionKey({
+      parentSessionKey: 'ac2:did:key:z6MkkMu6H9Us:default',
+    });
+    expect(key).toBe('agent:main:subagent:child-1');
+  });
+
+  // The host does not store the bare requester key — it namespaces it with the
+  // child's agent, e.g. `agent:main:ac2:did:key:…:default`. Discovery must strip
+  // that `agent:<agentId>:` prefix before comparing (this was the real cause of
+  // finished background tasks never delivering their answer).
+  it('matches an owner stored with the `agent:<agentId>:` namespace prefix', () => {
+    mocks.listSessionEntries.mockReturnValue([
+      {
+        sessionKey: 'agent:main:subagent:child-ns',
+        entry: {
+          spawnedBy: 'agent:main:ac2:did:key:z6mkkmu6h9us:default',
+          startedAt: 100,
+        },
+      },
+    ]);
+
+    const key = discoverChildSessionKey({
+      parentSessionKey: 'ac2:did:key:z6MkkMu6H9Us:default',
+    });
+    expect(key).toBe('agent:main:subagent:child-ns');
+  });
+
+  it('matches a namespaced owner on the host `parentSessionKey` field too', () => {
+    mocks.listSessionEntries.mockReturnValue([
+      {
+        sessionKey: 'agent:main:subagent:child-ns2',
+        entry: {
+          parentSessionKey: 'agent:main:ac2:did:key:z6mkkmu6h9us:default',
+          startedAt: 7,
+        },
+      },
+    ]);
+    const key = discoverChildSessionKey({
+      parentSessionKey: 'ac2:did:key:z6MkkMu6H9Us:default',
+    });
+    expect(key).toBe('agent:main:subagent:child-ns2');
+  });
+
+  it('also matches the host `parentSessionKey` field, case-insensitively', () => {
+    mocks.listSessionEntries.mockReturnValue([
+      {
+        sessionKey: 'agent:main:subagent:child-2',
+        entry: { parentSessionKey: 'ac2:did:key:z6mkkmu6h9us:default', startedAt: 5 },
+      },
+    ]);
+    const key = discoverChildSessionKey({
+      parentSessionKey: 'ac2:did:key:z6MkkMu6H9Us:default',
+    });
+    expect(key).toBe('agent:main:subagent:child-2');
+  });
+
+  it('prefers the most recent unclaimed child for the same parent', () => {
+    mocks.listSessionEntries.mockReturnValue([
+      {
+        sessionKey: 'agent:main:subagent:old',
+        entry: { spawnedBy: 'ac2:did:key:zabc:default', startedAt: 1 },
+      },
+      {
+        sessionKey: 'agent:main:subagent:claimed',
+        entry: { spawnedBy: 'ac2:did:key:zabc:default', startedAt: 9 },
+      },
+      {
+        sessionKey: 'agent:main:subagent:new',
+        entry: { spawnedBy: 'ac2:did:key:zABC:default', startedAt: 5 },
+      },
+    ]);
+    const key = discoverChildSessionKey({
+      parentSessionKey: 'ac2:did:key:zabc:default',
+      excludeKeys: ['agent:main:subagent:claimed'],
+    });
+    // 'claimed' is excluded and 'old' is older than 'new'.
+    expect(key).toBe('agent:main:subagent:new');
+  });
+
+  it('ignores entries owned by a different parent', () => {
+    mocks.listSessionEntries.mockReturnValue([
+      {
+        sessionKey: 'agent:main:subagent:other',
+        entry: { spawnedBy: 'ac2:did:key:zsomeoneelse:default', startedAt: 1 },
+      },
+    ]);
+    const key = discoverChildSessionKey({
+      parentSessionKey: 'ac2:did:key:zme:default',
+    });
+    expect(key).toBeUndefined();
+  });
+
+  it('returns undefined without a parent session key', () => {
+    const key = discoverChildSessionKey({});
+    expect(key).toBeUndefined();
+    expect(mocks.listSessionEntries).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ac2-open-claw-reference/tests/subsession-outbound.test.ts
+++ b/packages/ac2-open-claw-reference/tests/subsession-outbound.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { Ac2Transport } from '@algorandfoundation/ac2-sdk/transport';
+import {
+  buildChannelObject,
+  sessionManager,
+  registerTask,
+  getTaskByThid,
+  resetTasks,
+} from '../src/index.js';
+
+const STX = '\u0002';
+const CONTROLLER = 'did:key:zStubController';
+
+interface SendTextChannel {
+  message: {
+    send: {
+      text: (a: {
+        to: string;
+        text: string;
+        threadId?: string | number | null;
+      }) => Promise<{ receipt: unknown }>;
+    };
+  };
+}
+
+describe('host-initiated outbound (sub-agent completion delivery)', () => {
+  const baseSent: string[] = [];
+  const controlSent: string[] = [];
+
+  beforeEach(() => {
+    resetTasks();
+    baseSent.length = 0;
+    controlSent.length = 0;
+  });
+
+  afterEach(() => {
+    sessionManager.clearActive();
+  });
+
+  function activate(withControl: boolean): void {
+    const transport = {
+      isOpen: true,
+      send: (payload: string) => baseSent.push(payload),
+    } as unknown as Ac2Transport;
+    sessionManager.setActive({
+      transport,
+      client: {} as never,
+      controllerDid: CONTROLLER,
+      agentDid: 'did:ac2:agent',
+      ...(withControl
+        ? {
+            controlTransport: {
+              isOpen: true,
+              send: (payload: string) => controlSent.push(payload),
+            },
+          }
+        : {}),
+    });
+  }
+
+  it('flips the matching task card to completed with the result inline', async () => {
+    activate(true);
+    const task = registerTask({ parentThid: 'thread-7', task: 'do research', taskName: 'research' });
+
+    const channel = buildChannelObject() as unknown as SendTextChannel;
+    await channel.message.send.text({
+      to: CONTROLLER,
+      text: 'here is the research result',
+      threadId: 'thread-7',
+    });
+
+    // A host-driven completion for a still-running task is delivered as the
+    // self-contained task card flipping to `completed` with the result inline —
+    // NOT a separate finalize reply bubble.
+    expect(baseSent).toHaveLength(0);
+    expect(controlSent).toHaveLength(1);
+    const frame = JSON.parse(controlSent[0]!.slice(1));
+    expect(controlSent[0]!.startsWith(STX)).toBe(true);
+    expect(frame).toMatchObject({
+      t: 'task',
+      thid: 'thread-7',
+      status: 'completed',
+      result: 'here is the research result',
+    });
+
+    // The completion announce flips the pending task to completed.
+    expect(getTaskByThid(task.taskThid)?.status).toBe('completed');
+    expect(getTaskByThid(task.taskThid)?.resultText).toBe('here is the research result');
+  });
+
+  it('flips the task card over the main transport when no separate stream channel exists', async () => {
+    // Regression: with a single DataChannel (no dedicated `ac2-stream`), the
+    // session has no `controlTransport`. The completion for a still-running task
+    // MUST still be emitted as a `t:'task'` control frame over the main transport
+    // so the card flips in place — NOT downgraded to a raw text write, which left
+    // the card stuck `running` and posted a disconnected reply bubble.
+    activate(false);
+    const task = registerTask({
+      parentThid: 'thread-7',
+      task: 'do research',
+      taskName: 'research',
+    });
+
+    const channel = buildChannelObject() as unknown as SendTextChannel;
+    await channel.message.send.text({
+      to: CONTROLLER,
+      text: 'here is the research result',
+      threadId: 'thread-7',
+    });
+
+    expect(controlSent).toHaveLength(0);
+    expect(baseSent).toHaveLength(1);
+    expect(baseSent[0]!.startsWith(STX)).toBe(true);
+    const frame = JSON.parse(baseSent[0]!.slice(1));
+    expect(frame).toMatchObject({
+      t: 'task',
+      thid: 'thread-7',
+      status: 'completed',
+      result: 'here is the research result',
+    });
+    expect(getTaskByThid(task.taskThid)?.status).toBe('completed');
+  });
+
+  it('falls back to a raw transport write for untracked agent text when no control channel exists', async () => {
+    activate(false);
+    const channel = buildChannelObject() as unknown as SendTextChannel;
+    await channel.message.send.text({ to: CONTROLLER, text: 'plain fallback' });
+    expect(controlSent).toHaveLength(0);
+    expect(baseSent).toEqual(['plain fallback']);
+  });
+
+  it('rejects delivery to a peer that is not the active controller', async () => {
+    activate(true);
+    const channel = buildChannelObject() as unknown as SendTextChannel;
+    await expect(
+      channel.message.send.text({ to: 'did:key:zSomeoneElse', text: 'nope' }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/ac2-open-claw-reference/tests/tasks.test.ts
+++ b/packages/ac2-open-claw-reference/tests/tasks.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  deriveTaskThid,
+  isTaskThid,
+  registerTask,
+  attachSpawnResult,
+  taskDisplayTitle,
+  findTaskByRun,
+  findPendingTaskForParent,
+  markTaskResult,
+  getTaskByThid,
+  listTasks,
+  resetTasks,
+  taskCardId,
+  TASK_THREAD_PREFIX,
+} from '../src/index.js';
+
+describe('sub-agent task registry', () => {
+  beforeEach(() => {
+    resetTasks();
+  });
+
+  describe('deriveTaskThid', () => {
+    it('prefers taskName, then label, then a short runId', () => {
+      expect(deriveTaskThid({ taskName: 'Docs_Update' })).toBe(`${TASK_THREAD_PREFIX}docs-update`);
+      expect(deriveTaskThid({ label: 'Linux Validation' })).toBe(
+        `${TASK_THREAD_PREFIX}linux-validation`,
+      );
+      expect(deriveTaskThid({ runId: 'run-abcdef0123456789' })).toBe(
+        `${TASK_THREAD_PREFIX}run-abcdef01`,
+      );
+    });
+
+    it('falls back to a unique anonymous id when nothing is provided', () => {
+      const a = deriveTaskThid({});
+      const b = deriveTaskThid({});
+      expect(a).not.toBe(b);
+      expect(isTaskThid(a)).toBe(true);
+      expect(isTaskThid(b)).toBe(true);
+    });
+  });
+
+  it('registers a running task under a stable thread id and derives a title', () => {
+    const task = registerTask({
+      parentThid: 'default',
+      task: 'Research the weather API',
+      taskName: 'weather_research',
+      label: 'Weather research',
+    });
+    expect(task.taskThid).toBe(`${TASK_THREAD_PREFIX}weather-research`);
+    expect(task.status).toBe('running');
+    expect(task.parentThid).toBe('default');
+    expect(taskDisplayTitle(task)).toBe('Weather research');
+    expect(getTaskByThid(task.taskThid)).toEqual(task);
+  });
+
+  it('enriches an existing task in place with the accepted spawn envelope', () => {
+    const task = registerTask({
+      parentThid: 'default',
+      task: 'do work',
+      taskName: 'worker',
+    });
+    const enriched = attachSpawnResult(task.taskThid, {
+      runId: 'run-xyz',
+      childSessionKey: 'agent:a:subagent:uuid',
+    });
+    expect(enriched?.runId).toBe('run-xyz');
+    expect(enriched?.childSessionKey).toBe('agent:a:subagent:uuid');
+    // No duplicate task was created.
+    expect(listTasks()).toHaveLength(1);
+    expect(findTaskByRun({ runId: 'run-xyz' })?.taskThid).toBe(task.taskThid);
+    expect(findTaskByRun({ childSessionKey: 'agent:a:subagent:uuid' })?.taskThid).toBe(
+      task.taskThid,
+    );
+  });
+
+  it('finds the newest pending task for a parent and clears it once completed', () => {
+    const first = registerTask({ parentThid: 'thread-1', task: 'a', taskName: 'a' });
+    const second = registerTask({ parentThid: 'thread-1', task: 'b', taskName: 'b' });
+    // A task on another parent must not be returned.
+    registerTask({ parentThid: 'thread-2', task: 'c', taskName: 'c' });
+
+    expect(findPendingTaskForParent('thread-1')?.taskThid).toBe(second.taskThid);
+
+    markTaskResult(second.taskThid, 'completed', 'done b');
+    expect(getTaskByThid(second.taskThid)?.status).toBe('completed');
+    expect(getTaskByThid(second.taskThid)?.resultText).toBe('done b');
+    // Now the older still-running task is the pending one.
+    expect(findPendingTaskForParent('thread-1')?.taskThid).toBe(first.taskThid);
+  });
+
+  it('records a failed terminal status', () => {
+    const task = registerTask({ parentThid: 'default', task: 'x', taskName: 'x' });
+    markTaskResult(task.taskThid, 'failed', 'boom');
+    expect(getTaskByThid(task.taskThid)?.status).toBe('failed');
+    expect(findPendingTaskForParent('default')).toBeUndefined();
+  });
+
+  it('records a stopped terminal status', () => {
+    const task = registerTask({ parentThid: 'default', task: 'x', taskName: 'x' });
+    markTaskResult(task.taskThid, 'stopped', 'killed');
+    expect(getTaskByThid(task.taskThid)?.status).toBe('stopped');
+  });
+
+  it('derives a stable card id from the task thread id', () => {
+    const task = registerTask({ parentThid: 'default', task: 'x', taskName: 'weather_research' });
+    // The spawn card and the completion update must share this id so the wallet
+    // upserts one card in place across its lifecycle.
+    expect(taskCardId(task.taskThid)).toBe(`task:${task.taskThid}`);
+    expect(taskCardId(task.taskThid)).toBe(taskCardId(task.taskThid));
+  });
+});

--- a/packages/ac2-sdk/src/signaling/index.ts
+++ b/packages/ac2-sdk/src/signaling/index.ts
@@ -124,8 +124,30 @@ export interface Ac2PairingHandle {
   /**
    * Resolves when the remote peer has completed pairing and the
    * channel is open. Rejects on timeout, abort, or signaling failure.
+   *
+   * Providers MAY support calling `connect()` more than once on the same
+   * handle: each call (re)establishes the peer session over a persistent
+   * signaling connection. This lets a caller answer a returning peer's fresh
+   * bringup in place — without dropping the underlying signaling link — so a
+   * reconnect does not churn presence or force the peer to re-pair.
    */
   connect(): Promise<Ac2PairedChannel>;
+  /**
+   * Optional: whether the provider's underlying signaling connection is still
+   * live. When a paired channel drops, a caller can consult this to decide
+   * between re-arming pairing on the SAME signaling connection (call
+   * `connect()` again) versus starting a fresh pairing handle. Providers with
+   * no persistent signaling connection omit this.
+   */
+  isSignalingAlive?(): boolean;
+  /**
+   * Optional: fully tear down the provider's persistent signaling connection
+   * (and any peer session). Idempotent. Callers use this when abandoning a
+   * handle whose signaling connection is still open (e.g. before replacing it
+   * with a fresh handle). Providers with no persistent signaling connection
+   * omit this.
+   */
+  dispose?(): Promise<void>;
 }
 
 /**

--- a/packages/ac2-sdk/src/transport/index.ts
+++ b/packages/ac2-sdk/src/transport/index.ts
@@ -122,6 +122,10 @@ export function rtcDataChannelTransport(channel: RtcDataChannelLike): Ac2Transpo
     errorHandler?.(err);
   };
   channel.onmessage = (ev) => {
+    console.log(
+      `[ac2-sdk] transport onmessage channel=${channel.label} type=${typeof ev.data} ` +
+        `hasMessageHandler=${messageHandler != null} hasRawHandler=${rawMessageHandler != null}`,
+    );
     // Binary frames: route to the optional binary hook. Per SPEC.md →
     // WebRTC DataChannel Transport §3, attachments MAY be sent as binary
     // DataChannel messages — so this is NOT an error condition. If no

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,8 +127,8 @@ importers:
         specifier: ^0.25.12
         version: 0.25.12
       openclaw:
-        specifier: 2026.6.1
-        version: 2026.6.1
+        specifier: 2026.7.1-2
+        version: 2026.7.1-2
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -172,8 +172,8 @@ packages:
   '@actions/io@3.0.2':
     resolution: {integrity: sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==}
 
-  '@agentclientprotocol/sdk@0.22.1':
-    resolution: {integrity: sha512-DfqXtl/8gO9NImq094MTaCXEU2vkhh6v7q/kT+9UjZxUqj8hYaya2OjLVIqn16MzNHcXEpShTR2RIauLSYeDQQ==}
+  '@agentclientprotocol/sdk@1.1.0':
+    resolution: {integrity: sha512-NT2KqphUJ3w6EksUL51ZhJgIYgq/ZLGcBPkyMKgRSO5PMVwe9DnKKX+Htnvk6KHh6dUuh34UHK4gKp+4te1Mdg==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
@@ -218,8 +218,8 @@ packages:
   '@algorandfoundation/xhd-wallet-api@2.0.0-canary.1':
     resolution: {integrity: sha512-U6rSWMO6FKDLvMxWtfKyW5ctqSy2NrONWTU/jOA+BX0SGru0GPXsxwzFdcPa5w+X055V/xVVsr8eA3xA+m/5jA==}
 
-  '@anthropic-ai/sdk@0.100.1':
-    resolution: {integrity: sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==}
+  '@anthropic-ai/sdk@0.109.1':
+    resolution: {integrity: sha512-q9OnEKLr5H9nxSuXdgDgJhxfYMiE+AaUEBze2Gk91UcaaLnsN+Lx5fbCYywiqurU/APLdwv23x03Wm6WN3EBsg==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -242,20 +242,20 @@ packages:
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
-  '@clack/core@1.3.1':
-    resolution: {integrity: sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA==}
+  '@clack/core@1.4.2':
+    resolution: {integrity: sha512-0Ty/1Gfm+Kb07sXcuESjyKfwEhSy4Ns1AgeEisHb/bDY5fWme0tTeTkU14T1Gmcs17YIjB/teiDe4uaCghbYqQ==}
     engines: {node: '>= 20.12.0'}
 
-  '@clack/prompts@1.4.0':
-    resolution: {integrity: sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==}
+  '@clack/prompts@1.6.0':
+    resolution: {integrity: sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA==}
     engines: {node: '>= 20.12.0'}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@earendil-works/pi-tui@0.78.0':
-    resolution: {integrity: sha512-3a705FnsVVUhAyceShNB3kS2rpxcxLcx+hqB0u6MMMpHwQGbW+m++MqA6r7eOzq/8FLx5e3vDh38h/SVTk2qzw==}
+  '@earendil-works/pi-tui@0.80.3':
+    resolution: {integrity: sha512-2BJI6qwRQfnM0Q7seL1+SbacU/jRRjBnN7Hu3n9BjAn7/s5FaBNnvdD1qBQYRsFTHfjqMaDsjYqanPyqwXj99w==}
     engines: {node: '>=22.19.0'}
 
   '@esbuild/aix-ppc64@0.25.12':
@@ -573,8 +573,8 @@ packages:
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
-  '@google/genai@2.7.0':
-    resolution: {integrity: sha512-tv0DRtcndt2oEhBYy+5mA0TaXH98+L1Gt0AP9unBfH7DP20KhB7+O3QqAN1Lz+laMARGTHS7BFQSNpLbl4gm1g==}
+  '@google/genai@2.10.0':
+    resolution: {integrity: sha512-e4cFxj3tiuMtsgOT4G9c1hXyGJhg7/Buj7VVeBacRY3fRtkRZZ59Q3nuVp2xbq8BGQXLXCDB253qMhklMOeUDg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.25.2
@@ -594,8 +594,8 @@ packages:
     peerDependencies:
       grammy: ^1.0.0
 
-  '@grammyjs/types@3.27.3':
-    resolution: {integrity: sha512-yUKMLliGsGbnxu96YUJ7km7B0zy4PzeH/Jvti5705R/LeKDMqkDV4DckMSt+OrliWQpTwQljHE0QLol5zgxBkg==}
+  '@grammyjs/types@3.28.0':
+    resolution: {integrity: sha512-4JvXCdxRZHCje0M4gHzLwtB4bLno3WD28xd8CNfk4POWIu73BFnSvGeW6OQ5gPem4eYTEwkD9yDaXssixl6tMQ==}
 
   '@homebridge/ciao@1.3.9':
     resolution: {integrity: sha512-TMy9zy173jDOpnFXDqL3BPIQn5lfcAkSsivYQatCCakoHk4fLGd7QjfAaNGYE3Ox+/ZI6Lq0e1gGcz1qdw/IbA==}
@@ -647,8 +647,13 @@ packages:
   '@lydell/node-pty@1.2.0-beta.12':
     resolution: {integrity: sha512-qIK890UwPupoj07osVvgOIa++1mxeHbcGry4PKRHhNVNs81V2SCG34eJr46GybiOmBtc8Sj5PB1/GGM5PL549g==}
 
-  '@mistralai/mistralai@2.2.5':
-    resolution: {integrity: sha512-ATbWzKkNzNAZ+gtw9MI/c/ULTMG80tKUiRNIbQFfg4OP0uEZZpTfXZeBCNfs5Dq0uqMQ/tQWc4o6RRJQtMrpDA==}
+  '@mistralai/mistralai@2.4.0':
+    resolution: {integrity: sha512-t6hCx242MTGolB76CI+17jDtPIe/bzLsMdUTMMoMn9Qo1h02N2G5jQYHmKDGU3X//OgR2wvngTD7tO6tPp5poQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -820,15 +825,23 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@openclaw/fs-safe@0.3.0':
-    resolution: {integrity: sha512-uIBE441CIt1kIURoP9qRGKZ8LkGyfD9ZzeESjwAd29ZPWtghws/5GR3Pjb67jKdcJHP1I6roNXcvnhzAU7lHlA==}
-    engines: {node: '>=20.11'}
+  '@openclaw/ai@2026.7.1-2':
+    resolution: {integrity: sha512-st+NH0cxlQqdbEur//yYqM7WlYBjeEBnop3cztJTSCONKjv6LNoGguI9cH65asZG94FdM/39z857isRGPnZvEw==}
+    engines: {node: '>=22.19.0'}
+
+  '@openclaw/fs-safe@0.4.1':
+    resolution: {integrity: sha512-hQi+BxO10KdRFlYUot1syC+hTaUnGeQNdqX5kwkKJig8CFq1tKsYJLPm+zkiiGsSKOprPAquQl/txejEhpKPgg==}
+    engines: {node: '>=22'}
 
   '@openclaw/proxyline@0.3.3':
     resolution: {integrity: sha512-sftHnW69NHQqLjCxBTvQ8f/eQl+peZ5pHCBQtuTWBbeuYRHZ0/GXVTmw/O/YKsShMbqPWhJB0UYtPPdvCUSS8w==}
     engines: {node: '>=22.19.0'}
     peerDependencies:
       undici: '>=8.3.0 <9'
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -1448,9 +1461,9 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  commander@14.0.3:
-    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
-    engines: {node: '>=20'}
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
 
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
@@ -1911,8 +1924,8 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  grammy@1.43.0:
-    resolution: {integrity: sha512-7dYm06A945mXuIk/5HUlSjeyIYChW8vCEiU2dkOKKqJJzwAWxTkCc91Eqbz7TgODh2rtFFKWI/fekowWHOkmjQ==}
+  grammy@1.44.0:
+    resolution: {integrity: sha512-gGVykS5+c5f1tPV97LuU6IDRMawE2NzpwM9pNz58HQ35IZXDnYL3VOLvNzYognPSeBIOSzQXRu5w96V0aY8y8A==}
     engines: {node: ^12.20.0 || >=14.13.1}
 
   handlebars@4.7.9:
@@ -2256,6 +2269,11 @@ packages:
     engines: {node: '>= 18'}
     hasBin: true
 
+  marked@18.0.5:
+    resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2504,21 +2522,29 @@ packages:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
 
-  openai@6.39.1:
-    resolution: {integrity: sha512-z3dO9fEWOXBzlXynVb/xZ/tujzUjFWQWn3C0n0mw6Vo0zJTbEkaN4b2cLWjhJ6haJQx8LlREoafHRl+Gu/Hl+A==}
-    hasBin: true
+  openai@6.45.0:
+    resolution: {integrity: sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==}
     peerDependencies:
+      '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
+      '@smithy/hash-node': '>=4.3.0 <5'
+      '@smithy/signature-v4': '>=5.4.0 <6'
       ws: ^8.18.0
       zod: ^3.25 || ^4.0
     peerDependenciesMeta:
+      '@aws-sdk/credential-provider-node':
+        optional: true
+      '@smithy/hash-node':
+        optional: true
+      '@smithy/signature-v4':
+        optional: true
       ws:
         optional: true
       zod:
         optional: true
 
-  openclaw@2026.6.1:
-    resolution: {integrity: sha512-rGSwhIo8N37cQQ5puG8vmWZESE8q/ych5VFpzOQNcf49TF/rvCYyxiNAyot11qbUZF5wfLh8bsvofapnOEh0BQ==}
-    engines: {node: '>=22.19.0'}
+  openclaw@2026.7.1-2:
+    resolution: {integrity: sha512-ycF3yPcbjN6bUPeaUx6Mh6vze1hQWoD3CT/wWcmD7a8xaHHHRUaAlaq+lFxMHf1ssEgODVAwjlzYqp2twkYZ7g==}
+    engines: {node: '>=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0'}
     hasBin: true
 
   p-each-series@3.0.0:
@@ -2673,8 +2699,8 @@ packages:
     resolution: {integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==}
     engines: {node: '>=4'}
 
-  playwright-core@1.60.0:
-    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2733,8 +2759,8 @@ packages:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
-  quickjs-wasi@3.0.0:
-    resolution: {integrity: sha512-X7ouKC4ZVf9bXQ8rsE7+L6TeBbesejAJH61x16xRaGAQGfBHHRcniWgzJZZVtHc8rS9yVsY+Tvk8/usAosg4bg==}
+  quickjs-wasi@3.0.2:
+    resolution: {integrity: sha512-SyfPzlrfz67/kv0SogmQgW4c2I1klkLcbvj9Y2gc1h7+VylmvuGevFljLXibGKajKJKiJV29d4S6FQLA6Sc80A==}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -3044,12 +3070,8 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
-  tar@7.5.13:
-    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
-    engines: {node: '>=18'}
-
-  tar@7.5.15:
-    resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
+  tar@7.5.19:
+    resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
     engines: {node: '>=18'}
 
   temp-dir@3.0.0:
@@ -3160,8 +3182,8 @@ packages:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
 
-  typebox@1.1.39:
-    resolution: {integrity: sha512-vj0afVtOfLQvv0GR0VxVagYxsXN64btL7Z9XoaG0ZggH3mruMMkOO6hXdgMsjCY3shZgEvooAWVeznQVs5c43w==}
+  typebox@1.3.3:
+    resolution: {integrity: sha512-URXGUE31PJDQC+PtRMJeLdF4kmmOdFoVPikPCtV2oOIhUpNpppEdIz7W8bH8cFYPYHdDpaRvqwdegMTmHliudg==}
 
   typedoc@0.28.19:
     resolution: {integrity: sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==}
@@ -3206,8 +3228,8 @@ packages:
     resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
     engines: {node: '>=20.18.1'}
 
-  undici@8.3.0:
-    resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
     engines: {node: '>=22.19.0'}
 
   unicode-emoji-modifier-base@1.0.0:
@@ -3345,8 +3367,8 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
-  web-tree-sitter@0.26.9:
-    resolution: {integrity: sha512-YJwSHANl6XFgeEjB8nitgj0qZYt5gkIesJ4w2srS2wcLB4GUa4xcOkM0YaMsU6WNR53YVIkDSY7Ej4pf3IXtCA==}
+  web-tree-sitter@0.26.10:
+    resolution: {integrity: sha512-vengBGYS7FpAerkR3o04oBL4L8MkVmjawK50AFBu7v0HZBkmF9ZavPGKoXLSSmRhp7T/YgsJ7joAS3yAxHPEqQ==}
 
   web-worker@1.5.0:
     resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
@@ -3505,7 +3527,7 @@ snapshots:
 
   '@actions/io@3.0.2': {}
 
-  '@agentclientprotocol/sdk@0.22.1(zod@4.4.3)':
+  '@agentclientprotocol/sdk@1.1.0(zod@4.4.3)':
     dependencies:
       zod: 4.4.3
 
@@ -3578,7 +3600,7 @@ snapshots:
       algo-msgpack-with-bigint: 2.1.1
       bn.js: 5.2.3
 
-  '@anthropic-ai/sdk@0.100.1(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.109.1(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0
@@ -3597,14 +3619,14 @@ snapshots:
 
   '@borewit/text-codec@0.2.2': {}
 
-  '@clack/core@1.3.1':
+  '@clack/core@1.4.2':
     dependencies:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@clack/prompts@1.4.0':
+  '@clack/prompts@1.6.0':
     dependencies:
-      '@clack/core': 1.3.1
+      '@clack/core': 1.4.2
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
@@ -3612,10 +3634,10 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@earendil-works/pi-tui@0.78.0':
+  '@earendil-works/pi-tui@0.80.3':
     dependencies:
       get-east-asian-width: 1.6.0
-      marked: 15.0.12
+      marked: 18.0.5
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -3781,7 +3803,7 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@google/genai@2.7.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
+  '@google/genai@2.10.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.7.0
       p-retry: 4.6.2
@@ -3794,17 +3816,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@grammyjs/runner@2.0.3(grammy@1.43.0)':
+  '@grammyjs/runner@2.0.3(grammy@1.44.0)':
     dependencies:
       abort-controller: 3.0.0
-      grammy: 1.43.0
+      grammy: 1.44.0
 
-  '@grammyjs/transformer-throttler@1.2.1(grammy@1.43.0)':
+  '@grammyjs/transformer-throttler@1.2.1(grammy@1.44.0)':
     dependencies:
       bottleneck: 2.19.5
-      grammy: 1.43.0
+      grammy: 1.44.0
 
-  '@grammyjs/types@3.27.3': {}
+  '@grammyjs/types@3.28.0': {}
 
   '@homebridge/ciao@1.3.9':
     dependencies:
@@ -3852,8 +3874,9 @@ snapshots:
       '@lydell/node-pty-win32-arm64': 1.2.0-beta.12
       '@lydell/node-pty-win32-x64': 1.2.0-beta.12
 
-  '@mistralai/mistralai@2.2.5':
+  '@mistralai/mistralai@2.4.0':
     dependencies:
+      '@opentelemetry/semantic-conventions': 1.43.0
       ws: 8.21.0
       zod: 4.4.3
       zod-to-json-schema: 3.25.2(zod@4.4.3)
@@ -4014,14 +4037,36 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@openclaw/fs-safe@0.3.0':
+  '@openclaw/ai@2026.7.1-2(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.109.1(zod@4.4.3)
+      '@google/genai': 2.10.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+      '@mistralai/mistralai': 2.4.0
+      openai: 6.45.0(ws@8.21.0)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.3.3
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - '@modelcontextprotocol/sdk'
+      - '@opentelemetry/api'
+      - '@smithy/hash-node'
+      - '@smithy/signature-v4'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@openclaw/fs-safe@0.4.1':
     optionalDependencies:
       jszip: 3.10.1
-      tar: 7.5.13
+      tar: 7.5.19
 
-  '@openclaw/proxyline@0.3.3(undici@8.3.0)':
+  '@openclaw/proxyline@0.3.3(undici@8.5.0)':
     dependencies:
-      undici: 8.3.0
+      undici: 8.5.0
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -4622,7 +4667,7 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  commander@14.0.3: {}
+  commander@15.0.0: {}
 
   compare-func@2.0.0:
     dependencies:
@@ -5161,9 +5206,9 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  grammy@1.43.0:
+  grammy@1.44.0:
     dependencies:
-      '@grammyjs/types': 3.27.3
+      '@grammyjs/types': 3.28.0
       abort-controller: 3.0.0
       debug: 4.4.3
       node-fetch: 2.7.0
@@ -5483,6 +5528,8 @@ snapshots:
 
   marked@15.0.12: {}
 
+  marked@18.0.5: {}
+
   math-intrinsics@1.1.0: {}
 
   mdurl@2.0.0: {}
@@ -5632,40 +5679,41 @@ snapshots:
     dependencies:
       mimic-fn: 4.0.0
 
-  openai@6.39.1(ws@8.21.0)(zod@4.4.3):
+  openai@6.45.0(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.21.0
       zod: 4.4.3
 
-  openclaw@2026.6.1:
+  openclaw@2026.7.1-2:
     dependencies:
-      '@agentclientprotocol/sdk': 0.22.1(zod@4.4.3)
-      '@anthropic-ai/sdk': 0.100.1(zod@4.4.3)
-      '@clack/core': 1.3.1
-      '@clack/prompts': 1.4.0
-      '@earendil-works/pi-tui': 0.78.0
-      '@google/genai': 2.7.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
-      '@grammyjs/runner': 2.0.3(grammy@1.43.0)
-      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.43.0)
+      '@agentclientprotocol/sdk': 1.1.0(zod@4.4.3)
+      '@anthropic-ai/sdk': 0.109.1(zod@4.4.3)
+      '@clack/core': 1.4.2
+      '@clack/prompts': 1.6.0
+      '@earendil-works/pi-tui': 0.80.3
+      '@google/genai': 2.10.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+      '@grammyjs/runner': 2.0.3(grammy@1.44.0)
+      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.44.0)
       '@homebridge/ciao': 1.3.9
       '@lydell/node-pty': 1.2.0-beta.12
-      '@mistralai/mistralai': 2.2.5
+      '@mistralai/mistralai': 2.4.0
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       '@mozilla/readability': 0.6.0
-      '@openclaw/fs-safe': 0.3.0
-      '@openclaw/proxyline': 0.3.3(undici@8.3.0)
+      '@openclaw/ai': 2026.7.1-2(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@openclaw/fs-safe': 0.4.1
+      '@openclaw/proxyline': 0.3.3(undici@8.5.0)
+      '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       chokidar: 5.0.0
       clawpdf: 0.3.0
-      commander: 14.0.3
+      commander: 15.0.0
       croner: 10.0.1
-      cross-spawn: 7.0.6
       diff: 9.0.0
       dotenv: 17.4.2
       express: 5.2.1
       file-type: 22.0.1
       glob: 13.0.6
-      grammy: 1.43.0
+      grammy: 1.44.0
       highlight.js: 11.11.1
       hosted-git-info: 10.1.1
       ignore: 7.0.5
@@ -5676,28 +5724,32 @@ snapshots:
       linkedom: 0.18.12
       minimatch: 10.2.5
       node-edge-tts: 1.2.10
-      openai: 6.39.1(ws@8.21.0)(zod@4.4.3)
+      openai: 6.45.0(ws@8.21.0)(zod@4.4.3)
       partial-json: 0.1.7
-      playwright-core: 1.60.0
+      playwright-core: 1.61.1
       proper-lockfile: 4.1.2
       qrcode: 1.5.4
-      quickjs-wasi: 3.0.0
+      quickjs-wasi: 3.0.2
       rastermill: 0.3.1
-      tar: 7.5.15
+      tar: 7.5.19
       tree-sitter-bash: 0.25.1
       tslog: 4.10.2
-      typebox: 1.1.39
+      typebox: 1.3.3
       typescript: 6.0.3
-      undici: 8.3.0
+      undici: 8.5.0
       web-push: 3.6.7
-      web-tree-sitter: 0.26.9
+      web-tree-sitter: 0.26.10
       ws: 8.21.0
       yaml: 2.9.0
       zod: 4.4.3
     optionalDependencies:
       sqlite-vec: 0.1.9
     transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
       - '@cfworker/json-schema'
+      - '@opentelemetry/api'
+      - '@smithy/hash-node'
+      - '@smithy/signature-v4'
       - bufferutil
       - canvas
       - encoding
@@ -5822,7 +5874,7 @@ snapshots:
       find-up: 2.1.0
       load-json-file: 4.0.0
 
-  playwright-core@1.60.0: {}
+  playwright-core@1.61.1: {}
 
   pngjs@5.0.0: {}
 
@@ -5881,7 +5933,7 @@ snapshots:
     dependencies:
       side-channel: 1.1.1
 
-  quickjs-wasi@3.0.0: {}
+  quickjs-wasi@3.0.2: {}
 
   range-parser@1.2.1: {}
 
@@ -6278,16 +6330,7 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tar@7.5.13:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.3
-      minizlib: 3.1.0
-      yallist: 5.0.0
-    optional: true
-
-  tar@7.5.15:
+  tar@7.5.19:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -6383,7 +6426,7 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typebox@1.1.39: {}
+  typebox@1.3.3: {}
 
   typedoc@0.28.19(typescript@5.8.3):
     dependencies:
@@ -6413,7 +6456,7 @@ snapshots:
 
   undici@7.27.2: {}
 
-  undici@8.3.0: {}
+  undici@8.5.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 
@@ -6536,7 +6579,7 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
-  web-tree-sitter@0.26.9: {}
+  web-tree-sitter@0.26.10: {}
 
   web-worker@1.5.0: {}
 


### PR DESCRIPTION
# Overview

- adds presence detection from peers for online/offline status
- prevent different controller wallets from accessing a paired instance
- includes agent subtask handling

Requires the following ac2-wallet: https://github.com/perawallet/ac2-wallet/pull/64