### PR TITLE
fix(openclaw): bound the post-offer handshake so a stale offer cannot wedge re-link

### DIFF
--- a/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
+++ b/packages/ac2-open-claw-reference/src/providers/liquid-auth.ts
@@ -116,6 +116,18 @@ const AC2_DEFAULT_PAIRING_TIMEOUT_MS = 120_000;
  * human takes to scan/approve — that phase has no ceiling of its own.
  */
 const AC2_DEFAULT_SIGNAL_DEAD_TIMEOUT_MS = 45_000;
+/**
+ * Once the wallet's `offer-description` has actually been RECEIVED, the rest
+ * of the handshake (answer + ICE + data-channel open) is machine-paced — no
+ * human is involved any more — so it must complete within this window or the
+ * negotiation is declared stalled and re-armed. Without this, answering a
+ * stale offer (one whose wallet-side peer has already been torn down, e.g.
+ * after the wallet switched networks mid-session) wedged `connect()` forever:
+ * the SDK's offer listener is one-shot, so every fresh offer from the
+ * wallet's retry loop was silently dropped while `peer()` waited on a data
+ * channel that could never open.
+ */
+const AC2_DEFAULT_NEGOTIATION_STALL_TIMEOUT_MS = 30_000;
 const AC2_CONTROL_LABEL = 'ac2-v1' as const;
 const AC2_STREAM_LABEL = 'ac2-stream' as const;
 /** Dedicated liveness channel — keeps keepalive off the control plane. */
