### PR TITLE
fix: darwin keyring, cli-entrypoint and windows fixes

### DIFF
--- a/packages/ac2-cli/ARCHITECTURE.md
+++ b/packages/ac2-cli/ARCHITECTURE.md
@@ -58,6 +58,14 @@ The service has no storage engine of its own.
 - **Secret material** is kept in the OS keychain (Keychain on macOS, Secret
   Service on Linux, Credential Manager on Windows), under a service name derived
   from the state directory, so separate AC2 homes never collide.
+- **On macOS the service uses a dedicated keychain** (`ac2-keystore.keychain-db`
+  in the state directory, password in the `0600` file `ac2-keystore.keychain-key`
+  next to it) that it creates and unlocks itself. The login keychain is locked
+  for background processes (launchd, SSH, before login) and fails with
+  `errSecInteractionNotAllowed` there; the dedicated keychain needs no user
+  interaction, so pairing works headless. Entries older versions wrote to the
+  login keychain are migrated on first read; `AC2_KEYRING=login` opts back into
+  the login keychain.
 - **Metadata** (key ids, public keys, algorithms) lives in one sealed blob,
   `ac2-keystore-metadata.bin`, beside the persisted connection records.
 - **Identity keys are non-extractable.** The service signs through the keystore

--- a/packages/ac2-cli/README.md
+++ b/packages/ac2-cli/README.md
@@ -22,8 +22,24 @@ npm install -g openclaw @algorandfoundation/ac2-cli
 While AC2 is in pre-release, add the canary tag: `npm install -g
 @algorandfoundation/ac2-cli@next`.
 
+To try it without installing anything:
+
+```sh
+npx @algorandfoundation/ac2-cli@next --help
+```
+
 Requirements: Node.js 22 or newer, and an OS keychain (macOS Keychain, Linux
 Secret Service such as `gnome-keyring`, or Windows Credential Manager).
+
+### Platform support
+
+macOS, Linux and Windows are all supported, with these differences:
+
+| | macOS | Linux | Windows |
+| --- | --- | --- | --- |
+| Control channel | Unix socket in `AC2_HOME` | Unix socket in `AC2_HOME` | named pipe (`\\.\pipe\ac2-daemon`, suffixed per custom `AC2_HOME`) |
+| Key storage | dedicated AC2 keychain (see Troubleshooting) | Secret Service (`gnome-keyring`, …) | Credential Manager |
+| `ac2 service install` | launchd agent | systemd user unit | not available — use `ac2 service start`, which survives the terminal |
 
 ## Quick start
 
@@ -85,13 +101,14 @@ Everything has a working default. Set these only if you need to.
 | --- | --- |
 | `AC2_HOME` | Runtime directory for the socket, log and pidfile (default `~/.ac2`). |
 | `AC2_STATE_DIR` | Where connections, identities and keystore metadata are persisted (default `~/.openclaw`). |
-| `AC2_DAEMON_SOCKET` | Control socket path, or Windows named pipe. |
+| `AC2_DAEMON_SOCKET` | Control socket path, or Windows named pipe. Defaults to `$AC2_HOME/ac2d.sock`, and on Windows to `\\.\pipe\ac2-daemon` (plus a digest of `AC2_HOME` when that is set, so profiles never share a pipe). |
 | `AC2_LIQUID_AUTH_SERVER` | Liquid Auth signaling server URL. |
 | `AC2_DEFAULT_AGENT` | Agent id inbound wallet traffic goes to (default `openclaw`). |
 | `AC2_HEARTBEAT_TIMEOUT_MS` | How long a silent wallet channel may stay open. |
 | `AC2_RUNTIME` | Which runtime adapter drives the agent: `socket` (default), `openclaw-gateway`, or an npm package name. |
 | `AC2_RUNTIME_CONFIG` | JSON config handed to that adapter. |
 | `AC2_WAIT_FOR_RUNTIME` | Set to `0` to await a wallet even when no agent runtime is alive. |
+| `AC2_KEYRING` | macOS only. Set to `login` to store keys in the login keychain instead of the dedicated AC2 keychain (see Troubleshooting). |
 | `OPENCLAW_GATEWAY_URL` / `_PORT` / `_TOKEN` | Gateway connection for the `openclaw-gateway` adapter. Discovered from `openclaw.json` when unset. |
 
 Set them in the environment of the process that runs the service, for example
@@ -113,9 +130,24 @@ before pairing a different wallet.
 the Liquid Auth signaling server, so both the phone and this machine need to reach
 it.
 
+**`ac2` prints nothing at all after installing.** A bug in `1.0.0-canary.2` and
+earlier: the command detected "was I run directly?" by comparing paths in a way
+that never matched the `node_modules/.bin/ac2` symlink npm, pnpm and `npx`
+install (and never matched on Windows at all), so it exited silently with status
+0. Upgrade — `npm install -g @algorandfoundation/ac2-cli@next`.
+
 **Keychain errors on Linux.** The service stores secrets in the Secret Service
 API, which needs a running keyring daemon (for example `gnome-keyring`) and an
 unlocked login keyring.
+
+**`User interaction is not allowed` on macOS.** The login keychain is locked for
+background processes (launchd, SSH, before login), so macOS cannot prompt to
+unlock it. The service therefore keeps its keys in a **dedicated keychain** in
+the state directory (`ac2-keystore.keychain-db`, password in the `0600` file
+`ac2-keystore.keychain-key` next to it) that it creates and unlocks itself — no
+prompt, works headless. Entries stored in the login keychain by older versions
+are migrated over on first read. Set `AC2_KEYRING=login` to opt back into the
+login keychain.
 
 ## Learn more
 

