### PR TITLE
feat: git signing

### DIFF
--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -4,7 +4,7 @@ The reference [OpenClaw](https://docs.openclaw.ai/) plugin for **AC2**. It lets
 your OpenClaw agent chat with a mobile wallet and ask that wallet to sign things,
 while you keep custody of your keys.
 
-You get three agent tools and one channel:
+You get four agent tools and one channel:
 
 | Tool or channel | What it gives the agent |
 | --- | --- |
@@ -76,9 +76,68 @@ https://example.x402.goplausible.xyz/avm/weather
 | `openclaw ac2 connections` | List remembered wallet connections. |
 | `openclaw ac2 forget` | Drop a pairing and the agent identity bound to it. |
 | `openclaw ac2 setup` | Write or refresh the plugin's `openclaw.json` wiring. |
+| `openclaw ac2 github-key` | Print the wallet's key as a GitHub SSH signing key. |
 | `/ac2 status` | The same status from inside a chat. |
 
-Everything except `pair` and `setup` is read-only and never starts the service.
+Only `pair` and `setup` write state or start the service; `git-resign` never
+starts the service but does rewrite repo refs in place. Everything else is
+read-only.
+
+## Git commit signing over AC2
+
+Git can sign commits with SSH keys (`gpg.format ssh`), and an SSHSIG
+signature is just a raw Ed25519 signature over a locally-constructed
+blob. Since an Algorand address *is* an Ed25519 public key, the paired
+wallet's account key doubles as a GitHub SSH signing key — no new key
+material, no protocol changes, and the private key never leaves the
+wallet.
+
+### One-time setup
+
+```bash
+openclaw ac2 github-key     # print the wallet's key as an ssh-ed25519 line
+```
+
+Add the printed line on GitHub under **Settings → SSH and GPG keys →
+New SSH key**, choosing key type **Signing Key**. Do this **before your
+first signed commit**: commits are signed with the Ed25519 key on your
+AC2 wallet, and GitHub marks them *Unverified* until that key is
+registered.
+
+The committer identity is your normal git config (`git config user.name`
+/ `user.email`) — usually already set up on your machine; GitHub shows
+*Verified* only when the email matches the account. Pushing uses an SSH remote
+(`git@github.com:owner/repo.git`) authenticated by your own GitHub SSH
+key (an Authentication Key, separate from the wallet signing key) —
+local-only work needs no auth at all.
+No git signing settings are configured — signing happens after the
+commit, below.
+
+### How a commit gets signed
+
+Commits are created unsigned and signed **in place** before push:
+
+```bash
+git commit -m "..."
+openclaw ac2 git-resign <repo-dir>   # or --base origin/<branch> for a chain
+git push
+```
+
+1. `git-resign` reads the exact commit payload with
+   `git cat-file commit` — for an unsigned commit this is byte-for-byte
+   the SSHSIG signing input.
+2. It builds the SSHSIG signed-data blob and routes a standard
+   `raw-ed25519` `SigningRequest` to the paired wallet; the user
+   approves it (e.g. `Sign git commit: "feat: …"`).
+3. It verifies the returned signature, inserts the armored
+   `SSH SIGNATURE` block as the commit's `gpgsig` header, writes the new
+   object with `git hash-object`, and moves the ref with a
+   compare-and-swap `git update-ref`. The commit hash changes; with
+   `--base`, a whole chain is re-signed oldest-first with parent hashes
+   rewritten along the way.
+
+Signing requires an active `ac2` session (`openclaw ac2 pair`) — each
+commit is a wallet approval.
 
 ## Configuration
 

--- a/packages/ac2-open-claw-reference/package.json
+++ b/packages/ac2-open-claw-reference/package.json
@@ -101,7 +101,8 @@
       "tools": [
         "ac2_sign",
         "ac2_capabilities",
-        "ac2_x402_fetch"
+        "ac2_x402_fetch",
+        "ac2_git_sign"
       ],
       "commands": [
         "ac2"

--- a/packages/ac2-open-claw-reference/skills/ac2/AGENTS.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/AGENTS.md
@@ -203,3 +203,9 @@ This reference plugin additionally exposes `ac2_x402_fetch` as
 `ac2-ext-x402/fetch`. It is an application/tool capability, not a new AC2 wire
 message: x402 Algorand payments still use ordinary `ac2/SigningRequest`
 messages for wallet approval.
+
+It also exposes the `ac2 git-resign` command (which signs existing commits
+in place after `git commit`) as `ac2-ext-git/sign`.
+This too is a tool capability, not a wire extension: the SSHSIG signed-data
+blob is built locally and signed with an ordinary `ac2/SigningRequest` using
+`sig_hint: raw-ed25519` over the wallet's account key.

--- a/packages/ac2-open-claw-reference/skills/ac2/IDENTITY.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/IDENTITY.md
@@ -73,6 +73,7 @@ Per AC2 SPEC §Capability Identifier Namespacing (three-tier convention):
 | Identifier            | Surface                                                                 |
 | --------------------- | ----------------------------------------------------------------------- |
 | `ac2-ext-x402/fetch`  | x402 exact Algorand paid HTTP fetch via the `ac2_x402_fetch` tool.      |
+| `ac2-ext-git/sign`    | Git SSHSIG signing via the `ac2 git-resign` command.                     |
 
 Downstream wallet plugins MAY add chain-specific `sig_hint`s (e.g.
 `message-algorand`, `transaction-evm`). When such a plugin is loaded, prefer

--- a/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ac2
-description: "How to use the AC2 channel to ask the user's connected wallet to sign bytes over a live WebRTC link. Use this whenever the user asks you to 'sign', 'approve', or 'authorize' something with their wallet — even if they don't say 'AC2'. The agent never holds keys; the wallet does."
+description: "How to use the AC2 channel to ask the user's connected wallet to sign bytes over a live WebRTC link. Use this whenever the user asks you to 'sign', 'approve', or 'authorize' something with their wallet — even if they don't say 'AC2'. ALSO REQUIRED for any git work: before running `git commit` or `git push`, or configuring a git identity, read this skill — commits MUST be signed by the user's AC2 wallet (never with your own or an invented identity), and it documents the required `openclaw ac2 github-key` setup and the commit → `git-resign` → push rhythm. The agent never holds keys; the wallet does."
 metadata:
   {
     'openclaw':
@@ -121,12 +121,53 @@ Important parameters:
 
 Treat `{ status: "rejected" }` as a normal user decision. Do not retry the same payment after a rejection.
 
+## Git commit signing over AC2
+
+The wallet's Ed25519 account key doubles as a **git/GitHub SSH signing key**. Use this flow for **any** git commit/push work on this channel — not just when the user explicitly says "sign my commits". Commits are created normally (unsigned) and then signed **in place** by the user's wallet with `openclaw ac2 git-resign` before every push — there is no git-side signing configuration.
+
+**Non-negotiable: commits are signed by the user's wallet, never by you.** Do not generate, use, or configure any local SSH/GPG key of your own, and do not set `user.name`/`user.email` to an invented identity (e.g. "GitHub Action" / `action@github.com`) — the committer identity must be the user's own name/email collected in setup. And **never push without re-signing first**: nothing in git enforces this model — you do. Every commit must be wallet-signed via `git-resign` before it leaves the machine.
+
+**Before starting — check state first, don't redo setup:**
+
+- The **key upload is once per wallet, not per repo or per commit.** If the user has already been shown the `openclaw ac2 github-key` output and acknowledged adding it to GitHub — in this conversation or a previous one — do not show it or ask about it again unless the user asks. Take their word for it: the worst case is commits show _Unverified_ on GitHub, which is harmless and fixable later.
+- Committer identity is the user's own git config, assumed already set up like their SSH key. Check with `git -C <repo-dir> config user.email` — if it prints a value, identity is done; only if it's empty, cover it in the one-time setup below.
+
+**One-time setup (per repo) — follow these steps IN ORDER:**
+
+1. **Run** `openclaw ac2 github-key` (shell). It prints an `ssh-ed25519 …` line: the public key of the paired AC2 wallet.
+2. **If the user has not previously acknowledged uploading this key**, output the full `ssh-ed25519 …` line in chat and ask them to add it on GitHub under **Settings → SSH and GPG keys → New SSH key**, key type **Signing Key** (not "Authentication Key"). It is a public key — safe and expected to show. Explain that every commit will be signed with this key, held on their AC2 wallet, and GitHub marks commits _Unverified_ until it is registered. Wait for their acknowledgment, then **never bring it up again** unless they ask. If they already acknowledged before, skip this step entirely.
+3. **If they intend to push** to GitHub, push auth is their **own SSH key** (a normal **Authentication Key**, e.g. `~/.ssh/id_ed25519.pub` — separate from the wallet signing key): assume it is already added to their GitHub account, and make sure the repo remote uses the SSH form (`git@github.com:owner/repo.git`, not `https://…`). If they haven't added an SSH key yet, advise them to add it under **Settings → SSH and GPG keys → New SSH key**, key type **Authentication Key**. For local-only work, skip all of this — no auth is required.
+4. **Only if the repo has no committer identity** (`git -C <repo-dir> config user.email` is empty): ask the user for their **GitHub username** and **commit email** — GitHub only shows _Verified_ when the committer email matches their account — and have them set it (or run it with the values they provide, never invented ones):
+
+   ```bash
+   git config user.name <github-username>
+   git config user.email <email>
+   ```
+
+**Adding push access later:** if a repo was set up local-only and the user later wants to push (`git push` fails to authenticate, or they ask you to push), check the remote is the SSH form (`git remote set-url origin git@github.com:owner/repo.git`) and that their own SSH key is added to their GitHub account as an Authentication Key — advise them to add it if not.
+
+**Signing commits — the required rhythm, before every push:**
+
+```bash
+git commit -m "..."                 # created unsigned, like any commit
+openclaw ac2 git-resign <repo-dir>  # wallet approval; commit rewritten signed in place
+git push                            # only ever push signed commits
+```
+
+- `git-resign <repo-dir>` signs the tip of `HEAD` in place. The commit hash changes; the ref is moved with a compare-and-swap, so re-sign before anything records the old hash.
+- Made several commits (or a rebase/merge produced a chain)? Sign them all in one pass: `openclaw ac2 git-resign <repo-dir> --base origin/<branch>` — each commit gets its own wallet approval (`Sign git commit: "…"`), oldest first, with parent hashes rewritten along the chain. Tell the user approvals are coming before you run it.
+- `already signed — nothing to do` is a success, not an error.
+- A declined wallet approval aborts with the ref untouched — a normal user decision, don't retry. If it fails with `no active AC2 wallet session`, ask the user to reconnect (`openclaw ac2 pair`) — don't retry in a loop.
+- Never work around a signing failure by pushing unsigned or substituting a different key — the user's wallet approval is the point. If the user asks why commits show _Unverified_ on GitHub, that's when to point back at the key upload (step 2) and the email match — don't volunteer it otherwise.
+
+`git-resign` is the only git signing surface: never hand-build SSHSIG envelopes or commit objects via `ac2_sign` — a malformed envelope shows as _Unverified_ on GitHub with no local error. (Signed tags are not covered yet.)
+
 ## `sig_hint` catalog (what the core reference defines)
 
 `sig_hint` selects the curve the wallet uses. **Always set it explicitly.** Omitting it falls back to plain Ed25519 over raw bytes.
 
-| `sig_hint`      | `key_type` | Use                                            |
-| --------------- | ---------- | ---------------------------------------------- |
+| `sig_hint`      | `key_type`              | Use                                            |
+| --------------- | ----------------------- | ---------------------------------------------- |
 | `raw-ed25519`   | `account` or `identity` | Ed25519 signature over the raw payload bytes   |
 | `raw-secp256k1` | `account` or `identity` | secp256k1 signature over the raw payload bytes |
 

--- a/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
@@ -149,15 +149,16 @@ The wallet's Ed25519 account key doubles as a **git/GitHub SSH signing key**. Us
 **Signing commits — the required rhythm, before every push:**
 
 ```bash
-git commit -m "..."                 # created unsigned, like any commit
+git commit --no-gpg-sign -m "..."   # created unsigned — bypasses any local auto-signing config
 openclaw ac2 git-resign <repo-dir>  # wallet approval; commit rewritten signed in place
 git push                            # only ever push signed commits
 ```
 
+- **Always pass `--no-gpg-sign`** to `git commit` (and to `git commit --amend`, and rebase via `git rebase -c commit.gpgsign=false` or re-sign after): the machine's git config may auto-sign with the user's own SSH/GPG key, and that key is never the wallet. `git-resign` strips and replaces a foreign signature (with a wallet approval), so a slip-through is recoverable — but creating commits unsigned is the correct path.
 - `git-resign <repo-dir>` signs the tip of `HEAD` in place. The commit hash changes; the ref is moved with a compare-and-swap, so re-sign before anything records the old hash.
 - Made several commits (or a rebase/merge produced a chain)? Sign them all in one pass: `openclaw ac2 git-resign <repo-dir> --base origin/<branch>` — each commit gets its own wallet approval (`Sign git commit: "…"`), oldest first, with parent hashes rewritten along the chain. Tell the user approvals are coming before you run it.
 - `already signed — nothing to do` is a success, not an error.
-- A declined wallet approval aborts with the ref untouched — a normal user decision, don't retry. If it fails with `no active AC2 wallet session`, ask the user to reconnect (`openclaw ac2 pair`) — don't retry in a loop.
+- A declined wallet approval aborts with the ref untouched — a normal user decision, don't retry. If it fails with `no active AC2 wallet session`, **stop the push entirely**: ask the user to connect/pair their wallet (`openclaw ac2 pair`) and only push once `git-resign` has succeeded — don't retry in a loop, and never push while signing is unavailable.
 - Never work around a signing failure by pushing unsigned or substituting a different key — the user's wallet approval is the point. If the user asks why commits show _Unverified_ on GitHub, that's when to point back at the key upload (step 2) and the email match — don't volunteer it otherwise.
 
 `git-resign` is the only git signing surface: never hand-build SSHSIG envelopes or commit objects via `ac2_sign` — a malformed envelope shows as _Unverified_ on GitHub with no local error. (Signed tags are not covered yet.)

--- a/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
+++ b/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
@@ -1,4 +1,9 @@
-/** The `ac2` shell + slash command: `pair`, `status`, `connections`, `forget`. */
+/** The `ac2` shell + slash command: `pair`, `status`, `connections`, `forget`, `github-key`, `git-resign`. */
+
+const GIT_RESIGN_USAGE =
+  'Usage: ac2 git-resign <repo-dir> [--ref <ref>] [--base <ref>]\n' +
+  'Signs the tip commit of <ref> (default HEAD) in place via the paired wallet.\n' +
+  'With --base, re-signs every commit in <base>..<ref>, rewriting the chain.';
 
 import qrcode from 'qrcode-terminal';
 import { Ac2Client } from '@algorandfoundation/ac2-sdk';
@@ -18,6 +23,9 @@ import {
   type ControlEvents,
 } from '@algorandfoundation/ac2-cli/control';
 import { sendNotice } from '../channel/index.js';
+import { resignCommits } from '../git/resign.js';
+import { toAuthorizedKeyLine } from '../git/sshsig.js';
+import { NO_WALLET_KEY_MESSAGE, resolveWalletSigningPublicKey } from '../git/config.js';
 
 /**
  * Banner notice shown when the wallet has not granted the agent an identity
@@ -85,6 +93,21 @@ function webRtcUnavailableInstructions(): string {
     '',
     'If this persists, this platform may not have a published @roamhq/wrtc prebuilt binary.',
   ].join('\n');
+}
+
+/**
+ * Split a raw argument string into tokens, honouring single/double quotes so
+ * values like `--name "Alice Smith"` survive as one token. Agents routinely
+ * quote values; a naive whitespace split mangles them.
+ */
+export function tokenizeArgs(raw: string): string[] {
+  const tokens: string[] = [];
+  const re = /"([^"]*)"|'([^']*)'|(\S+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(raw)) !== null) {
+    tokens.push(match[1] ?? match[2] ?? match[3]!.replace(/^(["'])(.*)\1$/, '$2'));
+  }
+  return tokens;
 }
 
 /** Shown when `pair` could not reach the daemon, even after trying to auto-start it. */
@@ -179,12 +202,16 @@ function daemonNotRunningText(): string {
 export function buildAc2Command(api: OpenClawApi): unknown {
   return {
     name: 'ac2',
-    description: 'AC2 channel control (pair, status, forget).',
+    description:
+      'AC2 channel control: pair | status | connections | forget | github-key | ' +
+      'git-resign <repo-dir> [--ref <ref>] [--base <ref>]. ' +
+      '`github-key` prints the wallet SSH signing key; `git-resign` ' +
+      'signs commits in place via the paired wallet before push.',
     acceptsArgs: true,
     requireAuth: false,
     async handler(ctx: any): Promise<{ text: string; keepAlive?: boolean }> {
       const args = (ctx.args ?? '').trim();
-      const tokens = args.split(/\s+/).filter(Boolean);
+      const tokens = tokenizeArgs(args);
       const sub = tokens[0] ?? 'pair';
 
       if (sub === 'status') {
@@ -280,6 +307,75 @@ export function buildAc2Command(api: OpenClawApi): unknown {
         } finally {
           client.close();
         }
+      }
+
+      if (sub === 'github-key') {
+        const key = resolveWalletSigningPublicKey();
+        if (!key) return { text: NO_WALLET_KEY_MESSAGE };
+        const line = toAuthorizedKeyLine(key.publicKey, `ac2-${key.address.slice(0, 8)}`);
+        return {
+          text: [
+            `Wallet account: ${key.address}`,
+            '',
+            'SSH signing public key (Ed25519):',
+            '',
+            `  ${line}`,
+            '',
+            'Add it on GitHub: Settings → SSH and GPG keys → New SSH key →',
+            'Key type: "Signing Key". Commits signed over AC2 then show as Verified',
+            'when the committer email matches your GitHub account.',
+            '',
+            "Committer identity is your normal git config (`git config user.name` /",
+            '`user.email`); sign commits before pushing with: openclaw ac2 git-resign',
+          ].join('\n'),
+        };
+      }
+
+      if (sub === 'git-resign') {
+        // Sign-after-commit: signs the tip (or a range) of an existing repo
+        // in place via the active session — no git signing config involved.
+        const rest = tokens.slice(1);
+        let repoDir: string | undefined;
+        let ref: string | undefined;
+        let base: string | undefined;
+        for (let i = 0; i < rest.length; i++) {
+          const token = rest[i]!;
+          if (token === '--ref') ref = rest[++i];
+          else if (token === '--base') base = rest[++i];
+          else if (!token.startsWith('--') && repoDir === undefined) repoDir = token;
+          else return { text: `git-resign: unexpected argument '${token}'\n${GIT_RESIGN_USAGE}` };
+        }
+        if (!repoDir) return { text: `git-resign: missing <repo-dir>\n${GIT_RESIGN_USAGE}` };
+
+        const cfg = resolveConfig(api);
+        const result = await resignCommits(
+          { repoDir, ...(ref !== undefined ? { ref } : {}), ...(base !== undefined ? { base } : {}) },
+          cfg,
+        );
+        if (result.status === 'rejected') {
+          if (result.reason === 'no_active_session') {
+            return {
+              text:
+                'git-resign: no active AC2 wallet session — pair the wallet first ' +
+                '(`openclaw ac2 pair`), then retry.',
+            };
+          }
+          if (result.reason === 'already_signed') {
+            return { text: 'git-resign: every commit in range is already signed — nothing to do.' };
+          }
+          return { text: `git-resign: ${result.reason}` };
+        }
+        return {
+          text: [
+            `Re-signed ${result.commits.length} commit(s) on ${result.ref}:`,
+            '',
+            ...result.commits.map(
+              (c) => `  ${c.oldSha.slice(0, 8)} → ${c.newSha.slice(0, 8)}  ${c.subject}`,
+            ),
+            '',
+            `Ref moved: ${result.oldTip.slice(0, 8)} → ${result.newTip.slice(0, 8)}. Push to publish.`,
+          ].join('\n'),
+        };
       }
 
       if (sub === 'pair') {
@@ -489,7 +585,9 @@ export function buildAc2Command(api: OpenClawApi): unknown {
         return { text: await buildInvitationText(pairing), keepAlive: true };
       }
 
-      return { text: `Unknown subcommand: ${sub}. Use 'pair', 'status', or 'forget'.` };
+      return {
+        text: `Unknown subcommand: ${sub}. Use 'pair', 'status', 'connections', 'forget', 'github-key', or 'git-resign'.`,
+      };
     },
   };
 }

--- a/packages/ac2-open-claw-reference/src/entry.ts
+++ b/packages/ac2-open-claw-reference/src/entry.ts
@@ -120,6 +120,9 @@ async function runAc2SlashCommand(ctx: { args?: string }): Promise<{ text: strin
       '  openclaw ac2 connections  List known connections + agent identities.',
       '  openclaw ac2 forget       Clear the saved pairing record.',
       '  openclaw ac2 setup        Print/update channel configuration.',
+      '  openclaw ac2 github-key   Print the wallet key as a GitHub SSH signing key.',
+      '  openclaw ac2 git-resign <repo-dir> [--ref r] [--base r]',
+      '                            Sign commits in place via the AC2 wallet before pushing.',
     ].join('\n'),
   };
 }

--- a/packages/ac2-open-claw-reference/src/git/config.ts
+++ b/packages/ac2-open-claw-reference/src/git/config.ts
@@ -7,7 +7,7 @@
 import { decodeAddress } from '@algorandfoundation/algokit-utils/common';
 
 import { loadAc2State } from '@algorandfoundation/ac2-cli/identity';
-import { sessionManager } from '../session/manager.js';
+import { sessionManager, type SessionManager } from '../session/manager.js';
 import {
   controllerDidToAlgorandAddress,
   sessionAlgorandAddress,
@@ -19,10 +19,10 @@ import {
  * SSH signing key directly. Falls back to the persisted bound controller when
  * no session is live (e.g. a fresh CLI process).
  */
-export function resolveWalletSigningPublicKey():
-  | { address: string; publicKey: Uint8Array }
-  | undefined {
-  const active = sessionManager.getActive();
+export function resolveWalletSigningPublicKey(
+  manager: SessionManager = sessionManager,
+): { address: string; publicKey: Uint8Array } | undefined {
+  const active = manager.getActive();
   const boundControllerDid = loadAc2State().identity?.controllerDid;
   const address = active
     ? sessionAlgorandAddress(active)

--- a/packages/ac2-open-claw-reference/src/git/config.ts
+++ b/packages/ac2-open-claw-reference/src/git/config.ts
@@ -1,0 +1,38 @@
+/**
+ * Resolve the wallet's git signing key. Signing itself needs no git
+ * configuration — see `./resign.ts`; committer identity is the user's own
+ * `git config user.name`/`user.email`.
+ */
+
+import { decodeAddress } from '@algorandfoundation/algokit-utils/common';
+
+import { loadAc2State } from '@algorandfoundation/ac2-cli/identity';
+import { sessionManager } from '../session/manager.js';
+import {
+  controllerDidToAlgorandAddress,
+  sessionAlgorandAddress,
+} from '../session/wallet-address.js';
+
+/**
+ * The wallet's account Ed25519 public key, used as the git signing key. An
+ * Algorand address *is* the account's Ed25519 key, so decoding it yields the
+ * SSH signing key directly. Falls back to the persisted bound controller when
+ * no session is live (e.g. a fresh CLI process).
+ */
+export function resolveWalletSigningPublicKey():
+  | { address: string; publicKey: Uint8Array }
+  | undefined {
+  const active = sessionManager.getActive();
+  const boundControllerDid = loadAc2State().identity?.controllerDid;
+  const address = active
+    ? sessionAlgorandAddress(active)
+    : boundControllerDid
+      ? controllerDidToAlgorandAddress(boundControllerDid)
+      : undefined;
+  if (!address) return undefined;
+  return { address, publicKey: decodeAddress(address).publicKey };
+}
+
+export const NO_WALLET_KEY_MESSAGE =
+  'No wallet key available: pair a wallet first (`openclaw ac2 pair`) so the ' +
+  "controller's account key is known.";

--- a/packages/ac2-open-claw-reference/src/git/resign.ts
+++ b/packages/ac2-open-claw-reference/src/git/resign.ts
@@ -15,7 +15,9 @@ import { spawnSync } from 'node:child_process';
 import type { PluginConfig, ToolContext } from '../session/contracts.js';
 import type { ResolveSignDeps } from '../session/flows.js';
 import { NoActiveSessionError } from '../session/manager.js';
+import { resolveWalletSigningPublicKey } from './config.js';
 import { gitSignFlow, subjectLine } from './sign-flow.js';
+import { buildSshSigSignedData, decodeSshSigArmor, verifyEd25519 } from './sshsig.js';
 
 const GIT_MAX_BUFFER = 64 * 1024 * 1024;
 
@@ -58,25 +60,35 @@ function isGpgsigStart(line: string): boolean {
 
 /**
  * Remove any `gpgsig` / `gpgsig-sha256` header (and its space-prefixed
- * continuation lines). The result is the exact payload the signature covers.
+ * continuation lines). The result is the exact payload the signature covers;
+ * `armor` is the removed signature block (continuation prefixes stripped).
  */
-export function stripGpgsigHeader(payload: Buffer): { payload: Buffer; hadSignature: boolean } {
+export function stripGpgsigHeader(payload: Buffer): {
+  payload: Buffer;
+  hadSignature: boolean;
+  armor?: string;
+} {
   const { headerLines, message } = splitHeaders(payload);
   const kept: string[] = [];
+  const armorLines: string[] = [];
   let inSignature = false;
   let hadSignature = false;
   for (const line of headerLines) {
     if (isGpgsigStart(line)) {
       inSignature = true;
       hadSignature = true;
+      armorLines.push(line.replace(/^gpgsig(-sha256)? /, ''));
       continue;
     }
-    if (inSignature && line.startsWith(' ')) continue;
+    if (inSignature && line.startsWith(' ')) {
+      armorLines.push(line.slice(1));
+      continue;
+    }
     inSignature = false;
     kept.push(line);
   }
   if (!hadSignature) return { payload, hadSignature: false };
-  return { payload: joinHeaders(kept, message), hadSignature: true };
+  return { payload: joinHeaders(kept, message), hadSignature: true, armor: armorLines.join('\n') };
 }
 
 /**
@@ -124,6 +136,19 @@ export interface GitResignOptions {
   base?: string;
 }
 
+/** True when `armor` is a valid SSHSIG by `walletKey` over `payload` (namespace `git`). */
+function isWalletSignature(armor: string, payload: Buffer, walletKey: Uint8Array): boolean {
+  try {
+    const decoded = decodeSshSigArmor(armor);
+    return (
+      Buffer.from(walletKey).equals(decoded.publicKey) &&
+      verifyEd25519(buildSshSigSignedData(payload), decoded.signature, decoded.publicKey)
+    );
+  } catch {
+    return false;
+  }
+}
+
 export type GitResignResult =
   | {
       status: 'signed';
@@ -166,14 +191,25 @@ export async function resignCommits(
     return { status: 'rejected', reason: 'no_commits_in_range' };
   }
 
+  // The wallet's key decides whether an existing signature counts as "already
+  // signed": a commit signed by any OTHER key (e.g. the machine's own git
+  // signing config auto-signing `git commit`) is stripped and wallet-signed.
+  // When no wallet key is resolvable, fall back to skipping any signed commit.
+  const walletKey = resolveWalletSigningPublicKey(deps.manager)?.publicKey;
+
   const mapping = new Map<string, string>();
   const commits: Array<{ oldSha: string; newSha: string; subject: string }> = [];
   for (const sha of shas) {
     const raw = git(options.repoDir, ['cat-file', 'commit', sha]);
     const withParents = rewriteParentHeaders(raw, mapping);
-    const { payload, hadSignature } = stripGpgsigHeader(withParents);
-    if (hadSignature && withParents === raw) {
-      // Already signed and its parents are untouched: nothing to redo.
+    const { payload, hadSignature, armor } = stripGpgsigHeader(withParents);
+    if (
+      hadSignature &&
+      withParents === raw &&
+      (walletKey === undefined ||
+        (armor !== undefined && isWalletSignature(armor, payload, walletKey)))
+    ) {
+      // Already wallet-signed and its parents are untouched: nothing to redo.
       continue;
     }
 

--- a/packages/ac2-open-claw-reference/src/git/resign.ts
+++ b/packages/ac2-open-claw-reference/src/git/resign.ts
@@ -1,0 +1,220 @@
+/**
+ * Sign-after-commit: `git commit` creates the commit unsigned, then it is
+ * rewritten in place. An unsigned commit's raw payload IS the SSHSIG
+ * signed-data input, so no git-side signing configuration is needed.
+ *
+ * Trade-offs: commits exist unsigned until re-signed (nothing in git enforces
+ * the re-sign — the skill instructions do), and rewriting a parent changes
+ * every descendant hash, so ranges are signed oldest first with parent headers
+ * rewritten along the way.
+ */
+
+import { Buffer } from 'node:buffer';
+import { spawnSync } from 'node:child_process';
+
+import type { PluginConfig, ToolContext } from '../session/contracts.js';
+import type { ResolveSignDeps } from '../session/flows.js';
+import { NoActiveSessionError } from '../session/manager.js';
+import { gitSignFlow, subjectLine } from './sign-flow.js';
+
+const GIT_MAX_BUFFER = 64 * 1024 * 1024;
+
+/** Run git in `repoDir`, returning stdout bytes; throws with stderr on failure. */
+function git(repoDir: string, args: string[], input?: Buffer): Buffer {
+  const result = spawnSync('git', ['-C', repoDir, ...args], {
+    ...(input !== undefined ? { input } : {}),
+    maxBuffer: GIT_MAX_BUFFER,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const stderr = result.stderr?.toString('utf8').trim() ?? '';
+    throw new Error(`git ${args.join(' ')} failed${stderr ? `: ${stderr}` : ''}`);
+  }
+  return result.stdout ?? Buffer.alloc(0);
+}
+
+/**
+ * Split a raw commit payload at the header/message boundary. Header bytes are
+ * handled as latin1 strings (byte-preserving) so non-UTF-8 author names
+ * survive the round-trip untouched.
+ */
+function splitHeaders(payload: Buffer): { headerLines: string[]; message: Buffer } {
+  const separator = payload.indexOf('\n\n');
+  if (separator === -1) {
+    throw new Error('malformed commit payload: missing header/message separator');
+  }
+  const headerLines = payload.subarray(0, separator).toString('latin1').split('\n');
+  // `message` keeps the separating blank line so joins stay byte-exact.
+  return { headerLines, message: payload.subarray(separator + 1) };
+}
+
+function joinHeaders(headerLines: string[], message: Buffer): Buffer {
+  return Buffer.concat([Buffer.from(`${headerLines.join('\n')}\n`, 'latin1'), message]);
+}
+
+function isGpgsigStart(line: string): boolean {
+  return /^gpgsig(-sha256)? /.test(line);
+}
+
+/**
+ * Remove any `gpgsig` / `gpgsig-sha256` header (and its space-prefixed
+ * continuation lines). The result is the exact payload the signature covers.
+ */
+export function stripGpgsigHeader(payload: Buffer): { payload: Buffer; hadSignature: boolean } {
+  const { headerLines, message } = splitHeaders(payload);
+  const kept: string[] = [];
+  let inSignature = false;
+  let hadSignature = false;
+  for (const line of headerLines) {
+    if (isGpgsigStart(line)) {
+      inSignature = true;
+      hadSignature = true;
+      continue;
+    }
+    if (inSignature && line.startsWith(' ')) continue;
+    inSignature = false;
+    kept.push(line);
+  }
+  if (!hadSignature) return { payload, hadSignature: false };
+  return { payload: joinHeaders(kept, message), hadSignature: true };
+}
+
+/**
+ * Insert an armored signature as a `gpgsig` header after the existing headers
+ * (continuation lines prefixed with a single space, as git requires). The
+ * payload must not already carry a signature — strip first.
+ */
+export function insertGpgsigHeader(payload: Buffer, armored: string): Buffer {
+  const { headerLines, message } = splitHeaders(payload);
+  if (headerLines.some(isGpgsigStart)) {
+    throw new Error('commit payload already has a gpgsig header');
+  }
+  const armorLines = armored.trimEnd().split('\n');
+  const sigLines = [`gpgsig ${armorLines[0]}`, ...armorLines.slice(1).map((l) => ` ${l}`)];
+  return joinHeaders([...headerLines, ...sigLines], message);
+}
+
+/** Rewrite `parent <sha>` headers through an old→new mapping (chain re-sign). */
+export function rewriteParentHeaders(
+  payload: Buffer,
+  mapping: ReadonlyMap<string, string>,
+): Buffer {
+  if (mapping.size === 0) return payload;
+  const { headerLines, message } = splitHeaders(payload);
+  let changed = false;
+  const rewritten = headerLines.map((line) => {
+    if (!line.startsWith('parent ')) return line;
+    const replacement = mapping.get(line.slice('parent '.length));
+    if (replacement === undefined) return line;
+    changed = true;
+    return `parent ${replacement}`;
+  });
+  return changed ? joinHeaders(rewritten, message) : payload;
+}
+
+export interface GitResignOptions {
+  /** Absolute path to the git repository. */
+  repoDir: string;
+  /** Ref whose tip to re-sign; defaults to `HEAD`. */
+  ref?: string;
+  /**
+   * When set, re-sign every commit in `base..ref` (oldest first), rewriting
+   * parent hashes along the chain. Without it only the tip commit is signed.
+   */
+  base?: string;
+}
+
+export type GitResignResult =
+  | {
+      status: 'signed';
+      ref: string;
+      oldTip: string;
+      newTip: string;
+      /** Old→new sha per re-signed commit, oldest first. */
+      commits: Array<{ oldSha: string; newSha: string; subject: string }>;
+    }
+  | { status: 'rejected'; reason: string };
+
+/**
+ * Re-sign the commit(s) at `ref` via the active AC2 session and move the ref
+ * to the rewritten tip. One wallet approval per commit; a rejection aborts
+ * before any ref is touched (loose objects already written are harmless).
+ */
+export async function resignCommits(
+  options: GitResignOptions,
+  config: PluginConfig,
+  deps: ResolveSignDeps = {},
+  context: ToolContext = {},
+): Promise<GitResignResult> {
+  const ref = options.ref ?? 'HEAD';
+  let oldTip: string;
+  let shas: string[];
+  try {
+    oldTip = git(options.repoDir, ['rev-parse', '--verify', `${ref}^{commit}`])
+      .toString('utf8')
+      .trim();
+    shas = options.base
+      ? git(options.repoDir, ['rev-list', '--reverse', `${options.base}..${oldTip}`])
+          .toString('utf8')
+          .split('\n')
+          .filter((line) => line.length > 0)
+      : [oldTip];
+  } catch (err) {
+    return { status: 'rejected', reason: `git_error: ${(err as Error).message}` };
+  }
+  if (shas.length === 0) {
+    return { status: 'rejected', reason: 'no_commits_in_range' };
+  }
+
+  const mapping = new Map<string, string>();
+  const commits: Array<{ oldSha: string; newSha: string; subject: string }> = [];
+  for (const sha of shas) {
+    const raw = git(options.repoDir, ['cat-file', 'commit', sha]);
+    const withParents = rewriteParentHeaders(raw, mapping);
+    const { payload, hadSignature } = stripGpgsigHeader(withParents);
+    if (hadSignature && withParents === raw) {
+      // Already signed and its parents are untouched: nothing to redo.
+      continue;
+    }
+
+    let signed: Awaited<ReturnType<typeof gitSignFlow>>;
+    try {
+      signed = await gitSignFlow(
+        { payload_base64: payload.toString('base64') },
+        config,
+        deps,
+        context,
+      );
+    } catch (err) {
+      if (err instanceof NoActiveSessionError) {
+        return { status: 'rejected', reason: err.code };
+      }
+      throw err;
+    }
+    if (signed.status !== 'signed') {
+      return { status: 'rejected', reason: signed.reason };
+    }
+
+    const resigned = insertGpgsigHeader(payload, signed.armored);
+    const newSha = git(options.repoDir, ['hash-object', '-t', 'commit', '-w', '--stdin'], resigned)
+      .toString('utf8')
+      .trim();
+    mapping.set(sha, newSha);
+    commits.push({ oldSha: sha, newSha, subject: subjectLine(payload) });
+  }
+
+  const newTip = mapping.get(oldTip);
+  if (newTip === undefined) {
+    return { status: 'rejected', reason: 'already_signed' };
+  }
+
+  // Compare-and-swap so a commit that raced in during wallet approval is
+  // never clobbered. `update-ref HEAD` follows the symbolic ref to the
+  // underlying branch (and works detached), so `ref` is passed as given.
+  try {
+    git(options.repoDir, ['update-ref', '-m', 'ac2 git-resign', ref, newTip, oldTip]);
+  } catch (err) {
+    return { status: 'rejected', reason: `git_error: ${(err as Error).message}` };
+  }
+  return { status: 'signed', ref, oldTip, newTip, commits };
+}

--- a/packages/ac2-open-claw-reference/src/git/sign-flow.ts
+++ b/packages/ac2-open-claw-reference/src/git/sign-flow.ts
@@ -1,0 +1,173 @@
+/**
+ * Git commit/tag signing flow over AC2: build the SSHSIG signed-data blob
+ * locally, ask the connected wallet for a raw Ed25519 signature via the
+ * standard `resolveSign` (in-process session when live, otherwise brokered
+ * through the daemon that owns the wallet connection), then assemble the
+ * armored `SSH SIGNATURE` block that `git` (and GitHub) verify.
+ */
+
+import { Buffer } from 'node:buffer';
+
+import type { PluginConfig, ToolContext } from '../session/contracts.js';
+import { resolveSign, type ResolveSignDeps } from '../session/flows.js';
+import {
+  SSHSIG_NAMESPACE_GIT,
+  assembleSshSigArmor,
+  buildSshSigSignedData,
+  parseAuthorizedKeyLine,
+  toAuthorizedKeyLine,
+  verifyEd25519,
+} from './sshsig.js';
+
+export const GIT_SIGN_SCHEMA = 'sshsig';
+const SUBJECT_PREVIEW_LIMIT = 72;
+
+export interface GitSignParams {
+  /** Base64 of the raw git object bytes (commit/tag buffer git wants signed). */
+  payload_base64: string;
+  /** SSHSIG namespace; git always signs under `git`. */
+  namespace?: string;
+  /** Wallet-facing description; derived from the payload when omitted. */
+  description?: string;
+  /**
+   * Expected signer key: an `ssh-ed25519 AAAA…` authorized-key line (git
+   * `key::` literals accepted) or base64 of the raw 32-byte key. When set,
+   * a wallet response signed by any other key is rejected.
+   */
+  expected_public_key?: string;
+  expires_in_seconds?: number;
+}
+
+export type GitSignResult =
+  | {
+      status: 'signed';
+      /** Armored `-----BEGIN SSH SIGNATURE-----` block for `<file>.sig`. */
+      armored: string;
+      /** Base64 raw 32-byte Ed25519 key that signed. */
+      public_key: string;
+      /** `ssh-ed25519 AAAA…` form of `public_key` (GitHub Signing Key format). */
+      authorized_key: string;
+      namespace: string;
+      thid: string;
+    }
+  | {
+      status: 'rejected';
+      reason: string;
+      thid?: string;
+    };
+
+/** Parse `expected_public_key` in either authorized-key-line or raw-base64 form. */
+export function parseExpectedPublicKey(value: string): Buffer | undefined {
+  const fromLine = parseAuthorizedKeyLine(value);
+  if (fromLine) return fromLine;
+  try {
+    const raw = Buffer.from(value.trim(), 'base64');
+    return raw.length === 32 ? raw : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Message subject line of a git object payload; empty when it has none. */
+export function subjectLine(payload: Buffer): string {
+  const text = payload.toString('utf8');
+  const separator = text.indexOf('\n\n');
+  return separator === -1 ? '' : (text.slice(separator + 2).split('\n')[0] ?? '').trim();
+}
+
+/** Wallet approval prompt for a git object: object kind plus subject line. */
+export function describeGitPayload(payload: Buffer): string {
+  const text = payload.toString('utf8');
+  const kind = text.startsWith('tree ')
+    ? 'git commit'
+    : text.startsWith('object ')
+      ? 'git tag'
+      : 'git object';
+  let subject = subjectLine(payload);
+  if (subject.length > SUBJECT_PREVIEW_LIMIT) {
+    subject = `${subject.slice(0, SUBJECT_PREVIEW_LIMIT - 1)}…`;
+  }
+  return subject.length > 0 ? `Sign ${kind}: "${subject}"` : `Sign ${kind}`;
+}
+
+/** One SSHSIG signing round-trip on the active AC2 session. */
+export async function gitSignFlow(
+  params: GitSignParams,
+  config: PluginConfig,
+  deps: ResolveSignDeps = {},
+  context: ToolContext = {},
+): Promise<GitSignResult> {
+  const namespace = params.namespace ?? SSHSIG_NAMESPACE_GIT;
+  let payload: Buffer;
+  try {
+    payload = Buffer.from(params.payload_base64, 'base64');
+  } catch {
+    return { status: 'rejected', reason: 'invalid_payload_base64' };
+  }
+  if (payload.length === 0) {
+    return { status: 'rejected', reason: 'empty_payload' };
+  }
+
+  let expectedKey: Buffer | undefined;
+  if (params.expected_public_key !== undefined) {
+    expectedKey = parseExpectedPublicKey(params.expected_public_key);
+    if (!expectedKey) {
+      return { status: 'rejected', reason: 'invalid_expected_public_key' };
+    }
+  }
+
+  const signedData = buildSshSigSignedData(payload, namespace);
+  const description = params.description ?? describeGitPayload(payload);
+
+  const result = await resolveSign(
+    {
+      description,
+      payload_base64: signedData.toString('base64'),
+      schema: GIT_SIGN_SCHEMA,
+      sig_hint: 'raw-ed25519',
+      display_hint: 'text',
+      key_type: 'account',
+      ...(params.expires_in_seconds !== undefined
+        ? { expires_in_seconds: params.expires_in_seconds }
+        : {}),
+    },
+    config,
+    deps,
+    context,
+  );
+
+  if (result.status === 'rejected') {
+    return {
+      status: 'rejected',
+      reason: result.reason,
+      ...(result.thid !== undefined ? { thid: result.thid } : {}),
+    };
+  }
+
+  const publicKey = Buffer.from(result.public_key, 'base64');
+  const signature = Buffer.from(result.signature, 'base64');
+  if (publicKey.length !== 32 || signature.length !== 64) {
+    return { status: 'rejected', reason: 'malformed_signing_response', thid: result.thid };
+  }
+  if (expectedKey && !expectedKey.equals(publicKey)) {
+    return {
+      status: 'rejected',
+      reason:
+        'public_key_mismatch: the wallet signed with a different key than expected — ' +
+        'check `openclaw ac2 github-key` and update the signing key on GitHub.',
+      thid: result.thid,
+    };
+  }
+  if (!verifyEd25519(signedData, signature, publicKey)) {
+    return { status: 'rejected', reason: 'invalid_signature', thid: result.thid };
+  }
+
+  return {
+    status: 'signed',
+    armored: assembleSshSigArmor(publicKey, signature, namespace),
+    public_key: result.public_key,
+    authorized_key: toAuthorizedKeyLine(publicKey),
+    namespace,
+    thid: result.thid,
+  };
+}

--- a/packages/ac2-open-claw-reference/src/git/sshsig.ts
+++ b/packages/ac2-open-claw-reference/src/git/sshsig.ts
@@ -1,0 +1,235 @@
+/**
+ * SSHSIG (OpenSSH `PROTOCOL.sshsig`) encoding for Ed25519 keys and
+ * signatures. This is the format `git` produces/consumes when
+ * `gpg.format = ssh`, and the format GitHub verifies for SSH signing keys.
+ *
+ * The crucial property exploited by the AC2 git-signing flow: an SSHSIG
+ * signature is a *raw Ed25519 signature* over a deterministic "signed data"
+ * blob that can be built locally from the message. The wallet therefore only
+ * needs the existing `raw-ed25519` `sig_hint` — no protocol changes.
+ */
+
+import { Buffer } from 'node:buffer';
+import { createHash, createPublicKey, verify as cryptoVerify } from 'node:crypto';
+
+export const SSHSIG_NAMESPACE_GIT = 'git';
+
+const MAGIC_PREAMBLE = Buffer.from('SSHSIG', 'utf8');
+const SIG_VERSION = 1;
+const HASH_ALGORITHM = 'sha512';
+const KEY_TYPE = 'ssh-ed25519';
+const ED25519_PUBLIC_KEY_BYTES = 32;
+const ED25519_SIGNATURE_BYTES = 64;
+const ARMOR_HEADER = '-----BEGIN SSH SIGNATURE-----';
+const ARMOR_FOOTER = '-----END SSH SIGNATURE-----';
+const ARMOR_LINE_LENGTH = 70;
+
+/** DER prefix that wraps a raw 32-byte Ed25519 public key into SPKI form. */
+const ED25519_SPKI_PREFIX = Buffer.from('302a300506032b6570032100', 'hex');
+
+function u32(n: number): Buffer {
+  const buf = Buffer.alloc(4);
+  buf.writeUInt32BE(n >>> 0);
+  return buf;
+}
+
+/** SSH wire `string`: uint32 length followed by the raw bytes. */
+function sshString(data: Uint8Array | string): Buffer {
+  const buf = typeof data === 'string' ? Buffer.from(data, 'utf8') : Buffer.from(data);
+  return Buffer.concat([u32(buf.length), buf]);
+}
+
+/** Read one SSH wire `string` at `offset`; returns the bytes and next offset. */
+function readSshString(blob: Buffer, offset: number): { value: Buffer; next: number } {
+  if (offset + 4 > blob.length) throw new Error('sshsig: truncated string length');
+  const length = blob.readUInt32BE(offset);
+  const start = offset + 4;
+  const end = start + length;
+  if (end > blob.length) throw new Error('sshsig: truncated string body');
+  return { value: blob.subarray(start, end), next: end };
+}
+
+function assertPublicKey(publicKey: Uint8Array): Buffer {
+  const buf = Buffer.from(publicKey);
+  if (buf.length !== ED25519_PUBLIC_KEY_BYTES) {
+    throw new Error(
+      `sshsig: expected a ${ED25519_PUBLIC_KEY_BYTES}-byte Ed25519 public key, got ${buf.length} bytes`,
+    );
+  }
+  return buf;
+}
+
+/** SSH wire encoding of an Ed25519 public key (what GitHub stores). */
+export function encodeSshEd25519PublicKey(publicKey: Uint8Array): Buffer {
+  return Buffer.concat([sshString(KEY_TYPE), sshString(assertPublicKey(publicKey))]);
+}
+
+/** `ssh-ed25519 AAAA… comment` line the user uploads to GitHub as a Signing Key. */
+export function toAuthorizedKeyLine(publicKey: Uint8Array, comment = 'ac2-wallet'): string {
+  const blob = encodeSshEd25519PublicKey(publicKey).toString('base64');
+  return comment.length > 0 ? `${KEY_TYPE} ${blob} ${comment}` : `${KEY_TYPE} ${blob}`;
+}
+
+/**
+ * Parse an `ssh-ed25519 AAAA… [comment]` authorized-key line back to the raw
+ * 32-byte public key. Accepts git's `key::` literal-signing-key prefix.
+ * Returns `undefined` for anything that is not an Ed25519 authorized key.
+ */
+export function parseAuthorizedKeyLine(line: string): Buffer | undefined {
+  let text = line.trim();
+  if (text.startsWith('key::')) text = text.slice('key::'.length).trim();
+  const parts = text.split(/\s+/);
+  if (parts.length < 2 || parts[0] !== KEY_TYPE) return undefined;
+  let blob: Buffer;
+  try {
+    blob = Buffer.from(parts[1]!, 'base64');
+  } catch {
+    return undefined;
+  }
+  try {
+    const type = readSshString(blob, 0);
+    if (type.value.toString('utf8') !== KEY_TYPE) return undefined;
+    const key = readSshString(blob, type.next);
+    if (key.next !== blob.length || key.value.length !== ED25519_PUBLIC_KEY_BYTES) {
+      return undefined;
+    }
+    return Buffer.from(key.value);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Build the exact bytes the signer must raw-Ed25519 sign, per
+ * `PROTOCOL.sshsig`:
+ *
+ *     byte[6]  MAGIC_PREAMBLE "SSHSIG"
+ *     string   namespace
+ *     string   reserved (empty)
+ *     string   hash_algorithm ("sha512")
+ *     string   H(message)
+ */
+export function buildSshSigSignedData(
+  message: Uint8Array,
+  namespace: string = SSHSIG_NAMESPACE_GIT,
+): Buffer {
+  const digest = createHash(HASH_ALGORITHM).update(message).digest();
+  return Buffer.concat([
+    MAGIC_PREAMBLE,
+    sshString(namespace),
+    sshString(''),
+    sshString(HASH_ALGORITHM),
+    sshString(digest),
+  ]);
+}
+
+/**
+ * Assemble the armored SSHSIG blob `git` expects in `<file>.sig`:
+ *
+ *     byte[6]  MAGIC_PREAMBLE
+ *     uint32   SIG_VERSION (1)
+ *     string   publickey (SSH wire encoded)
+ *     string   namespace
+ *     string   reserved
+ *     string   hash_algorithm
+ *     string   signature (SSH wire: string "ssh-ed25519", string sig)
+ */
+export function assembleSshSigArmor(
+  publicKey: Uint8Array,
+  rawSignature: Uint8Array,
+  namespace: string = SSHSIG_NAMESPACE_GIT,
+): string {
+  const signature = Buffer.from(rawSignature);
+  if (signature.length !== ED25519_SIGNATURE_BYTES) {
+    throw new Error(
+      `sshsig: expected a ${ED25519_SIGNATURE_BYTES}-byte Ed25519 signature, got ${signature.length} bytes`,
+    );
+  }
+  const blob = Buffer.concat([
+    MAGIC_PREAMBLE,
+    u32(SIG_VERSION),
+    sshString(encodeSshEd25519PublicKey(publicKey)),
+    sshString(namespace),
+    sshString(''),
+    sshString(HASH_ALGORITHM),
+    sshString(Buffer.concat([sshString(KEY_TYPE), sshString(signature)])),
+  ]);
+  const base64 = blob.toString('base64');
+  const lines: string[] = [];
+  for (let i = 0; i < base64.length; i += ARMOR_LINE_LENGTH) {
+    lines.push(base64.slice(i, i + ARMOR_LINE_LENGTH));
+  }
+  return `${ARMOR_HEADER}\n${lines.join('\n')}\n${ARMOR_FOOTER}\n`;
+}
+
+/** Decoded SSHSIG signature blob (for verification/tests). */
+export interface DecodedSshSig {
+  version: number;
+  publicKey: Buffer;
+  namespace: string;
+  hashAlgorithm: string;
+  signature: Buffer;
+}
+
+/** Decode an armored SSHSIG produced by {@link assembleSshSigArmor} (or ssh-keygen). */
+export function decodeSshSigArmor(armored: string): DecodedSshSig {
+  const body = armored
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0 && l !== ARMOR_HEADER && l !== ARMOR_FOOTER)
+    .join('');
+  const blob = Buffer.from(body, 'base64');
+  if (!blob.subarray(0, MAGIC_PREAMBLE.length).equals(MAGIC_PREAMBLE)) {
+    throw new Error('sshsig: bad magic preamble');
+  }
+  let offset = MAGIC_PREAMBLE.length;
+  const version = blob.readUInt32BE(offset);
+  offset += 4;
+  const pub = readSshString(blob, offset);
+  offset = pub.next;
+  const namespace = readSshString(blob, offset);
+  offset = namespace.next;
+  const reserved = readSshString(blob, offset);
+  offset = reserved.next;
+  const hashAlgorithm = readSshString(blob, offset);
+  offset = hashAlgorithm.next;
+  const sigWire = readSshString(blob, offset);
+
+  const keyType = readSshString(pub.value, 0);
+  if (keyType.value.toString('utf8') !== KEY_TYPE) {
+    throw new Error(`sshsig: unsupported key type ${keyType.value.toString('utf8')}`);
+  }
+  const publicKey = readSshString(pub.value, keyType.next).value;
+
+  const sigType = readSshString(sigWire.value, 0);
+  if (sigType.value.toString('utf8') !== KEY_TYPE) {
+    throw new Error(`sshsig: unsupported signature type ${sigType.value.toString('utf8')}`);
+  }
+  const signature = readSshString(sigWire.value, sigType.next).value;
+
+  return {
+    version,
+    publicKey: Buffer.from(publicKey),
+    namespace: namespace.value.toString('utf8'),
+    hashAlgorithm: hashAlgorithm.value.toString('utf8'),
+    signature: Buffer.from(signature),
+  };
+}
+
+/** Verify a raw Ed25519 signature over arbitrary bytes with a raw 32-byte key. */
+export function verifyEd25519(
+  message: Uint8Array,
+  signature: Uint8Array,
+  publicKey: Uint8Array,
+): boolean {
+  try {
+    const keyObject = createPublicKey({
+      key: Buffer.concat([ED25519_SPKI_PREFIX, assertPublicKey(publicKey)]),
+      format: 'der',
+      type: 'spki',
+    });
+    return cryptoVerify(null, Buffer.from(message), keyObject, Buffer.from(signature));
+  } catch {
+    return false;
+  }
+}

--- a/packages/ac2-open-claw-reference/src/tools/index.ts
+++ b/packages/ac2-open-claw-reference/src/tools/index.ts
@@ -219,3 +219,4 @@ export function buildCapabilitiesTool(): AnyAgentTool {
   };
   return tool as unknown as AnyAgentTool;
 }
+

--- a/packages/ac2-open-claw-reference/tests/cli-command.test.ts
+++ b/packages/ac2-open-claw-reference/tests/cli-command.test.ts
@@ -17,7 +17,7 @@ vi.mock('@algorandfoundation/ac2-cli/control', async (importOriginal) => {
   };
 });
 
-import { buildAc2Command, isMissingWebRtcError } from '../src/cli/ac2-command.js';
+import { buildAc2Command, isMissingWebRtcError, tokenizeArgs } from '../src/cli/ac2-command.js';
 
 /**
  * The daemon owns WebRTC now, so a missing `@roamhq/wrtc` arrives here as a
@@ -128,5 +128,18 @@ describe('ac2 pair command AC2_RUNTIME commitment', () => {
     };
     await command.handler({ args: 'pair' });
     expect(process.env['AC2_RUNTIME']).toBe('socket');
+  });
+});
+
+describe('tokenizeArgs', () => {
+  it('splits on whitespace and honours quotes', () => {
+    expect(tokenizeArgs('git-resign /r --base "origin/main"')).toEqual([
+      'git-resign',
+      '/r',
+      '--base',
+      'origin/main',
+    ]);
+    expect(tokenizeArgs("--name 'Alice Smith'")).toEqual(['--name', 'Alice Smith']);
+    expect(tokenizeArgs('  ')).toEqual([]);
   });
 });

--- a/packages/ac2-open-claw-reference/tests/git-resign.test.ts
+++ b/packages/ac2-open-claw-reference/tests/git-resign.test.ts
@@ -180,6 +180,36 @@ describe('resignCommits', () => {
     git(repoDir, ['fsck', '--strict']);
   });
 
+  it('strips and re-signs a tip signed by a foreign key', async () => {
+    // The "machine's own git signing config" case: the tip carries a valid
+    // SSHSIG by some other key — resign must replace it, not skip it.
+    const foreign = walletFixture();
+    const { manager, rawPublicKey, requests } = walletFixture();
+    const repoDir = makeRepo();
+    commit(repoDir, 'feat: locally-signed');
+    const foreignResult = await resignCommits({ repoDir }, {}, { manager: foreign.manager });
+    expect(foreignResult.status).toBe('signed');
+
+    const result = await resignCommits({ repoDir }, {}, { manager });
+    expect(result.status).toBe('signed');
+    expect(requests).toHaveLength(1);
+
+    const raw = git(repoDir, ['cat-file', 'commit', 'HEAD']);
+    const { payload } = stripGpgsigHeader(raw);
+    const lines = raw.toString('utf8').split('\n');
+    const start = lines.findIndex((l) => l.startsWith('gpgsig '));
+    const armorLines = [lines[start]!.slice('gpgsig '.length)];
+    for (let i = start + 1; i < lines.length && lines[i]!.startsWith(' '); i++) {
+      armorLines.push(lines[i]!.slice(1));
+    }
+    const decoded = decodeSshSigArmor(armorLines.join('\n'));
+    expect(decoded.publicKey.equals(rawPublicKey)).toBe(true);
+    expect(decoded.publicKey.equals(foreign.rawPublicKey)).toBe(false);
+    expect(
+      verifyEd25519(buildSshSigSignedData(payload, 'git'), decoded.signature, decoded.publicKey),
+    ).toBe(true);
+  });
+
   it('is a no-op on an already-signed tip', async () => {
     const { manager, requests } = walletFixture();
     const repoDir = makeRepo();

--- a/packages/ac2-open-claw-reference/tests/git-resign.test.ts
+++ b/packages/ac2-open-claw-reference/tests/git-resign.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect } from 'vitest';
+import { Buffer } from 'node:buffer';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { generateKeyPairSync, sign as cryptoSign } from 'node:crypto';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { SessionManager } from '../src/session/manager.js';
+import { walletFixture } from './wallet-fixture.js';
+import {
+  insertGpgsigHeader,
+  resignCommits,
+  rewriteParentHeaders,
+  stripGpgsigHeader,
+} from '../src/git/resign.js';
+import {
+  buildSshSigSignedData,
+  decodeSshSigArmor,
+  toAuthorizedKeyLine,
+  verifyEd25519,
+} from '../src/git/sshsig.js';
+
+const COMMIT = Buffer.from(
+  [
+    'tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904',
+    'parent 1111111111111111111111111111111111111111',
+    'author Ada <ada@example.com> 1700000000 +0000',
+    'committer Ada <ada@example.com> 1700000000 +0000',
+    '',
+    'feat: subject line',
+    '',
+    'Body.',
+    '',
+  ].join('\n'),
+);
+
+const ARMOR = '-----BEGIN SSH SIGNATURE-----\nAAAA\nBBBB\n-----END SSH SIGNATURE-----\n';
+
+function git(repoDir: string, args: string[], input?: Buffer): Buffer {
+  return execFileSync('git', ['-C', repoDir, ...args], {
+    ...(input !== undefined ? { input } : {}),
+  });
+}
+
+/** A fresh repo with signing off and a deterministic identity. */
+function makeRepo(): string {
+  const repoDir = mkdtempSync(join(tmpdir(), 'ac2-resign-'));
+  git(repoDir, ['init', '-q', '-b', 'main']);
+  git(repoDir, ['config', 'user.name', 'Ada']);
+  git(repoDir, ['config', 'user.email', 'ada@example.com']);
+  git(repoDir, ['config', 'commit.gpgsign', 'false']);
+  return repoDir;
+}
+
+function commit(repoDir: string, message: string): string {
+  writeFileSync(join(repoDir, 'file.txt'), `${message}\n`);
+  git(repoDir, ['add', 'file.txt']);
+  git(repoDir, ['commit', '-q', '-m', message]);
+  return git(repoDir, ['rev-parse', 'HEAD']).toString('utf8').trim();
+}
+
+describe('gpgsig header helpers', () => {
+  it('inserts the armor as a space-continued gpgsig header before the message', () => {
+    const signed = insertGpgsigHeader(COMMIT, ARMOR);
+    const text = signed.toString('utf8');
+    expect(text).toContain(
+      [
+        'committer Ada <ada@example.com> 1700000000 +0000',
+        'gpgsig -----BEGIN SSH SIGNATURE-----',
+        ' AAAA',
+        ' BBBB',
+        ' -----END SSH SIGNATURE-----',
+        '',
+        'feat: subject line',
+      ].join('\n'),
+    );
+  });
+
+  it('strip is the exact inverse of insert', () => {
+    const signed = insertGpgsigHeader(COMMIT, ARMOR);
+    const stripped = stripGpgsigHeader(signed);
+    expect(stripped.hadSignature).toBe(true);
+    expect(stripped.payload.equals(COMMIT)).toBe(true);
+  });
+
+  it('strip leaves unsigned payloads untouched', () => {
+    const stripped = stripGpgsigHeader(COMMIT);
+    expect(stripped.hadSignature).toBe(false);
+    expect(stripped.payload).toBe(COMMIT);
+  });
+
+  it('refuses to double-insert', () => {
+    const signed = insertGpgsigHeader(COMMIT, ARMOR);
+    expect(() => insertGpgsigHeader(signed, ARMOR)).toThrow(/already has a gpgsig header/);
+  });
+
+  it('rewrites mapped parent headers and leaves others alone', () => {
+    const mapping = new Map([
+      ['1111111111111111111111111111111111111111', '2222222222222222222222222222222222222222'],
+    ]);
+    const rewritten = rewriteParentHeaders(COMMIT, mapping);
+    expect(rewritten.toString('utf8')).toContain(
+      'parent 2222222222222222222222222222222222222222',
+    );
+    expect(rewriteParentHeaders(COMMIT, new Map([['dead', 'beef']]))).toBe(COMMIT);
+  });
+});
+
+describe('resignCommits', () => {
+  it('signs HEAD in place with a verifiable SSHSIG and moves the branch', async () => {
+    const { manager, rawPublicKey } = walletFixture();
+    const repoDir = makeRepo();
+    const oldSha = commit(repoDir, 'feat: one');
+
+    const result = await resignCommits({ repoDir }, {}, { manager });
+    expect(result.status).toBe('signed');
+    if (result.status !== 'signed') return;
+    expect(result.oldTip).toBe(oldSha);
+    expect(git(repoDir, ['rev-parse', 'HEAD']).toString('utf8').trim()).toBe(result.newTip);
+
+    // The rewritten commit is intact (same tree/message) and fsck-clean.
+    const raw = git(repoDir, ['cat-file', 'commit', 'HEAD']);
+    expect(raw.toString('utf8')).toContain('gpgsig -----BEGIN SSH SIGNATURE-----');
+    expect(raw.toString('utf8')).toContain('feat: one');
+    git(repoDir, ['fsck', '--strict']);
+
+    // The signature verifies over the stripped payload under the git namespace.
+    const { payload } = stripGpgsigHeader(raw);
+    const lines = raw.toString('utf8').split('\n');
+    const start = lines.findIndex((l) => l.startsWith('gpgsig '));
+    const armorLines = [lines[start]!.slice('gpgsig '.length)];
+    for (let i = start + 1; i < lines.length && lines[i]!.startsWith(' '); i++) {
+      armorLines.push(lines[i]!.slice(1));
+    }
+    const decoded = decodeSshSigArmor(armorLines.join('\n'));
+    expect(decoded.publicKey.equals(rawPublicKey)).toBe(true);
+    expect(
+      verifyEd25519(buildSshSigSignedData(payload, 'git'), decoded.signature, decoded.publicKey),
+    ).toBe(true);
+  });
+
+  it('passes git verify-commit when the key is an allowed signer', async () => {
+    const { manager, rawPublicKey } = walletFixture();
+    const repoDir = makeRepo();
+    commit(repoDir, 'feat: verified');
+
+    const result = await resignCommits({ repoDir }, {}, { manager });
+    expect(result.status).toBe('signed');
+
+    const signersPath = join(repoDir, 'allowed_signers');
+    writeFileSync(signersPath, `ada@example.com ${toAuthorizedKeyLine(rawPublicKey)}\n`);
+    git(repoDir, ['config', 'gpg.format', 'ssh']);
+    git(repoDir, ['config', 'gpg.ssh.allowedSignersFile', signersPath]);
+    // git shells out to ssh-keygen for SSHSIG verification; hosts without
+    // it can't run this check at all.
+    if (spawnSync('ssh-keygen', []).error) return;
+    git(repoDir, ['verify-commit', 'HEAD']);
+  });
+
+  it('re-signs a range oldest-first, rewriting the parent chain', async () => {
+    const { manager } = walletFixture();
+    const repoDir = makeRepo();
+    const base = commit(repoDir, 'feat: base');
+    const first = commit(repoDir, 'feat: first');
+    const second = commit(repoDir, 'feat: second');
+
+    const result = await resignCommits({ repoDir, base }, {}, { manager });
+    expect(result.status).toBe('signed');
+    if (result.status !== 'signed') return;
+    expect(result.commits.map((c) => c.oldSha)).toEqual([first, second]);
+    expect(result.commits.map((c) => c.subject)).toEqual(['feat: first', 'feat: second']);
+
+    // The new tip's parent is the re-signed first commit, and both carry sigs.
+    const newFirst = result.commits[0]!.newSha;
+    const tip = git(repoDir, ['cat-file', 'commit', 'HEAD']).toString('utf8');
+    expect(tip).toContain(`parent ${newFirst}`);
+    expect(tip).toContain('gpgsig ');
+    expect(git(repoDir, ['cat-file', 'commit', newFirst]).toString('utf8')).toContain('gpgsig ');
+    git(repoDir, ['fsck', '--strict']);
+  });
+
+  it('is a no-op on an already-signed tip', async () => {
+    const { manager, requests } = walletFixture();
+    const repoDir = makeRepo();
+    commit(repoDir, 'feat: once');
+    await resignCommits({ repoDir }, {}, { manager });
+    const signedTip = git(repoDir, ['rev-parse', 'HEAD']).toString('utf8').trim();
+
+    const again = await resignCommits({ repoDir }, {}, { manager });
+    expect(again).toEqual({ status: 'rejected', reason: 'already_signed' });
+    expect(git(repoDir, ['rev-parse', 'HEAD']).toString('utf8').trim()).toBe(signedTip);
+    expect(requests).toHaveLength(1);
+  });
+
+  it('leaves the ref untouched when the wallet rejects', async () => {
+    const { manager } = walletFixture({}, () => ({
+      kind: 'rejected',
+      message: { thid: 'thid-1', body: { reason: 'user_declined' } },
+    }));
+    const repoDir = makeRepo();
+    const sha = commit(repoDir, 'feat: declined');
+
+    const result = await resignCommits({ repoDir }, {}, { manager });
+    expect(result).toEqual({ status: 'rejected', reason: 'user_declined' });
+    expect(git(repoDir, ['rev-parse', 'HEAD']).toString('utf8').trim()).toBe(sha);
+  });
+
+  it('rejects with no_active_session when no wallet is paired and no daemon runs', async () => {
+    const repoDir = makeRepo();
+    commit(repoDir, 'feat: offline');
+    const result = await resignCommits(
+      { repoDir },
+      {},
+      { manager: new SessionManager(), connect: async () => undefined },
+    );
+    expect(result).toEqual({ status: 'rejected', reason: 'no_active_session' });
+  });
+
+  it('signs via the daemon when no in-process session exists', async () => {
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+    const spki = publicKey.export({ format: 'der', type: 'spki' }) as Buffer;
+    const rawPublicKey = Buffer.from(spki.subarray(spki.length - 32));
+    const daemon = {
+      async request(_method: string, args: any) {
+        const payload = Buffer.from(args.body.payload, 'base64');
+        return {
+          message: {
+            type: 'ac2/SigningResponse',
+            thid: 'thid-daemon',
+            body: {
+              signature: cryptoSign(null, payload, privateKey).toString('base64'),
+              public_key: rawPublicKey.toString('base64'),
+            },
+          },
+        };
+      },
+      close() {},
+    };
+
+    const repoDir = makeRepo();
+    commit(repoDir, 'feat: daemon-signed');
+    const result = await resignCommits(
+      { repoDir },
+      {},
+      { manager: new SessionManager(), connect: async () => daemon as never },
+    );
+    expect(result.status).toBe('signed');
+
+    const raw = git(repoDir, ['cat-file', 'commit', 'HEAD']);
+    const { payload } = stripGpgsigHeader(raw);
+    const lines = raw.toString('utf8').split('\n');
+    const start = lines.findIndex((l) => l.startsWith('gpgsig '));
+    const armorLines = [lines[start]!.slice('gpgsig '.length)];
+    for (let i = start + 1; i < lines.length && lines[i]!.startsWith(' '); i++) {
+      armorLines.push(lines[i]!.slice(1));
+    }
+    const decoded = decodeSshSigArmor(armorLines.join('\n'));
+    expect(decoded.publicKey.equals(rawPublicKey)).toBe(true);
+    expect(
+      verifyEd25519(buildSshSigSignedData(payload, 'git'), decoded.signature, decoded.publicKey),
+    ).toBe(true);
+  });
+
+  it('rejects on a directory that is not a git repo', async () => {
+    const { manager } = walletFixture();
+    const dir = mkdtempSync(join(tmpdir(), 'ac2-resign-notrepo-'));
+    const result = await resignCommits({ repoDir: dir }, {}, { manager });
+    expect(result.status).toBe('rejected');
+    if (result.status === 'rejected') expect(result.reason).toMatch(/^git_error:/);
+  });
+});

--- a/packages/ac2-open-claw-reference/tests/git-sign-flow.test.ts
+++ b/packages/ac2-open-claw-reference/tests/git-sign-flow.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import { Buffer } from 'node:buffer';
+import { generateKeyPairSync } from 'node:crypto';
+
+import { walletFixture } from './wallet-fixture.js';
+import { describeGitPayload, gitSignFlow, parseExpectedPublicKey } from '../src/git/sign-flow.js';
+import {
+  buildSshSigSignedData,
+  decodeSshSigArmor,
+  toAuthorizedKeyLine,
+  verifyEd25519,
+} from '../src/git/sshsig.js';
+
+const COMMIT = Buffer.from(
+  [
+    'tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904',
+    'author Ada <ada@example.com> 1700000000 +0000',
+    'committer Ada <ada@example.com> 1700000000 +0000',
+    '',
+    'feat: sign commits over AC2',
+    '',
+    'Body text.',
+    '',
+  ].join('\n'),
+);
+
+describe('describeGitPayload', () => {
+  it('names commits and surfaces the subject line', () => {
+    expect(describeGitPayload(COMMIT)).toBe('Sign git commit: "feat: sign commits over AC2"');
+  });
+
+  it('names tag objects', () => {
+    const tag = Buffer.from('object abc\ntype commit\ntag v1\n\nrelease v1\n');
+    expect(describeGitPayload(tag)).toBe('Sign git tag: "release v1"');
+  });
+
+  it('falls back for unknown payloads without a subject', () => {
+    expect(describeGitPayload(Buffer.from('mystery-bytes'))).toBe('Sign git object');
+  });
+});
+
+describe('gitSignFlow', () => {
+  it('signs a commit and returns a verifiable armored SSHSIG', async () => {
+    const { manager, rawPublicKey, requests } = walletFixture();
+    const result = await gitSignFlow({ payload_base64: COMMIT.toString('base64') }, {}, { manager });
+
+    expect(result.status).toBe('signed');
+    if (result.status !== 'signed') return;
+    expect(result.public_key).toBe(rawPublicKey.toString('base64'));
+    expect(result.authorized_key).toBe(toAuthorizedKeyLine(rawPublicKey));
+    expect(result.namespace).toBe('git');
+    expect(result.thid).toBe('thid-1');
+
+    // The wallet was asked to raw-ed25519 sign the SSHSIG blob, not the commit.
+    const request = requests[0] as any;
+    expect(request.body.sig_hint).toBe('raw-ed25519');
+    expect(request.body.schema).toBe('sshsig');
+    expect(request.body.key_type).toBe('account');
+    expect(Buffer.from(request.body.payload, 'base64')).toEqual(buildSshSigSignedData(COMMIT));
+    expect(request.body.description).toContain('feat: sign commits over AC2');
+
+    const decoded = decodeSshSigArmor(result.armored);
+    expect(decoded.publicKey).toEqual(rawPublicKey);
+    expect(
+      verifyEd25519(buildSshSigSignedData(COMMIT), decoded.signature, decoded.publicKey),
+    ).toBe(true);
+  });
+
+  it('pins the expected public key and rejects a mismatched signer', async () => {
+    const { manager } = walletFixture();
+    const { publicKey: otherPub } = generateKeyPairSync('ed25519');
+    const otherSpki = otherPub.export({ format: 'der', type: 'spki' }) as Buffer;
+    const otherRaw = Buffer.from(otherSpki.subarray(otherSpki.length - 32));
+
+    const result = await gitSignFlow(
+      {
+        payload_base64: COMMIT.toString('base64'),
+        expected_public_key: toAuthorizedKeyLine(otherRaw),
+      },
+      {},
+      { manager },
+    );
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') return;
+    expect(result.reason).toContain('public_key_mismatch');
+  });
+
+  it('accepts the expected key when it matches (key:: literal form)', async () => {
+    const { manager, rawPublicKey } = walletFixture();
+    const result = await gitSignFlow(
+      {
+        payload_base64: COMMIT.toString('base64'),
+        expected_public_key: `key::${toAuthorizedKeyLine(rawPublicKey)}`,
+      },
+      {},
+      { manager },
+    );
+    expect(result.status).toBe('signed');
+  });
+
+  it('rejects a wallet response whose signature does not verify', async () => {
+    const { manager } = walletFixture({}, () => ({
+      kind: 'response',
+      message: {
+        thid: 'thid-bad',
+        body: {
+          signature: Buffer.alloc(64).toString('base64'),
+          public_key: Buffer.alloc(32, 7).toString('base64'),
+        },
+      },
+    }));
+    const result = await gitSignFlow({ payload_base64: COMMIT.toString('base64') }, {}, { manager });
+    expect(result).toMatchObject({ status: 'rejected', reason: 'invalid_signature' });
+  });
+
+  it('propagates wallet rejections', async () => {
+    const { manager } = walletFixture({}, () => ({
+      kind: 'rejected',
+      message: { thid: 'thid-2', body: { reason: 'user_declined' } },
+    }));
+    const result = await gitSignFlow({ payload_base64: COMMIT.toString('base64') }, {}, { manager });
+    expect(result).toMatchObject({ status: 'rejected', reason: 'user_declined' });
+  });
+
+  it('rejects when the session has no granted identity', async () => {
+    const { manager } = walletFixture({ identityGranted: false });
+    const result = await gitSignFlow({ payload_base64: COMMIT.toString('base64') }, {}, { manager });
+    expect(result).toMatchObject({ status: 'rejected', reason: 'no_identity' });
+  });
+
+  it('rejects empty and malformed inputs without contacting the wallet', async () => {
+    const { manager, requests } = walletFixture();
+    expect(await gitSignFlow({ payload_base64: '' }, {}, { manager })).toMatchObject({
+      status: 'rejected',
+      reason: 'empty_payload',
+    });
+    expect(
+      await gitSignFlow(
+        { payload_base64: COMMIT.toString('base64'), expected_public_key: 'not-a-key' },
+        {},
+        { manager },
+      ),
+    ).toMatchObject({ status: 'rejected', reason: 'invalid_expected_public_key' });
+    expect(requests).toHaveLength(0);
+  });
+});
+
+describe('parseExpectedPublicKey', () => {
+  it('accepts raw base64 32-byte keys', () => {
+    const raw = Buffer.alloc(32, 3);
+    expect(parseExpectedPublicKey(raw.toString('base64'))).toEqual(raw);
+  });
+
+  it('rejects wrong-size raw keys', () => {
+    expect(parseExpectedPublicKey(Buffer.alloc(16).toString('base64'))).toBeUndefined();
+  });
+});

--- a/packages/ac2-open-claw-reference/tests/sshsig.test.ts
+++ b/packages/ac2-open-claw-reference/tests/sshsig.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { Buffer } from 'node:buffer';
+import { generateKeyPairSync, sign as cryptoSign } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  SSHSIG_NAMESPACE_GIT,
+  assembleSshSigArmor,
+  buildSshSigSignedData,
+  decodeSshSigArmor,
+  encodeSshEd25519PublicKey,
+  parseAuthorizedKeyLine,
+  toAuthorizedKeyLine,
+  verifyEd25519,
+} from '../src/git/sshsig.js';
+
+function ed25519Fixture(): {
+  rawPublicKey: Buffer;
+  signRaw: (data: Uint8Array) => Buffer;
+} {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  const spki = publicKey.export({ format: 'der', type: 'spki' }) as Buffer;
+  return {
+    rawPublicKey: Buffer.from(spki.subarray(spki.length - 32)),
+    signRaw: (data) => cryptoSign(null, Buffer.from(data), privateKey),
+  };
+}
+
+const hasSshKeygen = spawnSync('ssh-keygen', ['-?'], { encoding: 'utf8' }).error === undefined;
+
+describe('sshsig — authorized key lines', () => {
+  it('round-trips a 32-byte key through the authorized-key line form', () => {
+    const { rawPublicKey } = ed25519Fixture();
+    const line = toAuthorizedKeyLine(rawPublicKey, 'test-comment');
+    expect(line).toMatch(/^ssh-ed25519 [A-Za-z0-9+/=]+ test-comment$/);
+    expect(parseAuthorizedKeyLine(line)).toEqual(rawPublicKey);
+  });
+
+  it("accepts git's key:: literal signing-key prefix", () => {
+    const { rawPublicKey } = ed25519Fixture();
+    const line = `key::${toAuthorizedKeyLine(rawPublicKey)}`;
+    expect(parseAuthorizedKeyLine(line)).toEqual(rawPublicKey);
+  });
+
+  it('rejects non-Ed25519 and malformed lines', () => {
+    expect(parseAuthorizedKeyLine('ssh-rsa AAAAB3NzaC1yc2E= nope')).toBeUndefined();
+    expect(parseAuthorizedKeyLine('ssh-ed25519')).toBeUndefined();
+    expect(parseAuthorizedKeyLine('ssh-ed25519 not-base64!!!')).toBeUndefined();
+    // Valid base64 but wrong wire content.
+    expect(
+      parseAuthorizedKeyLine(`ssh-ed25519 ${Buffer.from('junk').toString('base64')}`),
+    ).toBeUndefined();
+  });
+
+  it('refuses keys that are not 32 bytes', () => {
+    expect(() => encodeSshEd25519PublicKey(Buffer.alloc(31))).toThrow(/32-byte/);
+    expect(() => toAuthorizedKeyLine(Buffer.alloc(33))).toThrow(/32-byte/);
+  });
+});
+
+describe('sshsig — signed data + armor', () => {
+  it('builds the PROTOCOL.sshsig signed-data blob over SHA-512', () => {
+    const message = Buffer.from('tree abc\n\nfeat: hello\n');
+    const blob = buildSshSigSignedData(message);
+    expect(blob.subarray(0, 6).toString('utf8')).toBe('SSHSIG');
+    // namespace string follows the magic
+    expect(blob.readUInt32BE(6)).toBe(SSHSIG_NAMESPACE_GIT.length);
+    expect(blob.subarray(10, 10 + 3).toString('utf8')).toBe('git');
+  });
+
+  it('assembles an armored SSHSIG that decodes back to its parts', () => {
+    const { rawPublicKey, signRaw } = ed25519Fixture();
+    const message = Buffer.from('tree abc\nparent def\n\nfeat: sshsig\n');
+    const signedData = buildSshSigSignedData(message);
+    const signature = signRaw(signedData);
+
+    const armored = assembleSshSigArmor(rawPublicKey, signature);
+    expect(armored.startsWith('-----BEGIN SSH SIGNATURE-----\n')).toBe(true);
+    expect(armored.endsWith('-----END SSH SIGNATURE-----\n')).toBe(true);
+
+    const decoded = decodeSshSigArmor(armored);
+    expect(decoded.version).toBe(1);
+    expect(decoded.namespace).toBe('git');
+    expect(decoded.hashAlgorithm).toBe('sha512');
+    expect(decoded.publicKey).toEqual(rawPublicKey);
+    expect(decoded.signature).toEqual(Buffer.from(signature));
+    expect(verifyEd25519(signedData, decoded.signature, decoded.publicKey)).toBe(true);
+  });
+
+  it('rejects signatures that are not 64 bytes', () => {
+    const { rawPublicKey } = ed25519Fixture();
+    expect(() => assembleSshSigArmor(rawPublicKey, Buffer.alloc(63))).toThrow(/64-byte/);
+  });
+
+  it('verifyEd25519 fails closed on garbage input', () => {
+    const { rawPublicKey } = ed25519Fixture();
+    expect(verifyEd25519(Buffer.from('msg'), Buffer.alloc(64), rawPublicKey)).toBe(false);
+    expect(verifyEd25519(Buffer.from('msg'), Buffer.alloc(64), Buffer.alloc(31))).toBe(false);
+  });
+
+  it.runIf(hasSshKeygen)('produces a signature ssh-keygen accepts (check-novalidate)', () => {
+    const { rawPublicKey, signRaw } = ed25519Fixture();
+    const message = Buffer.from('tree abc\nauthor a <a@b.c> 0 +0000\n\nfeat: interop\n');
+    const armored = assembleSshSigArmor(rawPublicKey, signRaw(buildSshSigSignedData(message)));
+
+    const dir = mkdtempSync(join(tmpdir(), 'ac2-sshsig-'));
+    const sigPath = join(dir, 'payload.sig');
+    writeFileSync(sigPath, armored);
+
+    const result = spawnSync('ssh-keygen', ['-Y', 'check-novalidate', '-n', 'git', '-s', sigPath], {
+      input: message,
+      encoding: 'utf8',
+    });
+    expect(result.status, result.stderr).toBe(0);
+  });
+});

--- a/packages/ac2-open-claw-reference/tests/wallet-fixture.ts
+++ b/packages/ac2-open-claw-reference/tests/wallet-fixture.ts
@@ -1,0 +1,50 @@
+import { Buffer } from 'node:buffer';
+import { generateKeyPairSync, sign as cryptoSign } from 'node:crypto';
+
+import { SessionManager, type ActiveSession } from '../src/session/manager.js';
+
+export interface WalletFixture {
+  manager: SessionManager;
+  rawPublicKey: Buffer;
+  requests: unknown[];
+}
+
+/** A fake active session whose "wallet" signs raw-ed25519 with a local key. */
+export function walletFixture(
+  overrides: Partial<ActiveSession> = {},
+  respond?: (args: any) => unknown,
+): WalletFixture {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  const spki = publicKey.export({ format: 'der', type: 'spki' }) as Buffer;
+  const rawPublicKey = Buffer.from(spki.subarray(spki.length - 32));
+  const requests: unknown[] = [];
+
+  const client = {
+    async requestSignature(args: any) {
+      requests.push(args);
+      if (respond) return respond(args);
+      const payload = Buffer.from(args.body.payload, 'base64');
+      return {
+        kind: 'response',
+        message: {
+          thid: 'thid-1',
+          body: {
+            signature: cryptoSign(null, payload, privateKey).toString('base64'),
+            public_key: rawPublicKey.toString('base64'),
+          },
+        },
+      };
+    },
+  };
+
+  const manager = new SessionManager();
+  manager.setActive({
+    transport: {} as never,
+    client: client as never,
+    controllerDid: 'did:key:controller',
+    agentDid: 'did:key:agent',
+    identityGranted: true,
+    ...overrides,
+  });
+  return { manager, rawPublicKey, requests };
+}

--- a/packages/ac2-open-claw-reference/tests/wallet-fixture.ts
+++ b/packages/ac2-open-claw-reference/tests/wallet-fixture.ts
@@ -1,6 +1,8 @@
 import { Buffer } from 'node:buffer';
 import { generateKeyPairSync, sign as cryptoSign } from 'node:crypto';
 
+import { encodeAddress } from '@algorandfoundation/algokit-utils/common';
+
 import { SessionManager, type ActiveSession } from '../src/session/manager.js';
 
 export interface WalletFixture {
@@ -41,7 +43,9 @@ export function walletFixture(
   manager.setActive({
     transport: {} as never,
     client: client as never,
-    controllerDid: 'did:key:controller',
+    // An Algorand address IS the account's Ed25519 key, so using the fixture
+    // key's address here makes the wallet signing key resolvable in tests.
+    controllerDid: encodeAddress(rawPublicKey),
     agentDid: 'did:key:agent',
     identityGranted: true,
     ...overrides,


### PR DESCRIPTION
## Git commit signing over AC2 (SSHSIG)

Signs git commits with the paired AC2 wallet's Ed25519 account key, producing standard
SSH signatures (`SSHSIG`) that git and GitHub verify — with **zero git-side signing
configuration** and no key material ever leaving the wallet.

### How it works

Sign-after-commit: commits are created unsigned (`git commit --no-gpg-sign`), then
rewritten in place by `openclaw ac2 git-resign <repo-dir>`:

1. Read the raw commit bytes: `git cat-file commit <sha>`. An unsigned commit's raw
   payload is *exactly* the byte sequence an SSH signature must cover — no
   canonicalization or reconstruction needed.
2. Build the SSHSIG signed-data blob locally
   (`"SSHSIG" | namespace "git" | reserved | "sha512" | sha512(payload)`), and send it
   over AC2 as an ordinary `ac2/SigningRequest` with `sig_hint: raw-ed25519`. The wallet
   just raw-signs bytes — **no protocol changes needed**; the user approves each commit
   on their phone.
3. Verify the returned signature, assemble the armored `SSH SIGNATURE` block, insert it
   as a `gpgsig` header, and write the object back with `git hash-object -w`. The ref is
   moved with a compare-and-swap (`git update-ref <new> <old>`). Ranges re-sign oldest
   first, rewriting parent hashes along the chain.

The wallet's Algorand address *is* its Ed25519 public key, so `openclaw ac2 github-key`
prints the `ssh-ed25519 …` line to register on GitHub as a Signing Key.

### Also in this PR

- `git-resign` works from a fresh CLI process: signing is brokered through the AC2
  daemon (which owns the wallet transport) when no in-process session exists.
- Key-aware re-signing: a commit auto-signed by the machine's own git config is
  detected (signature key ≠ wallet key), stripped, and wallet-signed instead of skipped.
- Removed the `ac2_git_sign` tool: `git-resign` is the single git signing surface, so
  agents can't hand-assemble commit objects. (Signed tags: future work.)
- Verified end-to-end against `git verify-commit` / `ssh-keygen -Y verify`.