@@ -392,6 +404,99 @@ export function withSignalingHealthGuard<T>(
     sock.on('disconnect', onDisconnect);
     sock.on('connect', onReconnect);
     opts.signal?.addEventListener('abort', onAbort);
+
+    promise.then(
+      (value) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(value);
+      },
+      (err) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(err);
+      },
+    );
+  });
+}
+
+/** Raised when a received offer's handshake never produces a data channel. */
+export class NegotiationStallError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NegotiationStallError';
+  }
+}
+
+/**
+ * Race the pairing-handshake promise against a deadline that arms only once
+ * the wallet's `offer-description` has actually been RECEIVED (the client
+ * emits `offer-description` at that moment). Before the offer arrives there
+ * is no ceiling at all — that phase legitimately waits on the human scanning
+ * the QR / reopening their wallet, exactly like `withSignalingHealthGuard`.
+ * After it, the answer/ICE/data-channel steps are machine-paced and should
+ * complete in seconds, so a `stallTimeoutMs` overrun means the answered offer
+ * is dead.
+ *
+ * Why this must exist: the SDK's `signal('offer')` waits with a one-shot
+ * `socket.once('offer-description')`. If the first offer heard is stale (its
+ * wallet-side peer was already torn down — e.g. the wallet switched networks
+ * and its cancelled attempt's traffic was flushed on socket reconnect), the
+ * agent answers it and then `peer()` waits forever for a data channel while
+ * every fresh offer from the wallet's retry loop is silently dropped. Nothing
+ * else recovers this: the signaling socket stays healthy (so the health guard
+ * never fires), the heartbeat isn't running yet, and presence teardown stands
+ * down while `negotiating`. On stall, invokes `onFailure` (tear down the dead
+ * peer) and rejects, so the caller's re-pair loop re-arms `connect()` with a
+ * fresh offer listener on the same socket.
+ */
+export function withNegotiationStallGuard<T>(
+  promise: Promise<T>,
+  client: {
+    on: (event: string, listener: (...args: any[]) => void) => void;
+    off?: (event: string, listener: (...args: any[]) => void) => void;
+  },
+  opts: { stallTimeoutMs: number; onFailure?: () => void },
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    let stallTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = (): void => {
+      if (stallTimer !== undefined) {
+        clearTimeout(stallTimer);
+        stallTimer = undefined;
+      }
+      client.off?.('offer-description', onOfferReceived);
+    };
+
+    function onOfferReceived(): void {
+      // Arm once, on the FIRST received offer; later emissions (offer
+      // resends) must not push the deadline out.
+      if (settled || stallTimer !== undefined) return;
+      stallTimer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        try {
+          opts.onFailure?.();
+        } catch {
+          // Teardown is best-effort; still reject the caller.
+        }
+        reject(
+          new NegotiationStallError(
+            `[ac2-open-claw] offer answered but no data channel opened within ${opts.stallTimeoutMs}ms — ` +
+              're-arming to await a fresh offer',
+          ),
+        );
+      }, opts.stallTimeoutMs);
+      // Don't keep the event loop alive just for the stall deadline.
+      (stallTimer as { unref?: () => void }).unref?.();
+    }
+
+    client.on('offer-description', onOfferReceived);
 
     promise.then(
       (value) => {
@@ -1071,8 +1176,28 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
         // tear this down — not the human simply taking their time. A genuine
         // failure here means the socket itself is unusable, so fully tear it
         // down (the caller then builds a fresh pairing handle).
+        //
+        // The inner stall guard is the one bounded phase: once an offer has
+        // actually been RECEIVED, the rest of the handshake is machine-paced,
+        // so a data channel must open within the stall window. Answering a
+        // stale offer (the wallet tore that peer down — e.g. a mid-session
+        // network switch) otherwise wedges this `peer()` forever: its offer
+        // listener is one-shot, so the wallet's fresh retries are dropped, the
+        // socket stays healthy (health guard never fires), and presence
+        // teardown stands down while `negotiating`. On stall, tear down ONLY
+        // the p2p peer and rethrow — the re-pair loop re-arms `connect()` on
+        // this same socket and answers the wallet's next offer.
         const primary: any = await withSignalingHealthGuard(
-          client.peer(requestId, 'offer', AC2_ICE_CONFIG, { dataChannels }),
+          withNegotiationStallGuard(
+            client.peer(requestId, 'offer', AC2_ICE_CONFIG, { dataChannels }),
+            client as any,
+            {
+              stallTimeoutMs: AC2_DEFAULT_NEGOTIATION_STALL_TIMEOUT_MS,
+              onFailure: () => {
+                teardownPeer();
+              },
+            },
+          ),
           socket,
           {
             deadSocketTimeoutMs: AC2_DEFAULT_SIGNAL_DEAD_TIMEOUT_MS,

--- a/packages/ac2-open-claw-reference/tests/liquid-auth-stall-guard.test.ts
+++ b/packages/ac2-open-claw-reference/tests/liquid-auth-stall-guard.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for `withNegotiationStallGuard` — the post-offer handshake
+ * deadline that keeps a re-armed `connect()` from wedging forever after it
+ * answers a stale offer (e.g. one flushed from the wallet's cancelled attempt
+ * when its socket reconnected after a network switch). The guard must:
+ *
+ *  - impose NO deadline before an offer is received (that phase waits on the
+ *    human scanning the QR / reopening the wallet and can take arbitrarily
+ *    long);
+ *  - once `offer-description` fires, reject with `NegotiationStallError` (and
+ *    run `onFailure`) if the handshake promise has not settled within the
+ *    stall window;
+ *  - arm exactly once — offer re-emissions must not push the deadline out;
+ *  - pass through resolution/rejection untouched and detach its listener.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  NegotiationStallError,
+  withNegotiationStallGuard,
+} from '../src/providers/liquid-auth.js';
+
+type Listener = (...args: any[]) => void;
+
+function makeEmitter() {
+  const listeners: Record<string, Listener[]> = {};
+  return {
+    on(event: string, listener: Listener) {
+      (listeners[event] ??= []).push(listener);
+    },
+    off(event: string, listener: Listener) {
+      listeners[event] = (listeners[event] ?? []).filter((l) => l !== listener);
+    },
+    emit(event: string, ...args: any[]) {
+      for (const listener of [...(listeners[event] ?? [])]) listener(...args);
+    },
+    count(event: string): number {
+      return (listeners[event] ?? []).length;
+    },
+  };
+}
+
+describe('withNegotiationStallGuard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('imposes no deadline before an offer is received', async () => {
+    const client = makeEmitter();
+    const onFailure = vi.fn();
+    let resolvePeer!: (value: string) => void;
+    const peer = new Promise<string>((resolve) => {
+      resolvePeer = resolve;
+    });
+
+    const guarded = withNegotiationStallGuard(peer, client, {
+      stallTimeoutMs: 30_000,
+      onFailure,
+    });
+
+    // Hours pass while the wallet is closed — nothing may reject.
+    await vi.advanceTimersByTimeAsync(3_600_000);
+    expect(onFailure).not.toHaveBeenCalled();
+
+    resolvePeer('channel');
+    await expect(guarded).resolves.toBe('channel');
+  });
+
+  it('rejects with NegotiationStallError when no channel opens after an offer', async () => {
+    const client = makeEmitter();
+    const onFailure = vi.fn();
+    const peer = new Promise<string>(() => {
+      /* never settles — the answered offer is dead */
+    });
+
+    const guarded = withNegotiationStallGuard(peer, client, {
+      stallTimeoutMs: 30_000,
+      onFailure,
+    });
+    const outcome = expect(guarded).rejects.toBeInstanceOf(NegotiationStallError);
+
+    client.emit('offer-description', { type: 'offer', sdp: 'v=0' });
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(onFailure).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await outcome;
+    expect(onFailure).toHaveBeenCalledTimes(1);
+    // The guard's listener is detached once settled.
+    expect(client.count('offer-description')).toBe(0);
+  });
+
+  it('arms once: offer re-emissions do not extend the deadline', async () => {
+    const client = makeEmitter();
+    const onFailure = vi.fn();
+    const peer = new Promise<string>(() => {
+      /* never settles */
+    });
+
+    const guarded = withNegotiationStallGuard(peer, client, {
+      stallTimeoutMs: 30_000,
+      onFailure,
+    });
+    const outcome = expect(guarded).rejects.toBeInstanceOf(NegotiationStallError);
+
+    client.emit('offer-description', { type: 'offer', sdp: 'v=0' });
+    await vi.advanceTimersByTimeAsync(20_000);
+    // A resent offer 20s in must not reset the clock to a fresh 30s.
+    client.emit('offer-description', { type: 'offer', sdp: 'v=0' });
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await outcome;
+    expect(onFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves normally when the channel opens within the stall window', async () => {
+    const client = makeEmitter();
+    const onFailure = vi.fn();
+    let resolvePeer!: (value: string) => void;
+    const peer = new Promise<string>((resolve) => {
+      resolvePeer = resolve;
+    });
+
+    const guarded = withNegotiationStallGuard(peer, client, {
+      stallTimeoutMs: 30_000,
+      onFailure,
+    });
+
+    client.emit('offer-description', { type: 'offer', sdp: 'v=0' });
+    await vi.advanceTimersByTimeAsync(5_000);
+    resolvePeer('channel');
+    await expect(guarded).resolves.toBe('channel');
+
+    // The stall timer is cancelled and the listener detached.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(onFailure).not.toHaveBeenCalled();
+    expect(client.count('offer-description')).toBe(0);
+  });
+
+  it('passes through an underlying rejection untouched', async () => {
+    const client = makeEmitter();
+    const onFailure = vi.fn();
+    const boom = new Error('peer exploded');
+    const guarded = withNegotiationStallGuard(Promise.reject(boom), client, {
+      stallTimeoutMs: 30_000,
+      onFailure,
+    });
+
+    await expect(guarded).rejects.toBe(boom);
+    expect(onFailure).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

When the wallet switches networks mid-session, the agent closes the channel on heartbeat timeout, logs `Controller link dropped — … awaiting the wallet to re-link`, re-arms `connect()` — and then never reconnects. The wallet retries forever ("Reconnecting (attempt N)…") while presence correctly shows 2 devices online and the agent logs nothing further.

Root cause on this side: the re-armed `connect()` can answer a **stale** `offer-description` — one whose wallet-side peer was already torn down (the wallet's iOS signaling client flushed a cancelled attempt's queued `link`/offer onto the socket when it reconnected; wallet-side fixes in perawallet/ac2-wallet#72 and perawallet/ac2-wallet#73). liquid-client's `signal('offer')` uses `socket.once('offer-description')`, so after answering the dead offer:

- every fresh offer from the wallet's retry loop is silently dropped,
- `peer()` waits forever for a data channel that can never open,
- `withSignalingHealthGuard` never fires (the socket is healthy),
- the heartbeat watchdog isn't running yet,
- presence-driven teardown deliberately stands down while `negotiating && !connected`.

The negotiation is permanently wedged until the agent process restarts. Even with the wallet fixes there is an inherent race (the wallet's 30s negotiation deadline can cancel an attempt right as the agent answers it), so the agent needs to self-heal.

## Fix

New `withNegotiationStallGuard` wrapping `client.peer(...)` inside the existing health guard:

- **No deadline before an offer is received** — that phase waits on the human (QR scan / reopening the wallet) and keeps the existing no-flat-timeout behavior.
- Once `offer-description` fires, the answer/ICE/data-channel steps are machine-paced: if no channel opens within 30s, tear down **only** the p2p peer and reject with `NegotiationStallError`. The re-pair loop then re-arms `connect()` on the same live socket with a fresh offer listener — so the wallet's next retry is answered instead of dropped.
- Arms exactly once per negotiation (offer resends don't extend the deadline).

## Testing

- New unit tests in `tests/liquid-auth-stall-guard.test.ts` (no-deadline-before-offer, stall rejection + teardown, arm-once, clean resolve, rejection passthrough).
- `tests/liquid-auth-reconnect.test.ts` and `tests/liquid-auth-provider.test.ts` still pass (41 tests total).
- `pnpm run type-check` clean.