--- a/packages/ac2-cli/src/cli-entry.ts
+++ b/packages/ac2-cli/src/cli-entry.ts
@@ -1,0 +1,108 @@
+/**
+ * "Was this process started *as* the `ac2` command?" — the guard `src/cli.ts`
+ * uses before it dispatches a command.
+ *
+ * The naive check (`import.meta.url === \`file://${process.argv[1]}\``) is
+ * wrong on every real installation:
+ *
+ * - **npm / npx / pnpm on Linux and macOS** put a *symlink* on `PATH`
+ *   (`node_modules/.bin/ac2` -> `…/ac2-cli/dist/cli.js`). Node reports the
+ *   symlink in `process.argv[1]` but resolves `import.meta.url` to the real
+ *   file, so the two never match and the CLI exits silently (exit code 0, no
+ *   output) — which is exactly what "installing the distribution shows no CLI
+ *   commands" looks like.
+ * - **Windows** paths (`C:\…\cli.js`) are not valid `file://` URLs at all, and
+ *   the shims npm writes (`ac2.cmd`, `ac2.ps1`) invoke a path with backslashes
+ *   and arbitrary casing.
+ * - Any path with a space or a non-ASCII character breaks the string compare
+ *   too, because a real file URL is percent-encoded.
+ *
+ * So the entry is compared as a *path*: both sides are resolved through
+ * `realpath` (following the bin symlink), normalised for separator style, and
+ * compared case-insensitively on Windows. Wrappers that neither symlink nor
+ * exec the real file (Yarn PnP shims, for instance) are still recognised via
+ * the launcher's file name.
+ */
+
+import { realpathSync } from 'node:fs';
+
+/** Launcher file names that unambiguously mean "the `ac2` CLI was invoked". */
+const BIN_NAMES = ['ac2'] as const;
+
+/** Executable suffixes the OS package managers add to their shims. */
+const SHIM_EXTENSIONS = ['.cmd', '.ps1', '.bat', '.exe', '.js', '.mjs', '.cjs'] as const;
+
+/** Options for {@link isDirectInvocation} (all injectable for tests). */
+export interface DirectInvocationOptions {
+  /** The launcher path, i.e. `process.argv[1]`. */
+  argv1?: string | undefined;
+  /** Defaults to `process.platform`; only `'win32'` changes the comparison. */
+  platform?: NodeJS.Platform;
+  /** Symlink resolver; defaults to `realpathSync` (missing paths pass through). */
+  realpath?: (path: string) => string;
+}
+
+/**
+ * Convert a `file:` URL to a filesystem path, tolerating Windows drive paths.
+ *
+ * `node:url`'s `fileURLToPath` throws on a Windows URL when it runs on POSIX
+ * (and vice versa), which would make the guard platform-dependent; this
+ * conversion is deliberately platform-agnostic. Non-`file:` inputs are
+ * returned untouched so a plain path can be passed in.
+ */
+export function moduleUrlToPath(moduleUrl: string): string {
+  if (!moduleUrl.startsWith('file:')) return moduleUrl;
+  const withoutScheme = moduleUrl.replace(/^file:(\/\/)?/, '');
+  let path: string;
+  try {
+    path = decodeURIComponent(withoutScheme);
+  } catch {
+    path = withoutScheme;
+  }
+  // `file:///C:/dir/cli.js` -> `C:/dir/cli.js`
+  return /^\/[A-Za-z]:/.test(path) ? path.slice(1) : path;
+}
+
+/** Separator-, trailing-slash- and (on Windows) case-insensitive path form. */
+function normalizePath(path: string, platform: NodeJS.Platform): string {
+  const unified = path.replace(/\\/g, '/').replace(/\/{2,}/g, '/').replace(/\/+$/, '');
+  return platform === 'win32' ? unified.toLowerCase() : unified;
+}
+
+/** Last segment of `path`, with any shim extension stripped. */
+function launcherName(path: string): string {
+  const name = path.replace(/\\/g, '/').split('/').pop() ?? '';
+  const lower = name.toLowerCase();
+  const extension = SHIM_EXTENSIONS.find((candidate) => lower.endsWith(candidate));
+  return (extension ? lower.slice(0, -extension.length) : lower).trim();
+}
+
+/**
+ * Whether the module identified by `moduleUrl` is the program Node was asked
+ * to run (as opposed to a module some other entry point imported).
+ */
+export function isDirectInvocation(
+  moduleUrl: string,
+  options: DirectInvocationOptions = {},
+): boolean {
+  const argv1 = options.argv1 ?? process.argv[1];
+  if (argv1 === undefined || argv1.trim() === '') return false;
+  const platform = options.platform ?? process.platform;
+  const realpath =
+    options.realpath ??
+    ((path: string): string => {
+      try {
+        return realpathSync(path);
+      } catch {
+        return path;
+      }
+    });
+
+  const self = normalizePath(realpath(moduleUrlToPath(moduleUrl)), platform);
+  const entry = normalizePath(realpath(argv1), platform);
+  if (self === entry) return true;
+
+  // A wrapper that neither symlinks nor execs the real file (e.g. a Yarn PnP
+  // shim) still names itself after the bin it stands for.
+  return BIN_NAMES.includes(launcherName(argv1) as (typeof BIN_NAMES)[number]);
+}

