### PR TITLE
docs: restructure plugin README and add root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# AC2 — Agentic Communication and Control
+
+Monorepo for the **AC2 (Agentic Communication and Control) protocol**: a
+peer-to-peer authenticated messaging system for secure communication between
+users and AI agents. AC2 enables human-in-the-loop digital signing operations —
+agents request signatures, users validate and approve through their own wallet
+or application, and signatures are delegated back to the agent for continued
+operations. Users keep custody of their keys at all times.
+
+The protocol itself is specified in [ac2.md](ac2.md).
+
+## Packages
+
+| Package | npm | Summary |
+| --- | --- | --- |
+| [ac2-sdk](packages/ac2-sdk/) | `@algorandfoundation/ac2-sdk` | TypeScript SDK for the AC2 protocol. Transport-agnostic: the same `Ac2Client` runs over WebRTC DataChannels, an in-memory loopback pair, or any custom transport. |
+| [ac2-cli](packages/ac2-cli/) | `@algorandfoundation/ac2-cli` | The **AC2 service**: a background process that holds one connection to a mobile wallet, plus the `ac2` command line that manages it. Owns the Liquid Auth pairing lifecycle, identity persistence, and keystore hosting so any agent can share one wallet connection. |
+| [ac2-open-claw-reference](packages/ac2-open-claw-reference/) | `@algorandfoundation/ac2-open-claw-reference` | The reference [OpenClaw](https://docs.openclaw.ai/) plugin for AC2. Implements signing, chat, and x402 Algorand paid fetch over the AC2 service. |
+| [ac2-open-claw-server](packages/ac2-open-claw-server/) | — (deployment) | Publicly accessible OpenClaw instance with the AC2 reference plugin: a Dockerized, token-protected web page for pairing a wallet by QR code. |
+
+Shared release tooling lives in [build/](build/)
+(`@algorandfoundation/package-releaser`).
+
+## For agents and LLMs
+
+Go directly to the document that matches your task:
+
+| Task | Read |
+| --- | --- |
+| Understand the AC2 protocol (messages, signing flows, transport) | [ac2.md](ac2.md) |
+| Install the OpenClaw plugin (human guide) | [packages/ac2-open-claw-reference/INSTALL.md](packages/ac2-open-claw-reference/INSTALL.md) |
+| Install the OpenClaw plugin (agent/automation guide) | [packages/ac2-open-claw-reference/INSTALL-AGENT.md](packages/ac2-open-claw-reference/INSTALL-AGENT.md) |
+| Use the plugin's tools, channel, and commands | [packages/ac2-open-claw-reference/README.md](packages/ac2-open-claw-reference/README.md) |
+| How the plugin, service, and gateway divide the work | [packages/ac2-open-claw-reference/ARCHITECTURE.md](packages/ac2-open-claw-reference/ARCHITECTURE.md) |
+| Run and manage the AC2 service (`ac2` CLI) | [packages/ac2-cli/README.md](packages/ac2-cli/README.md) |
+| Service internals: identity, keystore, runtime adapters | [packages/ac2-cli/ARCHITECTURE.md](packages/ac2-cli/ARCHITECTURE.md) |
+| Build a client of the service's control socket | [packages/ac2-cli/PROTOCOL.md](packages/ac2-cli/PROTOCOL.md) |
+| Build with the SDK (`Ac2Client`, transports, providers) | [packages/ac2-sdk/README.md](packages/ac2-sdk/README.md) |
+| Extend the SDK (custom transports, signaling providers) | [packages/ac2-sdk/EXTENDING.md](packages/ac2-sdk/EXTENDING.md) |
+| Deploy a public pairing server | [packages/ac2-open-claw-server/README.md](packages/ac2-open-claw-server/README.md) |
+| Repository layout and development workflow | [packages/CONTRIBUTING.md](packages/CONTRIBUTING.md) |
+
+## Contributing
+
+See [packages/CONTRIBUTING.md](packages/CONTRIBUTING.md) for the repository
+structure, prerequisites, and day-to-day workflow.

--- a/packages/ac2-open-claw-reference/INSTALL-AGENT.md
+++ b/packages/ac2-open-claw-reference/INSTALL-AGENT.md
@@ -1,0 +1,122 @@
+# AC2 OpenClaw Plugin — Agent Install Guide
+
+This guide is for AI agents and operator automation. It installs
+`@algorandfoundation/ac2-open-claw-reference` (the OpenClaw plugin) and
+`@algorandfoundation/ac2-cli` (the AC2 service) deterministically. Humans should
+read [INSTALL.md](./INSTALL.md); background is in [README.md](./README.md) and
+[ARCHITECTURE.md](./ARCHITECTURE.md).
+
+**Critical dependency:** the plugin is a client of the AC2 service. The `ac2`
+binary from `@algorandfoundation/ac2-cli` must be on `PATH` before pairing can
+work. Installing the plugin alone is not sufficient. Always run Step 1 checks
+before anything else.
+
+## Identity: map intent to commands
+
+| Operator intent | Commands |
+| --- | --- |
+| Fresh install | Steps 1–4 below, in order. |
+| Pair (or re-print pairing info) | `openclaw ac2 pair` |
+| Check status | `openclaw ac2 status` (or `ac2 service status`) |
+| Upgrade | `openclaw plugins update ac2` then `openclaw gateway restart` |
+| Reset pairing / switch wallet | `openclaw ac2 forget`, then `openclaw ac2 pair` |
+| Uninstall | `openclaw plugins uninstall ac2` |
+
+Do not substitute other install mechanisms. The plugin is installed through
+`openclaw plugins install`, and the service through `npm install -g`.
+
+## Step 1 — Preconditions
+
+Run these checks; resolve each failure before continuing.
+
+| Check | Command | On failure |
+| --- | --- | --- |
+| Node.js ≥ 22 | `node --version` | Install Node.js 22 or newer, then re-check. |
+| OpenClaw installed | `command -v openclaw` | `npm install -g openclaw` (an OpenClaw agent must already be set up/onboarded). |
+| `ac2` binary on PATH | `command -v ac2` | `npm install -g @algorandfoundation/ac2-cli@next` |
+| OS keychain available | — | The service stores keys in macOS Keychain, Linux Secret Service (e.g. `gnome-keyring`, running and unlocked), or Windows Credential Manager. On headless Linux, ensure a keyring daemon is running. |
+
+`command -v ac2` failing is the most common cause of a broken install. Never
+skip it.
+
+## Step 2 — Install and wire the plugin
+
+Run in order; each command must succeed before the next:
+
+```sh
+openclaw plugins install @algorandfoundation/ac2-open-claw-reference@next
+openclaw plugins enable ac2
+openclaw ac2 setup
+openclaw gateway restart
+```
+
+Rules:
+
+- Keep the `@next` tag. Do not add `--pin` (OpenClaw records the moving spec so
+  updaters can find newer AC2 canary releases; `@latest` and the unversioned
+  package will not pick up canaries).
+- `openclaw ac2 setup` writes the channel + tool wiring into `openclaw.json`.
+  It only writes configuration; it is safe to re-run.
+
+## Step 3 — Pair a wallet
+
+```sh
+openclaw ac2 pair
+```
+
+Expected behavior (from the plugin and service docs):
+
+- The command prints a QR code and waits. It auto-starts the AC2 service if it
+  is not already running — no separate service start is needed.
+- A human must scan the QR code with their AC2 controller wallet and approve.
+  This step cannot be completed by the agent alone; hand the QR code to the
+  operator and wait.
+- If a wallet is **already connected**, the command prints the live session and
+  exits. That is success, not an error.
+
+## Step 4 — Verify
+
+| Command | Success signal | Failure handling |
+| --- | --- | --- |
+| `ac2 service status` | Exit code 0; reports service and connection status. | Exit code 1 means the service is not running → run `openclaw ac2 pair` (it auto-starts the service). |
+| `openclaw ac2 status` | Reports the connected wallet. | See the status branch table below. |
+
+Status branches (documented behaviors):
+
+| Observed status | Meaning | Action |
+| --- | --- | --- |
+| Connected wallet reported | Install complete. | Done. |
+| `idle (waiting for a runtime before awaiting a wallet)` | The service will not await a wallet until an agent runtime is alive. | Run `openclaw ac2 pair` — it selects the `openclaw-gateway` runtime adapter for you. |
+| Locked / wallet paired but nothing reaches the agent | The agent is bound to a different wallet (first-controller lock). | `openclaw ac2 forget`, then `openclaw ac2 pair`. |
+| Service not running (commands report it; they never auto-start it) | `status`, `connections` and `forget` are read-only. | Run `openclaw ac2 pair` to start the service. |
+| Nothing happens after a scan | Signaling unreachable: pairing goes through the Liquid Auth signaling server; both the phone and this machine must reach it. | Check `ac2 service logs -n 50` and network egress. |
+
+## Upgrade
+
+```sh
+openclaw plugins update ac2 --dry-run   # preview first
+openclaw plugins update ac2
+openclaw gateway restart
+```
+
+A service that was already running keeps the runtime it started with. If turns
+are not running after an upgrade:
+
+```sh
+ac2 service stop
+openclaw ac2 pair
+```
+
+## Uninstall
+
+```sh
+openclaw ac2 forget            # drop the pairing + agent identity (optional)
+openclaw plugins uninstall ac2
+```
+
+## Reporting back to the operator
+
+- On success, report the wallet connection as shown by `openclaw ac2 status`.
+- Never report success without a passing verify step (Step 4).
+- If pairing is pending, report that the QR code is waiting for the operator to
+  scan — do not treat a pending pair as a failure.

--- a/packages/ac2-open-claw-reference/INSTALL.md
+++ b/packages/ac2-open-claw-reference/INSTALL.md
@@ -1,0 +1,128 @@
+# Install `@algorandfoundation/ac2-open-claw-reference`
+
+This guide installs the AC2 reference plugin for OpenClaw and pairs it with a
+mobile wallet. It covers two pieces:
+
+- **The plugin** (`@algorandfoundation/ac2-open-claw-reference`) — the OpenClaw
+  channel, tools and `openclaw ac2` commands.
+- **The AC2 service** (`@algorandfoundation/ac2-cli`) — the separate background
+  process that owns the wallet connection. **The plugin cannot work without
+  it**; the `ac2` binary must be on your `PATH` before you pair.
+
+This guide is for humans. AI agents and operator automation should follow
+[INSTALL-AGENT.md](./INSTALL-AGENT.md) instead.
+
+## Requirements
+
+- **Node.js 22 or newer.**
+- **An OpenClaw agent already set up** (`npm install -g openclaw` and completed
+  onboarding).
+- **The `ac2` binary from `@algorandfoundation/ac2-cli` on your `PATH`** (step 1
+  below installs it). The native WebRTC and keychain dependencies belong to that
+  service, not to this plugin.
+- **An OS keychain** for the AC2 service to store keys in: macOS Keychain, Linux
+  Secret Service (such as `gnome-keyring`), or Windows Credential Manager.
+
+## Step 1 — Install the AC2 service (required first)
+
+```sh
+npm install -g openclaw @algorandfoundation/ac2-cli@next
+```
+
+If OpenClaw is already installed, install only the service:
+
+```sh
+npm install -g @algorandfoundation/ac2-cli@next
+```
+
+While AC2 is in pre-release, keep the `@next` (canary) tag.
+
+## Step 2 — Install and wire the plugin
+
+```sh
+openclaw plugins install @algorandfoundation/ac2-open-claw-reference@next
+openclaw plugins enable ac2
+openclaw ac2 setup          # writes the channel + tools into openclaw.json
+openclaw gateway restart
+```
+
+Keep the `@next` tag and do not add `--pin`: OpenClaw records that moving spec, so
+both the OpenClaw updater and the plugin-only updater can find newer AC2 canary
+releases. The unversioned package and `@latest` follow stable releases and will
+not pick up canaries.
+
+## Step 3 — Pair a wallet
+
+```sh
+openclaw ac2 pair
+```
+
+Scan the QR code with your AC2 controller wallet and approve. That command starts
+the AC2 service if it is not already running, so this is the only step.
+
+Running `openclaw ac2 pair` again while a wallet is connected simply prints the
+live session and exits.
+
+## Step 4 — Verify
+
+```sh
+openclaw ac2 status     # the connection as the service reports it
+ac2 service status      # service + connection status; exits 1 when not running
+```
+
+After a successful pairing, `openclaw ac2 status` reports the connected wallet.
+From inside a chat, `/ac2 status` shows the same status.
+
+## Configuration
+
+`openclaw ac2 setup` writes the plugin wiring for you; the result and the
+service's environment variables are documented in the
+[Configuration section of the README](./README.md#configuration). Connection
+settings are read by the process that owns the connection, which is the AC2
+service, so set them in its environment (before `ac2 service start`, or in the
+unit written by `ac2 service install`). The full service variable list is in the
+[ac2-cli README](../ac2-cli/README.md#configuration).
+
+## Update
+
+```sh
+openclaw update                     # updates OpenClaw and @next plugins together
+openclaw plugins update ac2         # AC2 only
+openclaw gateway restart
+```
+
+Preview an update with `openclaw plugins update ac2 --dry-run`.
+
+After upgrading, note that a service that was already running keeps the runtime
+it started with. If turns are not running, stop and re-pair:
+
+```sh
+ac2 service stop
+openclaw ac2 pair
+```
+
+## Uninstall
+
+```sh
+openclaw plugins uninstall ac2
+```
+
+To also drop the pairing and the agent identity bound to it, run
+`openclaw ac2 forget` before uninstalling.
+
+## Troubleshooting
+
+**The tools say no wallet is connected.** Check `openclaw ac2 status`. If the
+service is not running, run `openclaw ac2 pair`.
+
+**The wallet paired but nothing reaches the agent.** The agent may be bound to a
+different wallet (see the first-controller lock in
+[ARCHITECTURE.md](./ARCHITECTURE.md)). Run `openclaw ac2 forget`, then pair again.
+
+**You upgraded and turns are not running.** A service that was already running
+keeps the runtime it started with. Run `ac2 service stop`, then
+`openclaw ac2 pair`.
+
+For service-level issues (pairing never completes, keychain errors, runtime
+status), see the
+[Troubleshooting section of the ac2-cli README](../ac2-cli/README.md#troubleshooting).

--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -4,7 +4,68 @@ The reference [OpenClaw](https://docs.openclaw.ai/) plugin for **AC2**. It lets
 your OpenClaw agent chat with a mobile wallet and ask that wallet to sign things,
 while you keep custody of your keys.
 
-You get three agent tools and one channel:
+You get three agent tools and one channel — see [Tools](#tools).
+
+The wallet connection itself is owned by the separate
+[AC2 service](../ac2-cli/README.md), which this plugin starts for you.
+
+## Quick start
+
+> **Prerequisite:** the plugin needs the `ac2` binary from
+> [`@algorandfoundation/ac2-cli`](../ac2-cli/README.md) on your `PATH` — the
+> first command below installs it. The native WebRTC and keychain dependencies
+> belong to that service, not to this plugin. You also need Node.js 22 or newer
+> and an OpenClaw agent already set up.
+
+```sh
+npm install -g openclaw @algorandfoundation/ac2-cli@next
+
+openclaw plugins install @algorandfoundation/ac2-open-claw-reference@next
+openclaw plugins enable ac2
+openclaw ac2 setup          # writes the channel + tools into openclaw.json
+openclaw gateway restart
+
+openclaw ac2 pair           # print a QR code
+```
+
+Scan the QR code with your AC2 controller wallet and approve. `openclaw ac2 pair`
+starts the AC2 service if it is not already running, so this is the only step.
+
+For requirements, the reason behind the `@next` tag, updating, uninstalling and
+troubleshooting, see [INSTALL.md](./INSTALL.md). AI agents and operator
+automation should follow [INSTALL-AGENT.md](./INSTALL-AGENT.md) instead.
+
+## How it works
+
+The plugin does not own the wallet connection. The
+[AC2 service](../ac2-cli/README.md) does: pairing, controller binding, the
+agent's identity bootstrap, key storage and reconnect all live there. The plugin
+talks to it over the service's local control socket.
+
+```
+mobile wallet ──► AC2 service ──(gateway WS/RPC)──► OpenClaw gateway ──► agent
+                      ▲                                                    │
+                      └────────── control socket ◄─── plugin tools ────────┘
+                                 (sign, capabilities, x402)
+```
+
+Once a wallet is paired:
+
+- Message your agent from the wallet app and the reply comes back to your phone,
+  including tool activity and sub-agent progress. Runs happen in the service,
+  which drives the OpenClaw agent over the gateway WebSocket/RPC and pushes
+  replies straight to the wallet.
+- The agent can call `ac2_capabilities` to see the connection, `ac2_sign` to ask
+  you to sign a payload, and `ac2_x402_fetch` for paid resources.
+- Running `openclaw ac2 pair` again while a wallet is connected simply prints the
+  live session and exits.
+
+The full model — why the tools query the service, the first-controller lock, the
+runtime adapter, the x402 details — is in [ARCHITECTURE.md](./ARCHITECTURE.md).
+
+## Tools
+
+Once installed, the agent gets three tools and one channel:
 
 | Tool or channel | What it gives the agent |
 | --- | --- |
@@ -12,52 +73,6 @@ You get three agent tools and one channel:
 | `ac2_sign` | Ask the wallet to sign a payload; the user approves on their phone. |
 | `ac2_x402_fetch` | Fetch an HTTP resource that charges with x402 on Algorand, paying with wallet approval. |
 | Channel `ac2` | The wallet becomes a chat channel: you message your agent from your phone. |
-
-The wallet connection itself is owned by the separate
-[AC2 service](../ac2-cli/README.md), which this plugin starts for you.
-
-## Install
-
-```sh
-npm install -g openclaw @algorandfoundation/ac2-cli@next
-```
-
-Then add the plugin to OpenClaw:
-
-```sh
-openclaw plugins install @algorandfoundation/ac2-open-claw-reference@next
-openclaw plugins enable ac2
-openclaw ac2 setup          # writes the channel + tools into openclaw.json
-openclaw gateway restart
-```
-
-Keep the `@next` tag and do not add `--pin`: OpenClaw records that moving spec, so
-both the OpenClaw updater and the plugin-only updater can find newer AC2 canary
-releases. The unversioned package and `@latest` follow stable releases and will
-not pick up canaries.
-
-You need Node.js 22 or newer, an OpenClaw agent already set up, and the `ac2`
-binary from `@algorandfoundation/ac2-cli` on your `PATH`. The native WebRTC and
-keychain dependencies belong to that service, not to this plugin.
-
-## Use it
-
-```sh
-openclaw ac2 pair
-```
-
-Scan the QR code with your AC2 controller wallet and approve. That command starts
-the AC2 service if it is not already running, so this is the only step.
-
-From then on:
-
-- Message your agent from the wallet app and the reply comes back to your phone,
-  including tool activity and sub-agent progress.
-- The agent can call `ac2_capabilities` to see the connection, `ac2_sign` to ask
-  you to sign a payload, and `ac2_x402_fetch` for paid resources.
-
-Running `openclaw ac2 pair` again while a wallet is connected simply prints the
-live session and exits.
 
 ### Paid fetches
 
@@ -71,7 +86,7 @@ endpoint:
 https://example.x402.goplausible.xyz/avm/weather
 ```
 
-## Commands
+### Commands
 
 | Command | What it does |
 | --- | --- |
@@ -105,34 +120,48 @@ unit written by `ac2 service install`):
 | `AC2_HEARTBEAT_TIMEOUT_MS` | Wallet channel liveness timeout (default `50000`). |
 | `AC2_RUNTIME` | Which runtime drives agent turns. `openclaw ac2 pair` selects `openclaw-gateway`; `socket` is the rollback. |
 
-## Update and remove
+## Data flow and privacy
+
+- **Your account keys and passkeys never leave your wallet.** Neither the plugin
+  nor the agent ever touches them. The agent requests signatures; you review and
+  approve on your phone, and only the resulting signature is delegated back.
+- **The agent's own identity key** is issued by the wallet during the service's
+  bootstrap and stored in an OS-keychain-protected keystore.
+- **Pairing goes through the Liquid Auth signaling server** (set by
+  `liquidAuthServer` / `AC2_LIQUID_AUTH_SERVER`), so both the phone and this
+  machine need to reach it. The wallet channel itself is an authenticated
+  peer-to-peer WebRTC DataChannel, end-to-end encrypted, with no centralized
+  message relay server.
+- **Connection state is persisted by the AC2 service, not the plugin:**
+  connections, identities and keystore metadata live in its state directory
+  (`AC2_STATE_DIR`, default `~/.openclaw`), with secrets in the OS keychain.
+- **The agent stays bound to the first wallet that issued it an identity**
+  (first-controller lock). A different wallet cannot silently take over the
+  agent; the operator must clear the agent's keys first with
+  `openclaw ac2 forget`.
+
+## Verify
 
 ```sh
-openclaw update                     # updates OpenClaw and @next plugins together
-openclaw plugins update ac2         # AC2 only
-openclaw gateway restart
+openclaw ac2 status     # the connection as the service reports it
+ac2 service status      # service + connection status; exits 1 when not running
 ```
 
-Preview an update with `openclaw plugins update ac2 --dry-run`. To remove the
-plugin, run `openclaw plugins uninstall ac2`.
+After a successful pairing, `openclaw ac2 status` reports the connected wallet.
+From inside a chat, `/ac2 status` shows the same status. If something looks
+wrong, `ac2 service logs -n 50` prints the last log lines — see
+[Troubleshooting in INSTALL.md](./INSTALL.md#troubleshooting).
 
-## Troubleshooting
+## Documentation
 
-**The tools say no wallet is connected.** Check `openclaw ac2 status`. If the
-service is not running, run `openclaw ac2 pair`.
-
-**The wallet paired but nothing reaches the agent.** The agent may be bound to a
-different wallet (see the first-controller lock in
-[ARCHITECTURE.md](./ARCHITECTURE.md)). Run `openclaw ac2 forget`, then pair again.
-
-**You upgraded and turns are not running.** A service that was already running
-keeps the runtime it started with. Run `ac2 service stop`, then
-`openclaw ac2 pair`.
-
-## Learn more
-
-- [ARCHITECTURE.md](./ARCHITECTURE.md): how the plugin, the AC2 service and the
-  OpenClaw gateway divide the work, plus the x402 and identity details.
-- [`@algorandfoundation/ac2-cli`](../ac2-cli): the AC2 service and `ac2` CLI.
-- [`@algorandfoundation/ac2-sdk`](../ac2-sdk): the protocol SDK.
-- [Developing in this monorepo](../CONTRIBUTING.md).
+| Document | What it covers |
+| --- | --- |
+| [INSTALL.md](./INSTALL.md) | Step-by-step install, requirements, update, uninstall, troubleshooting. |
+| [INSTALL-AGENT.md](./INSTALL-AGENT.md) | Deterministic install guide for AI agents and operator automation. |
+| [ARCHITECTURE.md](./ARCHITECTURE.md) | How the plugin, the AC2 service and the OpenClaw gateway divide the work, plus the x402 and identity details. |
+| [`@algorandfoundation/ac2-cli`](../ac2-cli/README.md) | The AC2 service and `ac2` CLI. |
+| [ac2-cli ARCHITECTURE.md](../ac2-cli/ARCHITECTURE.md) | How the service, identities, keystore and runtime adapters fit together. |
+| [ac2-cli PROTOCOL.md](../ac2-cli/PROTOCOL.md) | The local control socket API, for building an agent, a tool or your own client. |
+| [`@algorandfoundation/ac2-sdk`](../ac2-sdk/README.md) | The protocol SDK. |
+| [CONTRIBUTING.md](../CONTRIBUTING.md) | Developing in this monorepo. |
+| [ac2.md](../../ac2.md) | The AC2 protocol specification. |

--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -69,10 +69,10 @@ Once installed, the agent gets three tools and one channel:
 
 | Tool or channel | What it gives the agent |
 | --- | --- |
-| `ac2_capabilities` | Whether a wallet is connected, its address, and what it can sign. |
-| `ac2_sign` | Ask the wallet to sign a payload; the user approves on their phone. |
-| `ac2_x402_fetch` | Fetch an HTTP resource that charges with x402 on Algorand, paying with wallet approval. |
-| Channel `ac2` | The wallet becomes a chat channel: you message your agent from your phone. |
+| `ac2_capabilities` | Agent DID, connected wallet address and signing-hint catalog, read from the service. |
+| `ac2_sign` | Brokers a signing request through the service and returns the signature details. |
+| `ac2_x402_fetch` | Pays x402 Algorand resources; payer address and every signature come from the service. |
+| Channel `ac2` | A delivery route, so the host can push messages toward the wallet. |
 
 ### Paid fetches
 


### PR DESCRIPTION
(OpenViking style structure - their openclaw plugin repo is a good reference!)

Based off https://github.com/algorandfoundation/ac2/pull/40 (still in-flight).

- New root README.md: monorepo summary, packages table, task-to-document map for agents/LLMs.
- packages/ac2-open-claw-reference/README.md restructured: summary, quick start, how it works, tools, configuration, data flow and privacy, verify, documentation. All previous content preserved; install/update/ troubleshooting details moved to INSTALL.md.
- New INSTALL.md (human step-by-step guide) and INSTALL-AGENT.md (deterministic guide for AI agents and operator automation), both stressing the ac2-cli binary as a hard prerequisite.