--- a/packages/ac2-cli/src/cli.ts
+++ b/packages/ac2-cli/src/cli.ts
@@ -20,6 +20,7 @@ import {
 import { installServiceUnit, uninstallServiceUnit } from './daemon/service-units.js';
 import { runDaemon } from './daemon/run.js';
 import { parseCliArgs, type CliFlags } from './cli-args.js';
+import { isDirectInvocation } from './cli-entry.js';
 
 const HELP_TEXT = `Usage: ac2 <command> [options]
 
@@ -390,12 +391,7 @@ export async function runCli(argv: string[]): Promise<number> {
   }
 }
 
-const invokedDirectly = (): boolean => {
-  const entry = process.argv[1];
-  return entry !== undefined && import.meta.url === `file://${entry}`;
-};
-
-if (invokedDirectly()) {
+if (isDirectInvocation(import.meta.url)) {
   runCli(process.argv.slice(2)).then((code) => {
     process.exitCode = code;
   });

--- a/packages/ac2-cli/src/control/protocol.ts
+++ b/packages/ac2-cli/src/control/protocol.ts
@@ -19,6 +19,7 @@
  * (default: {@link DEFAULT_TARGET_AGENT}).
  */
 
+import { createHash } from 'node:crypto';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
@@ -40,11 +41,25 @@ export function resolveAc2Home(env: NodeJS.ProcessEnv = process.env): string {
 /**
  * Control socket path. Override with `AC2_DAEMON_SOCKET`. On Windows a named
  * pipe is used because Unix domain socket paths are not portable there.
+ *
+ * A named pipe has no directory to live in, so the *profile* has to be encoded
+ * in its name: with a custom `AC2_HOME` the pipe is suffixed with a digest of
+ * that home, mirroring the per-home socket file on POSIX (otherwise two AC2
+ * profiles on one Windows box would fight over a single pipe). The default home
+ * keeps the historical, unsuffixed name.
  */
-export function resolveControlSocketPath(env: NodeJS.ProcessEnv = process.env): string {
+export function resolveControlSocketPath(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): string {
   const override = env.AC2_DAEMON_SOCKET?.trim();
   if (override && override.length > 0) return override;
-  if (process.platform === 'win32') return '\\\\.\\pipe\\ac2-daemon';
+  if (platform === 'win32') {
+    const home = env.AC2_HOME?.trim();
+    if (!home) return '\\\\.\\pipe\\ac2-daemon';
+    const digest = createHash('sha256').update(home).digest('hex').slice(0, 12);
+    return `\\\\.\\pipe\\ac2-daemon-${digest}`;
+  }
   return join(resolveAc2Home(env), 'ac2d.sock');
 }
 

--- a/packages/ac2-cli/src/daemon/manager.ts
+++ b/packages/ac2-cli/src/daemon/manager.ts
@@ -40,6 +40,8 @@ export async function startDetached(
     detached: true,
     stdio: ['ignore', logFd.fd, logFd.fd],
     env,
+    // Windows would otherwise flash (and keep) a console window for the daemon.
+    windowsHide: true,
   });
 
   const pid = child.pid;

--- a/packages/ac2-cli/src/daemon/service-units.ts
+++ b/packages/ac2-cli/src/daemon/service-units.ts
@@ -133,7 +133,12 @@ export async function installServiceUnit(opts: {
   const target = resolveServiceUnitTarget(platform, env, homeDir);
 
   if (target.kind === 'unsupported') {
-    throw new Error(`OS supervision is not supported on platform: ${platform}`);
+    // Windows has no user-level unit format the CLI can write; the detached
+    // daemon (`ac2 service start`) is the supported way to run it there.
+    throw new Error(
+      `OS supervision is not supported on platform: ${platform}. ` +
+        'Use `ac2 service start` to run the daemon detached instead.',
+    );
   }
 
   await mkdir(dirname(target.path), { recursive: true });

--- a/packages/ac2-cli/src/keystore/constants.ts
+++ b/packages/ac2-cli/src/keystore/constants.ts
@@ -11,6 +11,12 @@ export const KEYCHAIN_SERVICE_PREFIX = 'ac2-keystore';
 /** File name of the upstream keystore's AES-GCM sealed metadata blob. */
 export const METADATA_FILE = 'ac2-keystore-metadata.bin';
 
+/** File name of the dedicated macOS keychain (see `darwin-keyring.ts`). */
+export const KEYCHAIN_FILE = 'ac2-keystore.keychain-db';
+
+/** File name of the `0600` file holding the dedicated keychain's password. */
+export const KEYCHAIN_KEY_FILE = 'ac2-keystore.keychain-key';
+
 /** Keystore id of the daemon's own, self-generated service identity. */
 export const SERVICE_KEY_ID = 'ac2-service';
 

--- a/packages/ac2-cli/src/keystore/create.ts
+++ b/packages/ac2-cli/src/keystore/create.ts
@@ -11,6 +11,7 @@
 
 import { createNodeKeyStore, type KeyStoreState } from '@algorandfoundation/keystore-node';
 import { Store } from '@tanstack/store';
+import { createDefaultDarwinKeyring } from './darwin-keyring.js';
 import { migrateLegacyKeystore } from './migrate.js';
 import { resolveKeychainService, resolveKeystoreStateDir, resolveMetadataPath } from './paths.js';
 import type { Ac2KeyStore, Ac2KeyStoreOptions } from './types.js';
@@ -27,10 +28,15 @@ export function createAc2KeyStore(options: Ac2KeyStoreOptions = {}): Ac2KeyStore
   const store = options.store ?? new Store<KeyStoreState>({ keys: [], status: 'idle' });
   const log = options.log ?? ((): void => {});
 
+  // On macOS the default is a dedicated, self-unlocked AC2 keychain: the login
+  // keychain is locked in the headless contexts the daemon runs in (launchd,
+  // SSH) and every access there fails with "User interaction is not allowed".
+  const keyring = options.keyring ?? createDefaultDarwinKeyring({ stateDir, service, log });
+
   const keystore = createNodeKeyStore({
     store,
     service,
-    ...(options.keyring ? { keyring: options.keyring } : {}),
+    ...(keyring ? { keyring } : {}),
     ...(options.metadata ? { metadata: options.metadata } : { metadataPath }),
   });
 

--- a/packages/ac2-cli/src/keystore/darwin-keyring.ts
+++ b/packages/ac2-cli/src/keystore/darwin-keyring.ts
@@ -1,0 +1,316 @@
+/**
+ * A macOS keyring binding over a **dedicated keychain file** owned by AC2.
+ *
+ * The default binding (`@napi-rs/keyring`) files everything in the user's
+ * *login* keychain. That works in a GUI session, but the AC2 daemon is a
+ * background process: under launchd (`ac2 service install`), over SSH, or
+ * before login the login keychain is locked and macOS cannot show the unlock
+ * prompt, so every access fails with `errSecInteractionNotAllowed` ("User
+ * interaction is not allowed."). Since AC2's keys are only ever used by the
+ * daemon itself, they live in a private keychain instead:
+ *
+ * - The keychain file (`ac2-keystore.keychain-db`) sits in the AC2 state dir
+ *   next to the sealed metadata blob; its password is random and kept in a
+ *   `0600` secret file (`ac2-keystore.keychain-key`) in the same directory.
+ * - The daemon creates and unlocks the keychain itself via `/usr/bin/security`,
+ *   so no user interaction is ever required — pairing works headless.
+ * - Auto-lock is disabled (`set-keychain-settings` with no timeout), and every
+ *   operation retries once after an explicit unlock in case the keychain was
+ *   locked externally (e.g. after a reboot).
+ * - Secrets never appear on an argv: commands that carry the keychain password
+ *   or an entry's material are fed to `security -i` over stdin.
+ *
+ * The binding is synchronous (the upstream driver requires it) and shells out
+ * with `spawnSync`; keystore operations are rare, so the cost is irrelevant.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { randomBytes } from 'node:crypto';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import type { KeyringBinding } from '@algorandfoundation/keystore-node';
+import { KEYCHAIN_FILE, KEYCHAIN_KEY_FILE } from './constants.js';
+
+/** `errSecItemNotFound` / `errSecDuplicateKeychain` as `security(1)` exit codes. */
+const EXIT_NOT_FOUND = 44;
+const EXIT_DUPLICATE_KEYCHAIN = 48;
+
+/** Outcome of one `security(1)` invocation. */
+export interface SecurityResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Runs `security(1)`; injectable so tests never touch a real keychain. */
+export type SecurityRunner = (args: string[], input?: string) => SecurityResult;
+
+/** Options for {@link createDarwinKeyring}. */
+export interface DarwinKeyringOptions {
+  /** OS-keychain service every entry is filed under. */
+  service: string;
+  /** Absolute path of the dedicated keychain file. */
+  keychainPath: string;
+  /** Absolute path of the `0600` file holding the keychain password. */
+  secretPath: string;
+  /** Inject a `security(1)` runner — tests use a fake. */
+  runSecurity?: SecurityRunner;
+  /** Progress / diagnostics sink. */
+  log?: (line: string) => void;
+}
+
+/** Absolute path of the dedicated keychain file for `stateDir`. */
+export function resolveKeychainPath(stateDir: string): string {
+  return join(stateDir, KEYCHAIN_FILE);
+}
+
+/** Absolute path of the keychain-password secret file for `stateDir`. */
+export function resolveKeychainKeyPath(stateDir: string): string {
+  return join(stateDir, KEYCHAIN_KEY_FILE);
+}
+
+const defaultRunner: SecurityRunner = (args, input) => {
+  const result = spawnSync('/usr/bin/security', args, {
+    encoding: 'utf8',
+    ...(input === undefined ? {} : { input }),
+  });
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+};
+
+/** Quotes a token for `security -i`'s command parser. */
+function quote(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Creates a {@link KeyringBinding} over a dedicated, self-unlocked macOS
+ * keychain file. See the module doc for the full design.
+ */
+export function createDarwinKeyring(options: DarwinKeyringOptions): KeyringBinding {
+  const { service, keychainPath, secretPath } = options;
+  const run = options.runSecurity ?? defaultRunner;
+  const log = options.log ?? ((): void => {});
+
+  let password: string | null = null;
+  let ready = false;
+
+  /** Feeds one command (with secrets) to `security -i` over stdin. */
+  const runStdin = (command: string): SecurityResult => run(['-i'], `${command}\n`);
+
+  const readOrCreatePassword = (): string => {
+    if (password) return password;
+    mkdirSync(dirname(secretPath), { recursive: true, mode: 0o700 });
+    try {
+      password = readFileSync(secretPath, 'utf8').trim();
+    } catch {
+      password = null;
+    }
+    if (!password) {
+      password = randomBytes(32).toString('hex');
+      writeFileSync(secretPath, `${password}\n`, { mode: 0o600 });
+    }
+    // The password is the only thing standing between an attacker with file
+    // access and the key material — never leave it group/world readable.
+    chmodSync(secretPath, 0o600);
+    return password;
+  };
+
+  const unlock = (): void => {
+    const pw = readOrCreatePassword();
+    const result = runStdin(`unlock-keychain -p ${quote(pw)} ${quote(keychainPath)}`);
+    if (result.status !== 0) {
+      throw new Error(
+        `[ac2] failed to unlock the AC2 keychain (${keychainPath}): ${result.stderr.trim()}`,
+      );
+    }
+  };
+
+  const ensureReady = (): void => {
+    if (ready) return;
+    const pw = readOrCreatePassword();
+    if (!existsSync(keychainPath)) {
+      const created = runStdin(`create-keychain -p ${quote(pw)} ${quote(keychainPath)}`);
+      if (created.status === 0) {
+        log(`[ac2] created dedicated keychain ${keychainPath}`);
+      } else if (created.status !== EXIT_DUPLICATE_KEYCHAIN) {
+        throw new Error(
+          `[ac2] failed to create the AC2 keychain (${keychainPath}): ${created.stderr.trim()}`,
+        );
+      }
+    }
+    // No `-l`/`-u`: never auto-lock, so the daemon unlocks once per process.
+    run(['set-keychain-settings', keychainPath]);
+    unlock();
+    ready = true;
+  };
+
+  /** Runs `operation`, retrying once after an explicit unlock. */
+  const withUnlockRetry = (operation: () => SecurityResult): SecurityResult => {
+    ensureReady();
+    let result = operation();
+    if (result.status !== 0 && result.status !== EXIT_NOT_FOUND) {
+      unlock();
+      result = operation();
+    }
+    return result;
+  };
+
+  return {
+    get(account: string): string | null {
+      const result = withUnlockRetry(() =>
+        run(['find-generic-password', '-s', service, '-a', account, '-w', keychainPath]),
+      );
+      if (result.status === EXIT_NOT_FOUND) return null;
+      if (result.status !== 0) {
+        // Never mask a hard failure as "absent": the driver would regenerate
+        // its metadata master key and orphan every stored entry.
+        throw new Error(
+          `[ac2] failed to read keychain entry "${account}": ${result.stderr.trim()}`,
+        );
+      }
+      return result.stdout.replace(/\n$/, '');
+    },
+    set(account: string, secret: string): void {
+      const result = withUnlockRetry(() =>
+        runStdin(
+          `add-generic-password -U -s ${quote(service)} -a ${quote(account)} ` +
+            `-w ${quote(secret)} ${quote(keychainPath)}`,
+        ),
+      );
+      if (result.status !== 0) {
+        throw new Error(
+          `[ac2] failed to write keychain entry "${account}": ${result.stderr.trim()}`,
+        );
+      }
+    },
+    delete(account: string): boolean {
+      const result = withUnlockRetry(() =>
+        run(['delete-generic-password', '-s', service, '-a', account, keychainPath]),
+      );
+      return result.status === 0;
+    },
+  };
+}
+
+/**
+ * Wraps `primary` with a best-effort, lazy **read** fallback to the login
+ * keychain: entries written by earlier AC2 versions (which used the default
+ * `@napi-rs/keyring` binding) are copied into the dedicated keychain the first
+ * time they are read, so existing pairings survive the switch. Writes and
+ * deletes always target the dedicated keychain; login-keychain failures (e.g.
+ * headless sessions where it is locked) are treated as "absent".
+ */
+export function withLoginKeychainFallback(
+  primary: KeyringBinding,
+  options: {
+    /** OS-keychain service the legacy entries were filed under. */
+    service: string;
+    /** Progress / diagnostics sink. */
+    log?: (line: string) => void;
+    /** Inject the legacy binding — tests use a fake. */
+    login?: KeyringBinding | null;
+  },
+): KeyringBinding {
+  const { service } = options;
+  const log = options.log ?? ((): void => {});
+  let login: KeyringBinding | null | undefined = options.login;
+
+  const loginBinding = (): KeyringBinding | null => {
+    if (login !== undefined) return login;
+    try {
+      const require = createRequire(import.meta.url);
+      const { Entry } = require('@napi-rs/keyring') as {
+        Entry: new (
+          service: string,
+          account: string,
+        ) => { getPassword(): string; deletePassword(): boolean };
+      };
+      login = {
+        get(account: string): string | null {
+          try {
+            return new Entry(service, account).getPassword();
+          } catch {
+            return null;
+          }
+        },
+        set(): void {},
+        delete(account: string): boolean {
+          try {
+            return new Entry(service, account).deletePassword();
+          } catch {
+            return false;
+          }
+        },
+      };
+    } catch {
+      login = null;
+    }
+    return login;
+  };
+
+  return {
+    get(account: string): string | null {
+      const existing = primary.get(account);
+      if (existing !== null) return existing;
+      const legacy = loginBinding()?.get(account) ?? null;
+      if (legacy !== null) {
+        try {
+          primary.set(account, legacy);
+          log(`[ac2] migrated keychain entry "${account}" from the login keychain`);
+        } catch {
+          // Migration is best-effort — serving the value still works.
+        }
+      }
+      return legacy;
+    },
+    set(account: string, secret: string): void {
+      primary.set(account, secret);
+    },
+    delete(account: string): boolean {
+      const deleted = primary.delete(account);
+      const legacyDeleted = loginBinding()?.delete(account) ?? false;
+      return deleted || legacyDeleted;
+    },
+  };
+}
+
+/** Options for {@link createDefaultDarwinKeyring}. */
+export interface DefaultDarwinKeyringOptions {
+  stateDir: string;
+  service: string;
+  /** Injectable for tests; defaults to `process.platform`. */
+  platform?: NodeJS.Platform;
+  /** Injectable for tests; defaults to `process.env`. */
+  env?: NodeJS.ProcessEnv;
+  runSecurity?: SecurityRunner;
+  log?: (line: string) => void;
+}
+
+/**
+ * The default keyring for {@link createAc2KeyStore} when the caller injects
+ * none: on macOS a dedicated AC2 keychain (with the login-keychain read
+ * fallback), elsewhere `undefined` so the upstream default applies. Setting
+ * `AC2_KEYRING=login` restores the old login-keychain behaviour.
+ */
+export function createDefaultDarwinKeyring(
+  options: DefaultDarwinKeyringOptions,
+): KeyringBinding | undefined {
+  const platform = options.platform ?? process.platform;
+  const env = options.env ?? process.env;
+  if (platform !== 'darwin') return undefined;
+  if (env['AC2_KEYRING']?.trim() === 'login') return undefined;
+  const log = options.log ?? ((): void => {});
+  const dedicated = createDarwinKeyring({
+    service: options.service,
+    keychainPath: resolveKeychainPath(options.stateDir),
+    secretPath: resolveKeychainKeyPath(options.stateDir),
+    ...(options.runSecurity ? { runSecurity: options.runSecurity } : {}),
+    log,
+  });
+  return withLoginKeychainFallback(dedicated, { service: options.service, log });
+}

--- a/packages/ac2-cli/src/keystore/index.ts
+++ b/packages/ac2-cli/src/keystore/index.ts
@@ -6,6 +6,7 @@
 
 export * from './constants.js';
 export * from './create.js';
+export * from './darwin-keyring.js';
 export * from './errors.js';
 export * from './material.js';
 export * from './migrate.js';

--- a/packages/ac2-cli/tests/cli-entry.test.ts
+++ b/packages/ac2-cli/tests/cli-entry.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for the `ac2` entry-point guard (`src/cli-entry.ts`).
+ *
+ * The unit cases inject `argv1`, the platform and a fake `realpath`, so the
+ * Windows and Linux launcher shapes are covered on any host. The final case is
+ * a real `node` run through a bin *symlink* — the npm/pnpm install layout that
+ * used to make the CLI exit silently.
+ */
+
+import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { transformSync } from 'esbuild';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { isDirectInvocation, moduleUrlToPath } from '../src/cli-entry.js';
+
+/** A `realpath` that follows one fake symlink table and passes through misses. */
+const fakeRealpath =
+  (links: Record<string, string>) =>
+  (path: string): string =>
+    links[path] ?? path;
+
+describe('moduleUrlToPath', () => {
+  it('converts POSIX file URLs, decoding percent escapes', () => {
+    expect(moduleUrlToPath('file:///opt/ac2/dist/cli.js')).toBe('/opt/ac2/dist/cli.js');
+    expect(moduleUrlToPath('file:///opt/my%20apps/cli.js')).toBe('/opt/my apps/cli.js');
+  });
+
+  it('converts Windows file URLs by dropping the leading slash', () => {
+    expect(moduleUrlToPath('file:///C:/Users/me/node_modules/.pnpm/cli.js')).toBe(
+      'C:/Users/me/node_modules/.pnpm/cli.js',
+    );
+  });
+
+  it('passes plain paths through untouched', () => {
+    expect(moduleUrlToPath('/opt/ac2/dist/cli.js')).toBe('/opt/ac2/dist/cli.js');
+  });
+});
+
+describe('isDirectInvocation', () => {
+  const dist = '/opt/app/node_modules/@algorandfoundation/ac2-cli/dist/cli.js';
+  const selfUrl = `file://${dist}`;
+
+  it('accepts the plain `node dist/cli.js` invocation', () => {
+    expect(isDirectInvocation(selfUrl, { argv1: dist, platform: 'linux', realpath: (p) => p })).toBe(
+      true,
+    );
+  });
+
+  it('accepts the npm/pnpm bin symlink (the install-layout regression)', () => {
+    const bin = '/opt/app/node_modules/.bin/ac2';
+    expect(
+      isDirectInvocation(selfUrl, {
+        argv1: bin,
+        platform: 'linux',
+        realpath: fakeRealpath({ [bin]: dist }),
+      }),
+    ).toBe(true);
+  });
+
+  it('accepts a Windows shim path regardless of separators and casing', () => {
+    const winSelf = 'file:///C:/Users/Me/AppData/npm/node_modules/ac2-cli/dist/cli.js';
+    const winEntry = 'C:\\Users\\me\\AppData\\npm\\node_modules\\ac2-cli\\dist\\CLI.js';
+    expect(
+      isDirectInvocation(winSelf, { argv1: winEntry, platform: 'win32', realpath: (p) => p }),
+    ).toBe(true);
+  });
+
+  it('accepts paths with spaces and non-ASCII characters (percent-encoded URL)', () => {
+    const path = '/Users/josé/my apps/ac2-cli/dist/cli.js';
+    const url = `file:///Users/jos%C3%A9/my%20apps/ac2-cli/dist/cli.js`;
+    expect(isDirectInvocation(url, { argv1: path, platform: 'darwin', realpath: (p) => p })).toBe(
+      true,
+    );
+  });
+
+  it('accepts a wrapper named after the bin even when it resolves elsewhere', () => {
+    expect(
+      isDirectInvocation(selfUrl, {
+        argv1: '/opt/app/.yarn/unplugged/shims/ac2',
+        platform: 'linux',
+        realpath: (p) => p,
+      }),
+    ).toBe(true);
+    expect(
+      isDirectInvocation(selfUrl, {
+        argv1: 'C:\\opt\\app\\node_modules\\.bin\\AC2.CMD',
+        platform: 'win32',
+        realpath: (p) => p,
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects being imported by an unrelated entry point', () => {
+    expect(
+      isDirectInvocation(selfUrl, {
+        argv1: '/opt/app/node_modules/.bin/openclaw',
+        platform: 'linux',
+        realpath: (p) => p,
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects a missing argv[1] (e.g. `node --eval`)', () => {
+    expect(isDirectInvocation(selfUrl, { argv1: undefined, platform: 'linux' })).toBe(false);
+    expect(isDirectInvocation(selfUrl, { argv1: '  ', platform: 'linux' })).toBe(false);
+  });
+});
+
+describe('isDirectInvocation (real node run through a bin symlink)', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'ac2-cli-entry-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  /** Runs `launcher` with real `node` and returns its stdout. */
+  const runNode = (launcher: string): string => {
+    const run = spawnSync(process.execPath, [launcher], { encoding: 'utf8' });
+    expect(run.stderr).toBe('');
+    return run.stdout.trim();
+  };
+
+  it('reports true for the real file and for the npm-style bin symlink', () => {
+    // The guard runs in a plain node child (no TS loader), so it is transpiled
+    // next to a stand-in for `dist/cli.js` — same layout, same symlinked bin.
+    const source = new URL('../src/cli-entry.ts', import.meta.url);
+    const guard = transformSync(readFileSync(source, 'utf8'), { loader: 'ts', format: 'esm' }).code;
+    writeFileSync(join(dir, 'cli-entry.mjs'), guard);
+
+    const entry = join(dir, 'cli.mjs');
+    writeFileSync(
+      entry,
+      `import { isDirectInvocation } from './cli-entry.mjs';\n` +
+        `console.log(isDirectInvocation(import.meta.url) ? 'direct' : 'imported');\n`,
+    );
+    const bin = join(dir, 'ac2');
+    symlinkSync(entry, bin);
+
+    expect(runNode(entry)).toBe('direct');
+    expect(runNode(bin)).toBe('direct');
+  });
+
+  it('reports false when an unrelated entry point imports the module', () => {
+    const source = new URL('../src/cli-entry.ts', import.meta.url);
+    writeFileSync(
+      join(dir, 'cli-entry.mjs'),
+      transformSync(readFileSync(source, 'utf8'), { loader: 'ts', format: 'esm' }).code,
+    );
+    writeFileSync(
+      join(dir, 'cli.mjs'),
+      `import { isDirectInvocation } from './cli-entry.mjs';\n` +
+        `export const verdict = isDirectInvocation(import.meta.url) ? 'direct' : 'imported';\n`,
+    );
+    const host = join(dir, 'host.mjs');
+    writeFileSync(host, `import { verdict } from './cli.mjs';\nconsole.log(verdict);\n`);
+
+    expect(runNode(host)).toBe('imported');
+  });
+});

--- a/packages/ac2-cli/tests/control.test.ts
+++ b/packages/ac2-cli/tests/control.test.ts
@@ -9,6 +9,7 @@ import { tmpdir } from 'node:os';
 import {
   connectControl,
   createControlServer,
+  resolveControlSocketPath,
   type ControlClient,
   type ControlEventName,
   type ControlServer,
@@ -129,5 +130,42 @@ describe('ControlSocket', () => {
       handler: () => ({}),
     });
     await expect(second.listen()).rejects.toThrow(/daemon already running/);
+  });
+});
+
+describe('resolveControlSocketPath', () => {
+  const WIN_PIPE = '\\\\.\\pipe\\ac2-daemon';
+
+  it('uses a socket file inside AC2_HOME on Linux and macOS', () => {
+    for (const platform of ['linux', 'darwin'] as const) {
+      expect(resolveControlSocketPath({ AC2_HOME: '/srv/ac2' }, platform)).toBe(
+        join('/srv/ac2', 'ac2d.sock'),
+      );
+    }
+  });
+
+  it('uses the historical named pipe on Windows with the default home', () => {
+    expect(resolveControlSocketPath({}, 'win32')).toBe(WIN_PIPE);
+  });
+
+  it('gives every custom AC2_HOME its own Windows pipe', () => {
+    const first = resolveControlSocketPath({ AC2_HOME: 'C:\\ac2\\profile-a' }, 'win32');
+    const second = resolveControlSocketPath({ AC2_HOME: 'C:\\ac2\\profile-b' }, 'win32');
+    expect(first.startsWith(`${WIN_PIPE}-`)).toBe(true);
+    expect(first.slice(WIN_PIPE.length + 1)).toMatch(/^[0-9a-f]{12}$/);
+    expect(second).not.toBe(first);
+    // Stable across calls, so client and daemon always agree.
+    expect(resolveControlSocketPath({ AC2_HOME: 'C:\\ac2\\profile-a' }, 'win32')).toBe(first);
+  });
+
+  it('always honours an explicit AC2_DAEMON_SOCKET override', () => {
+    for (const platform of ['linux', 'darwin', 'win32'] as const) {
+      expect(
+        resolveControlSocketPath(
+          { AC2_DAEMON_SOCKET: '  \\\\.\\pipe\\custom  ', AC2_HOME: '/srv/ac2' },
+          platform,
+        ),
+      ).toBe('\\\\.\\pipe\\custom');
+    }
   });
 });

--- a/packages/ac2-cli/tests/darwin-keyring.test.ts
+++ b/packages/ac2-cli/tests/darwin-keyring.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Tests for the dedicated macOS keychain binding (`darwin-keyring.ts`).
+ *
+ * The unit tests inject a fake `security(1)` runner, so they run on every
+ * platform and never touch a real keychain. The final suite is a real
+ * roundtrip against a throwaway keychain file and only runs on macOS.
+ */
+
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { KeyringBinding } from '@algorandfoundation/keystore-node';
+import {
+  createDarwinKeyring,
+  createDefaultDarwinKeyring,
+  resolveKeychainKeyPath,
+  resolveKeychainPath,
+  withLoginKeychainFallback,
+  type SecurityResult,
+  type SecurityRunner,
+} from '../src/keystore/darwin-keyring.js';
+import { KEYCHAIN_FILE, KEYCHAIN_KEY_FILE } from '../src/keystore/constants.js';
+
+/** One recorded `security(1)` invocation. */
+interface Call {
+  args: string[];
+  input?: string;
+}
+
+/** A scriptable fake `security(1)`: responds per stdin/argv command keyword. */
+function fakeSecurity(
+  respond: (command: string, call: Call) => SecurityResult | undefined,
+): { runner: SecurityRunner; calls: Call[] } {
+  const calls: Call[] = [];
+  const runner: SecurityRunner = (args, input) => {
+    const call: Call = { args, ...(input === undefined ? {} : { input }) };
+    calls.push(call);
+    const command = input?.trim().split(/\s+/, 1)[0] ?? args[0] ?? '';
+    return respond(command, call) ?? { status: 0, stdout: '', stderr: '' };
+  };
+  return { runner, calls };
+}
+
+const ok = (stdout = ''): SecurityResult => ({ status: 0, stdout, stderr: '' });
+const notFound = (): SecurityResult => ({
+  status: 44,
+  stdout: '',
+  stderr: 'security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.',
+});
+
+describe('createDarwinKeyring (fake security)', () => {
+  let dir: string;
+  let keychainPath: string;
+  let secretPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'ac2-darwin-keyring-'));
+    keychainPath = join(dir, KEYCHAIN_FILE);
+    secretPath = join(dir, KEYCHAIN_KEY_FILE);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const binding = (runner: SecurityRunner): KeyringBinding =>
+    createDarwinKeyring({ service: 'svc', keychainPath, secretPath, runSecurity: runner });
+
+  it('bootstraps on first use: secret file (0600), create, settings, unlock', () => {
+    const { runner, calls } = fakeSecurity((command) =>
+      command === 'find-generic-password' ? notFound() : undefined,
+    );
+    expect(binding(runner).get('acct')).toBeNull();
+    const commands = calls.map((c) => c.input?.trim().split(/\s+/, 1)[0] ?? c.args[0]);
+    expect(commands.slice(0, 3)).toEqual([
+      'create-keychain',
+      'set-keychain-settings',
+      'unlock-keychain',
+    ]);
+    const mode = statSync(secretPath).mode & 0o777;
+    expect(mode).toBe(0o600);
+    const password = readFileSync(secretPath, 'utf8').trim();
+    expect(password).toMatch(/^[0-9a-f]{64}$/);
+    // The password travels over stdin, never on an argv.
+    for (const call of calls) {
+      expect(call.args.join(' ')).not.toContain(password);
+    }
+    expect(calls[0]?.input).toContain(password);
+    expect(calls[2]?.input).toContain(password);
+  });
+
+  it('reuses an existing secret file and skips create when the keychain exists', () => {
+    writeFileSync(secretPath, 'a'.repeat(64) + '\n', { mode: 0o600 });
+    writeFileSync(keychainPath, '');
+    const { runner, calls } = fakeSecurity((command) =>
+      command === 'find-generic-password' ? notFound() : undefined,
+    );
+    expect(binding(runner).get('acct')).toBeNull();
+    const commands = calls.map((c) => c.input?.trim().split(/\s+/, 1)[0] ?? c.args[0]);
+    expect(commands).not.toContain('create-keychain');
+    expect(calls.find((c) => c.input?.startsWith('unlock-keychain'))?.input).toContain(
+      'a'.repeat(64),
+    );
+  });
+
+  it('get returns the trimmed secret, null on 44, and throws on hard failures', () => {
+    const responses: Record<string, SecurityResult> = {
+      'find-generic-password': ok('c2VjcmV0\n'),
+    };
+    const { runner } = fakeSecurity((command) => responses[command]);
+    const keyring = binding(runner);
+    expect(keyring.get('acct')).toBe('c2VjcmV0');
+
+    responses['find-generic-password'] = notFound();
+    expect(keyring.get('acct')).toBeNull();
+
+    responses['find-generic-password'] = { status: 1, stdout: '', stderr: 'boom' };
+    expect(() => keyring.get('acct')).toThrow(/failed to read keychain entry "acct".*boom/);
+  });
+
+  it('retries a failed operation once after an explicit unlock', () => {
+    let finds = 0;
+    let unlocks = 0;
+    const { runner } = fakeSecurity((command) => {
+      if (command === 'unlock-keychain') {
+        unlocks += 1;
+        return ok();
+      }
+      if (command === 'find-generic-password') {
+        finds += 1;
+        return finds === 1
+          ? { status: 51, stdout: '', stderr: 'User interaction is not allowed.' }
+          : ok('after-unlock\n');
+      }
+      return undefined;
+    });
+    expect(binding(runner).get('acct')).toBe('after-unlock');
+    expect(finds).toBe(2);
+    expect(unlocks).toBe(2); // bootstrap + retry
+  });
+
+  it('set feeds the secret over stdin with -U and quoted, escaped tokens', () => {
+    const { runner, calls } = fakeSecurity(() => undefined);
+    binding(runner).set('a "b" \\c', 'top secret');
+    const add = calls.find((c) => c.input?.startsWith('add-generic-password'));
+    expect(add).toBeDefined();
+    expect(add?.args).toEqual(['-i']);
+    expect(add?.input).toContain('-U ');
+    expect(add?.input).toContain('-s "svc"');
+    expect(add?.input).toContain('-a "a \\"b\\" \\\\c"');
+    expect(add?.input).toContain('-w "top secret"');
+    // The secret never appears on an argv.
+    for (const call of calls) {
+      expect(call.args.join(' ')).not.toContain('top secret');
+    }
+  });
+
+  it('set throws on failure', () => {
+    const { runner } = fakeSecurity((command) =>
+      command === 'add-generic-password' ? { status: 1, stdout: '', stderr: 'nope' } : undefined,
+    );
+    expect(() => binding(runner).set('acct', 's')).toThrow(
+      /failed to write keychain entry "acct".*nope/,
+    );
+  });
+
+  it('delete returns true on success and false when absent', () => {
+    const responses: Record<string, SecurityResult> = { 'delete-generic-password': ok() };
+    const { runner } = fakeSecurity((command) => responses[command]);
+    const keyring = binding(runner);
+    expect(keyring.delete('acct')).toBe(true);
+    responses['delete-generic-password'] = notFound();
+    expect(keyring.delete('acct')).toBe(false);
+  });
+});
+
+describe('withLoginKeychainFallback', () => {
+  const memory = (): KeyringBinding & { map: Map<string, string> } => {
+    const map = new Map<string, string>();
+    return {
+      map,
+      get: (account) => map.get(account) ?? null,
+      set: (account, secret) => void map.set(account, secret),
+      delete: (account) => map.delete(account),
+    };
+  };
+
+  it('serves and migrates a legacy entry on read miss', () => {
+    const primary = memory();
+    const login = memory();
+    login.map.set('acct', 'legacy-secret');
+    const keyring = withLoginKeychainFallback(primary, { service: 'svc', login });
+    expect(keyring.get('acct')).toBe('legacy-secret');
+    expect(primary.map.get('acct')).toBe('legacy-secret');
+  });
+
+  it('prefers the dedicated keychain and never writes to the login keychain', () => {
+    const primary = memory();
+    const login = memory();
+    primary.map.set('acct', 'dedicated');
+    login.map.set('acct', 'legacy');
+    const keyring = withLoginKeychainFallback(primary, { service: 'svc', login });
+    expect(keyring.get('acct')).toBe('dedicated');
+    keyring.set('other', 'value');
+    expect(primary.map.get('other')).toBe('value');
+    expect(login.map.has('other')).toBe(false);
+  });
+
+  it('delete clears both stores', () => {
+    const primary = memory();
+    const login = memory();
+    login.map.set('acct', 'legacy');
+    const keyring = withLoginKeychainFallback(primary, { service: 'svc', login });
+    expect(keyring.delete('acct')).toBe(true);
+    expect(login.map.has('acct')).toBe(false);
+  });
+
+  it('treats an unavailable login keychain as absent', () => {
+    const primary = memory();
+    const keyring = withLoginKeychainFallback(primary, { service: 'svc', login: null });
+    expect(keyring.get('acct')).toBeNull();
+  });
+});
+
+describe('createDefaultDarwinKeyring', () => {
+  it('is inert off macOS', () => {
+    expect(
+      createDefaultDarwinKeyring({ stateDir: '/tmp/x', service: 'svc', platform: 'linux' }),
+    ).toBeUndefined();
+  });
+
+  it('honours the AC2_KEYRING=login escape hatch', () => {
+    expect(
+      createDefaultDarwinKeyring({
+        stateDir: '/tmp/x',
+        service: 'svc',
+        platform: 'darwin',
+        env: { AC2_KEYRING: 'login' },
+      }),
+    ).toBeUndefined();
+  });
+
+  it('returns a dedicated-keychain binding on macOS', () => {
+    const keyring = createDefaultDarwinKeyring({
+      stateDir: '/tmp/x',
+      service: 'svc',
+      platform: 'darwin',
+      env: {},
+      runSecurity: () => ok(),
+    });
+    expect(keyring).toBeDefined();
+  });
+});
+
+describe.runIf(process.platform === 'darwin')('real keychain roundtrip (macOS)', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'ac2-keychain-it-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('creates its keychain, then set/get/delete roundtrips survive re-instantiation', () => {
+    const options = {
+      service: 'ac2-keystore-test',
+      keychainPath: resolveKeychainPath(dir),
+      secretPath: resolveKeychainKeyPath(dir),
+    };
+    const first = createDarwinKeyring(options);
+
+    expect(first.get('missing')).toBeNull();
+
+    const material = 'QUJD'.repeat(256); // a chunk-sized base64 payload
+    first.set('m/did:key:z6MkTest', material);
+    expect(first.get('m/did:key:z6MkTest')).toBe(material);
+
+    // Overwrite (`-U`) and an account with spaces/quotes.
+    first.set('m/did:key:z6MkTest', 'dXBkYXRlZA==');
+    first.set('odd "account" name', 'dg==');
+    expect(first.get('m/did:key:z6MkTest')).toBe('dXBkYXRlZA==');
+    expect(first.get('odd "account" name')).toBe('dg==');
+
+    // A fresh binding (new process in real life) reuses the same keychain.
+    const second = createDarwinKeyring(options);
+    expect(second.get('m/did:key:z6MkTest')).toBe('dXBkYXRlZA==');
+
+    expect(second.delete('m/did:key:z6MkTest')).toBe(true);
+    expect(second.delete('m/did:key:z6MkTest')).toBe(false);
+    expect(second.get('m/did:key:z6MkTest')).toBeNull();
+    expect(second.delete('odd "account" name')).toBe(true);
+
+    const mode = statSync(options.secretPath).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+});


### PR DESCRIPTION
# Overview

- Fixes crash on service running on Darwin which doesn't have headless access to the login keychain. Resolved by moving to a keychain that is fully owned by the daemon
- Fixes cli output being empty in published packages
- Resolves paths for Windows targets