### PR TITLE
fix: refactor connection handling to address stale peer issues. 

### DIFF
--- a/packages/ac2-cli/ARCHITECTURE.md
+++ b/packages/ac2-cli/ARCHITECTURE.md
@@ -371,3 +371,18 @@ as the fallback for a daemon that was spawned but is not listening yet. That is
 what makes `ac2 status` report a supervised service correctly, and what stops
 `ac2 service start` (and an agent host's auto-start) from launching a second
 daemon on top of a healthy one.
+
+### Stopping exits the process explicitly
+
+A daemon that owns its process (`service run` / `--foreground`; anything but the
+in-process test embedding) calls `process.exit` itself once a stop — a signal or
+a control-socket `daemon.stop` — has finished tearing down, instead of trusting
+the event loop to drain: a paired daemon holds handles (native WebRTC peers,
+socket.io reconnect timers) that can keep a fully-stopped process alive forever,
+which is how a "stopped" daemon used to linger across a CLI reinstall until
+killed by hand. A graceful stop that itself wedges is bounded by an unref'd
+failsafe timer (exit code 1, so a supervisor can tell). `ac2 service stop`
+mirrors this from the outside: it resolves the pid first (the socket reports it
+even for a supervised daemon, which writes no pidfile), waits for the process to
+actually exit after `daemon.stop`, and escalates to SIGTERM, then SIGKILL, when
+it does not.

--- a/packages/ac2-cli/README.md
+++ b/packages/ac2-cli/README.md
@@ -106,7 +106,7 @@ Everything has a working default. Set these only if you need to.
 | `AC2_DEFAULT_AGENT` | Agent id inbound wallet traffic goes to (default `openclaw`). |
 | `AC2_HEARTBEAT_TIMEOUT_MS` | How long a silent wallet channel may stay open. |
 | `AC2_RUNTIME` | Which runtime adapter drives the agent: `socket` (default), `openclaw-gateway`, or an npm package name. |
-| `AC2_RUNTIME_CONFIG` | JSON config handed to that adapter. |
+| `AC2_RUNTIME_CONFIG` | JSON config handed to that adapter. For `openclaw-gateway` it also accepts `runTimeoutMs` (how long one agent turn may run, default 300000 — x402 payments block on a wallet signature round-trip, so keep this generous) and `taskTimeoutMs` (same budget for a spawned sub-agent task, default 900000), e.g. `AC2_RUNTIME_CONFIG='{"runTimeoutMs":600000}'`. Values must be JSON numbers. |
 | `AC2_WAIT_FOR_RUNTIME` | Set to `0` to await a wallet even when no agent runtime is alive. |
 | `AC2_KEYRING` | macOS only. Set to `login` to store keys in the login keychain instead of the dedicated AC2 keychain (see Troubleshooting). |
 | `OPENCLAW_GATEWAY_URL` / `_PORT` / `_TOKEN` | Gateway connection for the `openclaw-gateway` adapter. Discovered from `openclaw.json` when unset. |

--- a/packages/ac2-cli/README.md
+++ b/packages/ac2-cli/README.md
@@ -169,6 +169,19 @@ now comes from the live control socket, with the pidfile as fallback, and
 `ac2 service start` reports an already-running service instead of spawning a
 second one.
 
+**`ac2 service stop` "succeeded" but the daemon kept running** (classic symptom:
+reinstalling the CLI, then having to `kill` the old daemon by hand). Also fixed,
+twice over. The daemon used to rely on its event loop draining after a
+`daemon.stop`, which handles like native WebRTC peers could keep alive forever;
+it now exits its process explicitly once the graceful stop completes, with a
+failsafe exit if the teardown itself wedges. And `ac2 service stop` no longer
+reports success on the acknowledgement alone: it waits for the process to
+actually die and escalates to SIGTERM, then SIGKILL, when it does not — also for
+a supervised daemon with no pidfile, using the pid the daemon reported over the
+socket. Note that reinstalling the CLI never restarts a running daemon by
+itself: run `ac2 service stop` around the upgrade so the next start picks up the
+new code.
+
 **macOS asks whether "node" may run in the background.** That prompt (and the
 entry in System Settings → General → Login Items & Extensions) *is* the AC2
 service: macOS names a background item after the program its launchd job runs,

--- a/packages/ac2-cli/src/cli.ts
+++ b/packages/ac2-cli/src/cli.ts
@@ -12,6 +12,7 @@ import { resolveControlSocketPath } from './control/protocol.js';
 import type { DaemonStatus } from './control/protocol.js';
 import {
   followLogFile,
+  isProcessAlive,
   startDetached,
   stopDaemonProcess,
   tailLogFile,
@@ -54,6 +55,23 @@ Commands:
 
 function printHelp(): void {
   console.log(HELP_TEXT);
+}
+
+/**
+ * How long `service stop` waits for the daemon process to actually exit after
+ * it acknowledged `daemon.stop`, before escalating to signals. Covers the
+ * daemon's own graceful-stop failsafe (5s, see `run.ts`) with margin.
+ */
+const DAEMON_STOP_GRACE_MS = 8_000;
+
+/** Poll `pid` until it exits (true) or `timeoutMs` elapses (false). */
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) return true;
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  return !isProcessAlive(pid);
 }
 
 /** The `ac2` script's own path, used to spawn/reference itself (detached child, OS units). */
@@ -127,24 +145,55 @@ async function serviceStart(flags: CliFlags): Promise<number> {
 }
 
 async function serviceStop(): Promise<number> {
-  try {
-    const client = await connectControl({ timeoutMs: 1000 });
-    try {
-      await client.request('daemon.stop', {});
-      console.log('daemon stop requested');
-      return 0;
-    } finally {
-      client.close();
-    }
-  } catch {
-    const result = await stopDaemonProcess();
-    if (result.stopped) {
-      console.log(`daemon stopped (pid ${result.pid})`);
-      return 0;
-    }
+  // Resolve WHO to stop first: the control socket also yields the pid of an
+  // OS-supervised daemon (which writes no pidfile), so the signal escalation
+  // below can target it when the graceful path stalls.
+  const liveness = await daemonLiveness();
+  if (!liveness.running) {
     console.log('daemon is not running');
     return 1;
   }
+  const pid = liveness.pid;
+  if (liveness.source === 'control-socket') {
+    try {
+      const client = await connectControl({ timeoutMs: 1000 });
+      try {
+        await client.request('daemon.stop', {});
+      } finally {
+        client.close();
+      }
+      // `daemon.stop` only acknowledges that a stop has begun — never report
+      // success until the process is actually gone. A daemon wedged in
+      // teardown (or one predating the explicit post-stop exit) acknowledges
+      // and then lingers forever, which is exactly the "still active after a
+      // reinstall, had to kill it by hand" trap.
+      if (pid !== null && (await waitForProcessExit(pid, DAEMON_STOP_GRACE_MS))) {
+        console.log(`daemon stopped (pid ${pid})`);
+        return 0;
+      }
+      if (pid === null) {
+        // No pid to verify or signal (a daemon.status without one) — the
+        // request went through; nothing further can be checked.
+        console.log('daemon stop requested');
+        return 0;
+      }
+      console.log(`daemon did not exit after stop request; escalating to signals (pid ${pid})`);
+    } catch {
+      // The socket died between the liveness probe and the request — fall
+      // through to the signal path.
+    }
+  }
+  const result = await stopDaemonProcess({ ...(pid !== null ? { pid } : {}), force: true });
+  if (result.stopped) {
+    console.log(`daemon stopped (pid ${result.pid})`);
+    return 0;
+  }
+  if (result.pid !== null) {
+    console.error(`failed to stop daemon (pid ${result.pid}) — even SIGKILL did not take`);
+    return 1;
+  }
+  console.log('daemon is not running');
+  return 1;
 }
 
 function formatStatusLines(status: DaemonStatus): string[] {

--- a/packages/ac2-cli/src/daemon/manager.ts
+++ b/packages/ac2-cli/src/daemon/manager.ts
@@ -112,17 +112,30 @@ export async function daemonProcessStatus(
 
 /**
  * Stops the daemon process gracefully or forcefully.
+ *
+ * Targets `options.pid` when given — e.g. the pid the daemon itself reported
+ * over the control socket, which is the only handle on an OS-supervised
+ * daemon (it writes no pidfile) — and falls back to the pidfile otherwise.
+ * An explicit pid that is already dead reports `stopped: true`: the caller
+ * asked for a process it just observed alive to be gone, and it is.
  */
 export async function stopDaemonProcess(
-  options: DaemonManagerOptions & { timeoutMs?: number; force?: boolean } = {}
+  options: DaemonManagerOptions & { timeoutMs?: number; force?: boolean; pid?: number } = {}
 ): Promise<{ stopped: boolean; pid: number | null }> {
   const env = options.env ?? process.env;
   const pidFile = options.pidFile ?? resolvePidFilePath(env);
-  const status = await daemonProcessStatus(options);
-  const pid = status.pid;
-
-  if (!status.running || pid === null) {
-    return { stopped: false, pid: null };
+  let pid: number;
+  if (options.pid !== undefined) {
+    if (!isProcessAlive(options.pid)) {
+      return { stopped: true, pid: options.pid };
+    }
+    pid = options.pid;
+  } else {
+    const status = await daemonProcessStatus(options);
+    if (!status.running || status.pid === null) {
+      return { stopped: false, pid: null };
+    }
+    pid = status.pid;
   }
 
   const timeoutMs = options.timeoutMs ?? 10000;
@@ -156,10 +169,22 @@ export async function stopDaemonProcess(
   if (force) {
     try {
       process.kill(pid, 'SIGKILL');
-      await unlink(pidFile);
-      return { stopped: true, pid };
     } catch {
-      // Failed to kill
+      return { stopped: false, pid };
+    }
+    // SIGKILL cannot be caught, but delivery is asynchronous — poll briefly so
+    // `stopped: true` reflects an observed death, not just a sent signal.
+    const killDeadline = Date.now() + 2000;
+    while (Date.now() < killDeadline && isProcessAlive(pid)) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    if (!isProcessAlive(pid)) {
+      try {
+        await unlink(pidFile);
+      } catch {
+        // No pidfile to clean up (explicit-pid target) or already gone.
+      }
+      return { stopped: true, pid };
     }
   }
 

--- a/packages/ac2-cli/src/daemon/run.ts
+++ b/packages/ac2-cli/src/daemon/run.ts
@@ -52,6 +52,14 @@ export const AC2_DAEMON_VERSION = '1.0.0-canary.1';
 /** Default Liquid Auth origin when none is configured. */
 const DEFAULT_ORIGIN = 'https://debug.liquidauth.com';
 
+/**
+ * Ceiling on how long a graceful stop may run before the daemon exits the
+ * process anyway (see `shutdown` inside {@link runDaemon}). Generous next to a
+ * normal teardown (well under a second), tight enough that `ac2 service stop`
+ * can wait it out before escalating to signals.
+ */
+const SHUTDOWN_EXIT_FAILSAFE_MS = 5_000;
+
 export interface DaemonRunOptions {
   /** Control socket path; defaults to {@link resolveControlSocketPath}. */
   socketPath?: string;
@@ -92,8 +100,21 @@ export interface DaemonRunOptions {
   keystoreSocketPath?: string;
   /** Host the keystore RPC service when nothing else already does (default `true`). */
   hostKeystore?: boolean;
-  /** Install SIGTERM/SIGINT handlers that gracefully stop the daemon (default `true`). */
+  /**
+   * "This daemon owns its process": install SIGTERM/SIGINT handlers that
+   * gracefully stop it, and exit the process explicitly once a stop (signal
+   * or control-socket `daemon.stop`) has completed (default `true`). Disable
+   * for in-process embedding (tests), where exiting would kill the host.
+   */
   handleSignals?: boolean;
+  /**
+   * How long a graceful stop may take before the process exits anyway
+   * (default {@link SHUTDOWN_EXIT_FAILSAFE_MS}; only used when
+   * {@link handleSignals} says this daemon owns its process).
+   */
+  stopExitFailsafeMs?: number;
+  /** Test seam for the post-stop process exit (default `process.exit`). */
+  exit?: (code: number) => void;
   /**
    * Runtime adapter wiring (opts → `AC2_RUNTIME`/`AC2_RUNTIME_CONFIG` env →
    * the built-in `socket` default). See `../runtime/loader.ts`.
@@ -339,6 +360,8 @@ export async function runDaemon(options: DaemonRunOptions = {}): Promise<Running
   const origin = firstNonEmpty(options.origin, env['AC2_LIQUID_AUTH_SERVER']) ?? DEFAULT_ORIGIN;
   const hostKeystoreOpt = options.hostKeystore ?? true;
   const handleSignals = options.handleSignals ?? true;
+  const stopExitFailsafeMs = options.stopExitFailsafeMs ?? SHUTDOWN_EXIT_FAILSAFE_MS;
+  const exitProcess = options.exit ?? ((code: number): void => process.exit(code));
   const autoPair = options.autoPair ?? false;
   const resumeConnections = options.resumeConnections ?? true;
   const waitForRuntime = resolveWaitForRuntime(options, env);
@@ -591,9 +614,10 @@ export async function runDaemon(options: DaemonRunOptions = {}): Promise<Running
         return buildStatus();
 
       case 'daemon.stop': {
-        // Respond first, then tear down once the frame has been flushed.
+        // Respond first, then tear down — and exit, see `shutdown` — once the
+        // frame has been flushed.
         setImmediate(() => {
-          void stop();
+          void shutdown('daemon.stop');
         });
         return { stopping: true };
       }
@@ -767,6 +791,41 @@ export async function runDaemon(options: DaemonRunOptions = {}): Promise<Running
     return stopping;
   }
 
+  /**
+   * Stop gracefully, then — when this daemon owns its process
+   * (`handleSignals`) — exit it explicitly instead of trusting the event loop
+   * to drain. A paired daemon holds handles that can outlive a completed
+   * teardown (native WebRTC peers, socket.io reconnect timers), which used to
+   * leave the process alive after `daemon.stop` had "succeeded" — a stale
+   * daemon lingering across a CLI reinstall until someone killed it by hand.
+   * A graceful stop that itself hangs (a wedged adapter/provider close) is
+   * bounded by an unref'd failsafe timer for the same reason; it exits
+   * non-zero so a supervisor can tell the difference.
+   */
+  function shutdown(trigger: string): Promise<void> {
+    const finished = stop();
+    if (!handleSignals) return finished;
+    // First exit wins, like the real `process.exit` — the test seam would
+    // otherwise see a late graceful completion "exit 0" after the failsafe.
+    let exited = false;
+    const exitOnce = (code: number): void => {
+      if (exited) return;
+      exited = true;
+      exitProcess(code);
+    };
+    const failsafe = setTimeout(() => {
+      log(
+        `[ac2] graceful stop still running after ${stopExitFailsafeMs}ms (${trigger}); exiting anyway.`,
+      );
+      exitOnce(1);
+    }, stopExitFailsafeMs);
+    failsafe.unref?.();
+    return finished.then(() => {
+      clearTimeout(failsafe);
+      exitOnce(0);
+    });
+  }
+
   const server: ControlServer = createControlServer({
     ...(options.socketPath !== undefined ? { path: options.socketPath } : {}),
     handler: handleRequest,
@@ -835,7 +894,7 @@ export async function runDaemon(options: DaemonRunOptions = {}): Promise<Running
   if (handleSignals) {
     const onSignal = (): void => {
       log('[ac2] received signal, shutting down…');
-      void stop().then(() => process.exit(0));
+      void shutdown('signal');
     };
     process.once('SIGTERM', onSignal);
     process.once('SIGINT', onSignal);

--- a/packages/ac2-cli/src/runtime/gateway/adapter.ts
+++ b/packages/ac2-cli/src/runtime/gateway/adapter.ts
@@ -101,6 +101,19 @@ const RUN_FINALIZE_GRACE_MS = 400;
 const RUN_START_SKEW_MS = 2000;
 
 /**
+ * Slack added to a wait's SERVER-side deadline to derive the client-side RPC
+ * timeout for the same call. Every `agent.wait` must pass an explicit client
+ * timeout of `<its server timeoutMs> + this`: the client's own default
+ * (`DEFAULT_REQUEST_TIMEOUT_MS`, 30s — see `./client.ts`) is far below the run
+ * and task deadlines, so omitting it makes the client abandon a perfectly
+ * healthy run long before the gateway does, reporting a generic transport
+ * error for a run that keeps executing and can never be cancelled. Keeping the
+ * client deadline strictly above the server's means a server-side timeout
+ * always wins the race and yields the honest `status: 'timeout'` result.
+ */
+const WAIT_CLIENT_TIMEOUT_SLACK_MS = 5000;
+
+/**
  * Result shape of the `agent` RPC (accepted response), confirmed against the
  * Gateway source (`agent-run-admission-phase.ts`): `{runId, sessionKey,
  * agentId?, status:'accepted', acceptedAt, runtime?}`. Only `runId` is used
@@ -925,13 +938,14 @@ export function createOpenClawGatewayAdapter(
       try {
         if (!client) throw new Error('gateway not connected');
         // The RPC's own client-side timeout is kept slightly ABOVE the
-        // server-side `agent.wait` timeout it carries as a param, so a
-        // server-side timeout response always wins the race and yields the
-        // honest `failed` reason below instead of a generic client timeout.
+        // server-side `agent.wait` timeout it carries as a param (see
+        // {@link WAIT_CLIENT_TIMEOUT_SLACK_MS}), so a server-side timeout
+        // response always wins the race and yields the honest `failed` reason
+        // below instead of a generic client timeout.
         const waitResult = await client.request<AgentWaitResult>(
           'agent.wait',
           { runId: watch.childRunId, timeoutMs: cfg.taskTimeoutMs },
-          cfg.taskTimeoutMs + 5000,
+          cfg.taskTimeoutMs + WAIT_CLIENT_TIMEOUT_SLACK_MS,
         );
         if (stopped) return;
 
@@ -1545,10 +1559,24 @@ export function createOpenClawGatewayAdapter(
           }
           activeRun = run;
 
-          const waitResult = await client.request<AgentWaitResult>('agent.wait', {
-            runId: run.runId,
-            timeoutMs: cfg.runTimeoutMs,
-          });
+          // As on the spawned-task path (see the `agent.wait` call in the task
+          // watcher above), the RPC's own client-side timeout is kept slightly
+          // ABOVE the server-side `agent.wait` timeout it carries as a param.
+          // Without the third argument the client falls back to its 30s
+          // default, which is FAR below `runTimeoutMs` — so a turn that
+          // legitimately takes longer (an x402 payment blocks on a wallet
+          // signature round-trip, itself allowed 120s) was failed by the
+          // client timer at 30s while the gateway happily kept running. The
+          // run cannot be cancelled, so that surfaced as "the agent ran into
+          // an error" for work that then quietly succeeded.
+          const waitResult = await client.request<AgentWaitResult>(
+            'agent.wait',
+            {
+              runId: run.runId,
+              timeoutMs: cfg.runTimeoutMs,
+            },
+            cfg.runTimeoutMs + WAIT_CLIENT_TIMEOUT_SLACK_MS,
+          );
 
           if (waitResult.status === 'ok') {
             // `agent.wait` can resolve microseconds before the FINAL segment's

--- a/packages/ac2-cli/src/runtime/gateway/adapter.ts
+++ b/packages/ac2-cli/src/runtime/gateway/adapter.ts
@@ -1476,6 +1476,13 @@ export function createOpenClawGatewayAdapter(
     },
 
     async handleInbound(message: Ac2RuntimeInbound): Promise<void> {
+      // The run THIS invocation published to the `activeRun` slot (if it got
+      // that far). Every clear below is guarded by identity so an overlapping
+      // turn — or an early-returning frame that never started a run — cannot
+      // null out a slot that a NEWER run now owns (which would orphan that
+      // run's `session.message`/`session.tool` events at the `if (!run)`
+      // guard in the event handler).
+      let startedRun: ActiveRun | null = null;
       try {
         const controllerDid = message.controllerDid;
         if (!controllerDid) return;
@@ -1558,6 +1565,7 @@ export function createOpenClawGatewayAdapter(
             run.sessionKey = agentResult.sessionKey;
           }
           activeRun = run;
+          startedRun = run;
 
           // As on the spawned-task path (see the `agent.wait` call in the task
           // watcher above), the RPC's own client-side timeout is kept slightly
@@ -1585,14 +1593,14 @@ export function createOpenClawGatewayAdapter(
             // THEN detach (so no even-later event double-commits) and
             // reconcile any leftovers.
             await new Promise((resolve) => setTimeout(resolve, RUN_FINALIZE_GRACE_MS));
-            activeRun = null;
+            if (activeRun === run) activeRun = null;
             await finalizeRun(run, sessionKey);
             return;
           }
 
           // Detach the run before emitting the failure bubble so no late event
           // double-commits.
-          activeRun = null;
+          if (activeRun === run) activeRun = null;
 
           // Timeout / error: segments already committed stay as their bubbles;
           // add one more bubble carrying the failure so the wallet is not left
@@ -1612,7 +1620,7 @@ export function createOpenClawGatewayAdapter(
           }
           await host.send(buildFinalizeFrame(effectiveThid, randomUUID(), finalText), 'stream');
         } catch (err) {
-          activeRun = null;
+          if (activeRun === run) activeRun = null;
           host.log(`[ac2][openclaw-gateway] agent run failed: ${(err as Error).message}`);
           await host.send(
             buildNoticeFrame({
@@ -1634,7 +1642,11 @@ export function createOpenClawGatewayAdapter(
       } catch (err) {
         host.log(`[ac2][openclaw-gateway] handleInbound failed: ${(err as Error).message}`);
       } finally {
-        activeRun = null;
+        // Only clear the slot if THIS invocation still owns it — a frame that
+        // early-returned (whitespace-only text, gateway unavailable) never
+        // started a run, and a settled turn may have been superseded by a
+        // newer one that must keep streaming.
+        if (startedRun !== null && activeRun === startedRun) activeRun = null;
       }
     },
 

--- a/packages/ac2-cli/src/runtime/gateway/config.ts
+++ b/packages/ac2-cli/src/runtime/gateway/config.ts
@@ -31,7 +31,14 @@ export interface OpenClawGatewayConfig {
   agentId?: string;
   /** Timeout for the initial Gateway connect handshake. */
   connectTimeoutMs: number;
-  /** Timeout passed to `agent.wait` for a single run. */
+  /**
+   * Timeout passed to `agent.wait` for a single run. Must stay comfortably
+   * ABOVE the longest human-in-the-loop tool a turn can block on — notably an
+   * x402 payment, whose wallet signature round-trip alone is allowed 120s by
+   * the reference plugin — otherwise a turn the user is actively approving is
+   * reported as "the agent did not respond in time" while it keeps running
+   * (a run cannot be cancelled once started).
+   */
   runTimeoutMs: number;
   /**
    * Maximum number of past messages to fetch (via `chat.history`) when
@@ -57,7 +64,7 @@ export interface OpenClawGatewayConfig {
 
 const DEFAULT_PORT = 18789;
 const DEFAULT_CONNECT_TIMEOUT_MS = 10000;
-const DEFAULT_RUN_TIMEOUT_MS = 120000;
+const DEFAULT_RUN_TIMEOUT_MS = 300000;
 const DEFAULT_HISTORY_LIMIT = 100;
 const DEFAULT_TASK_TIMEOUT_MS = 900000;
 const DEFAULT_CONVERSATIONS_LIMIT = 100;

--- a/packages/ac2-cli/tests/daemon.test.ts
+++ b/packages/ac2-cli/tests/daemon.test.ts
@@ -381,6 +381,60 @@ describe('runDaemon', () => {
     await daemon.closed;
   });
 
+  it('daemon.stop exits the process explicitly when the daemon owns it', async () => {
+    // A paired daemon can hold handles that keep the event loop alive after a
+    // completed teardown (native WebRTC peers, socket.io timers) — trusting
+    // the loop to drain left stale daemons running across CLI reinstalls, so
+    // an owning daemon must exit itself once the graceful stop is done.
+    const exits: number[] = [];
+    const daemon = await startDaemon({ handleSignals: true, exit: (code) => exits.push(code) });
+    const client = await connect(daemon);
+
+    const result = await client.request('daemon.stop', {});
+    expect(result).toEqual({ stopping: true });
+
+    await daemon.closed;
+    await waitFor(() => exits.length > 0);
+    expect(exits).toEqual([0]);
+  });
+
+  it('exits non-zero via the failsafe when a graceful stop hangs', async () => {
+    let releaseDispose: () => void = () => {};
+    const disposeGate = new Promise<void>((resolve) => {
+      releaseDispose = resolve;
+    });
+    /** A pairing handle whose `dispose` wedges the broker's teardown. */
+    class HangingTeardownProvider extends FakeWalletProvider {
+      override async startPairing(
+        opts: Parameters<InMemoryChannelProvider['startPairing']>[0] = {},
+      ) {
+        const handle = await super.startPairing(opts);
+        return { ...handle, dispose: () => disposeGate };
+      }
+    }
+    const exits: number[] = [];
+    const daemon = await startDaemon({
+      handleSignals: true,
+      stopExitFailsafeMs: 150,
+      exit: (code) => exits.push(code),
+      providerFactory: () => new HangingTeardownProvider({ origin: ORIGIN }),
+    });
+    const client = await connect(daemon);
+    await client.request('pair.start', {});
+
+    const result = await client.request('daemon.stop', {});
+    expect(result).toEqual({ stopping: true });
+
+    // The graceful stop is stuck on the hanging dispose — only the failsafe
+    // can exit, and it must report the abnormal teardown (exit code 1).
+    await waitFor(() => exits.length > 0, 3000);
+    expect(exits).toEqual([1]);
+
+    // Unwedge the teardown so afterEach's `daemon.stop()` can settle.
+    releaseDispose();
+    await daemon.closed;
+  });
+
   it('hosts the embedded keystore service and reports its socket path', async () => {
     const keystoreSocketPath = join(socketDir, 'keystore.sock');
     const daemon = await startDaemon({ hostKeystore: true, keystoreSocketPath });

--- a/packages/ac2-cli/tests/manager.test.ts
+++ b/packages/ac2-cli/tests/manager.test.ts
@@ -3,6 +3,8 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { mkdtemp, rm, writeFile, appendFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -55,6 +57,57 @@ describe('DaemonManager', () => {
 
     const statusAfter = await daemonProcessStatus({ env });
     expect(statusAfter.running).toBe(false);
+    expect(isProcessAlive(pid)).toBe(false);
+  });
+
+  it('stops a daemon known only by an explicit pid (no pidfile)', async () => {
+    const { pid } = await startDetached({
+      command: process.execPath,
+      args: ['-e', 'setInterval(()=>{}, 1000)'],
+      env,
+    });
+    // Simulate an OS-supervised daemon: it writes no pidfile, so the pid must
+    // come from the caller (e.g. the pid `daemon.status` reported over the
+    // control socket).
+    await rm(join(tmpDir, 'ac2d.pid'), { force: true });
+
+    const result = await stopDaemonProcess({ env, pid, timeoutMs: 2000 });
+    expect(result).toEqual({ stopped: true, pid });
+    expect(isProcessAlive(pid)).toBe(false);
+  });
+
+  it('reports an explicit pid that is already dead as stopped', async () => {
+    const child = spawn(process.execPath, ['-e', ''], { stdio: 'ignore' });
+    const pid = child.pid!;
+    await new Promise((resolve) => child.once('exit', resolve));
+
+    // The caller observed this pid alive moments ago and asked for it to be
+    // gone — and it is: that is a successful stop, not "nothing running".
+    expect(await stopDaemonProcess({ env, pid })).toEqual({ stopped: true, pid });
+  });
+
+  it('escalates to SIGKILL when the process ignores SIGTERM and force is set', async () => {
+    const readyFile = join(tmpDir, 'sigterm-ignorer-ready');
+    const { pid } = await startDetached({
+      command: process.execPath,
+      args: [
+        '-e',
+        `process.on('SIGTERM', () => {}); require('fs').writeFileSync(${JSON.stringify(
+          readyFile,
+        )}, 'ready'); setInterval(()=>{}, 1000)`,
+      ],
+      env,
+    });
+    // Wait for the SIGTERM handler to be installed, so the graceful signal is
+    // genuinely ignored rather than delivered before the process booted.
+    const deadline = Date.now() + 5000;
+    while (!existsSync(readyFile) && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(existsSync(readyFile)).toBe(true);
+
+    const result = await stopDaemonProcess({ env, timeoutMs: 300, force: true });
+    expect(result).toEqual({ stopped: true, pid });
     expect(isProcessAlive(pid)).toBe(false);
   });
 

--- a/packages/ac2-cli/tests/runtime-gateway.test.ts
+++ b/packages/ac2-cli/tests/runtime-gateway.test.ts
@@ -749,6 +749,83 @@ describe('createOpenClawGatewayAdapter (adapter.ts)', () => {
     await handled;
   });
 
+  it('a settled earlier turn no longer orphans the newer run\'s streaming events (activeRun identity guard)', async () => {
+    const { sends, connection, adapter } = await setup();
+
+    // Turn A blocks on its agent.wait…
+    const handledA = adapter.handleInbound(inboundMessage('turn A'));
+    await waitFor(() => connection.sent.some((f) => f.method === 'sessions.messages.subscribe'));
+    connection.respondOk('sessions.messages.subscribe', {});
+    await waitFor(() => connection.sent.some((f) => f.method === 'agent'));
+    connection.respondOk('agent', { runId: 'run-A', acceptedAt: Date.now() });
+    await waitFor(() => connection.sent.some((f) => f.method === 'agent.wait'));
+
+    // …while turn B arrives and takes over the activeRun slot.
+    const handledB = adapter.handleInbound(inboundMessage('turn B'));
+    await waitFor(() => connection.sent.filter((f) => f.method === 'agent').length === 2);
+    connection.respondOk('agent', { runId: 'run-B', acceptedAt: Date.now() });
+    await waitFor(() => connection.sent.filter((f) => f.method === 'agent.wait').length === 2);
+
+    // A settles first. Its finalize path (grace timer, chat.history fallback,
+    // and the finally clause) must NOT null out the slot B now owns.
+    const waitA = connection.sent.find(
+      (f) =>
+        f.method === 'agent.wait' && (f.params as Record<string, unknown>)['runId'] === 'run-A',
+    );
+    expect(waitA).toBeDefined();
+    connection.emitFrame({ type: 'res', id: waitA!.id, ok: true, payload: { status: 'ok' } });
+    await waitFor(() => connection.sent.some((f) => f.method === 'chat.history'));
+    connection.respondOk('chat.history', { messages: [] });
+    await handledA;
+
+    // B's committed segment still lands as its own bubble (previously dropped
+    // at the `if (!run) return` guard because A's settle cleared the slot).
+    connection.emitEvent('session.message', {
+      sessionKey: 'ac2:did:key:zTest',
+      messageId: 'm-B',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'answer B' }] },
+    });
+    await waitFor(() =>
+      sends.some((s) => {
+        const f = parseStreamFrame(s.payload);
+        return f['t'] === 'finalize' && f['text'] === 'answer B' && f['mid'] === 'm-B';
+      }),
+    );
+
+    connection.respondOk('agent.wait', { status: 'ok' });
+    await handledB;
+  });
+
+  it('a whitespace-only frame does not orphan the active run\'s streaming events', async () => {
+    const { sends, connection, adapter } = await setup();
+
+    const handled = adapter.handleInbound(inboundMessage('real turn'));
+    await waitFor(() => connection.sent.some((f) => f.method === 'sessions.messages.subscribe'));
+    connection.respondOk('sessions.messages.subscribe', {});
+    await waitFor(() => connection.sent.some((f) => f.method === 'agent'));
+    connection.respondOk('agent', { runId: 'run-live', acceptedAt: Date.now() });
+    await waitFor(() => connection.sent.some((f) => f.method === 'agent.wait'));
+
+    // An empty frame early-returns — its finally clause used to null the live
+    // run's slot unconditionally, silently killing the stream.
+    await adapter.handleInbound(inboundMessage('   '));
+
+    connection.emitEvent('session.message', {
+      sessionKey: 'ac2:did:key:zTest',
+      messageId: 'm-live',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'still streaming' }] },
+    });
+    await waitFor(() =>
+      sends.some((s) => {
+        const f = parseStreamFrame(s.payload);
+        return f['t'] === 'finalize' && f['text'] === 'still streaming' && f['mid'] === 'm-live';
+      }),
+    );
+
+    connection.respondOk('agent.wait', { status: 'ok' });
+    await handled;
+  });
+
   it('splits one turn into a wallet message per committed assistant segment (intro then reply around a tool)', async () => {
     const { sends, connection, adapter } = await setup();
 

--- a/packages/ac2-cli/tests/runtime-gateway.test.ts
+++ b/packages/ac2-cli/tests/runtime-gateway.test.ts
@@ -371,7 +371,9 @@ describe('resolveGatewayConfig (config.ts)', () => {
     expect(cfg.token).toBeUndefined();
     expect(cfg.agentId).toBeUndefined();
     expect(cfg.connectTimeoutMs).toBe(10000);
-    expect(cfg.runTimeoutMs).toBe(120000);
+    // Deliberately above the 120s an x402 wallet signature is allowed to take,
+    // so a turn blocked on human approval is not failed as "did not respond".
+    expect(cfg.runTimeoutMs).toBe(300000);
   });
 
   it('prefers explicit config over env, and env over the default', () => {
@@ -603,6 +605,43 @@ describe('createOpenClawGatewayAdapter (adapter.ts)', () => {
     await handled;
     const finalize = parseStreamFrame(sends[sends.length - 1]!.payload);
     expect(finalize).toMatchObject({ t: 'discard', thid: 'default' });
+  });
+
+  it('lets a slow turn run past the client RPC default instead of failing it at 30s', async () => {
+    // Regression: the foreground `agent.wait` omitted its client-side timeout,
+    // so the RPC's 30s default fired long before the 5-minute server deadline
+    // it had just asked for. An x402 payment blocks on a wallet signature
+    // round-trip (itself allowed 120s), so every one of them was reported to
+    // the user as "the agent ran into an error" — while the run, which cannot
+    // be cancelled, kept going and often succeeded.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const { sends, logs, connection, adapter } = await setup();
+
+      const handled = adapter.handleInbound(inboundMessage('pay the invoice'));
+      await waitFor(() => connection.sent.some((f) => f.method === 'sessions.messages.subscribe'));
+      connection.respondOk('sessions.messages.subscribe', {});
+      await waitFor(() => connection.sent.some((f) => f.method === 'agent'));
+      connection.respondOk('agent', { runId: 'run-slow', acceptedAt: Date.now() });
+      await waitFor(() => connection.sent.some((f) => f.method === 'agent.wait'));
+
+      // Well past the client default, still inside the deadline we asked for.
+      await vi.advanceTimersByTimeAsync(60_000);
+      // (Only the wait matters here: the harness never answers the optional
+      // `sessions.subscribe`, whose own best-effort timeout is expected.)
+      expect(logs.filter((line) => line.includes('"agent.wait" timed out'))).toEqual([]);
+      expect(sends.some((s) => parseStreamFrame(s.payload)['t'] === 'finalize')).toBe(false);
+
+      // The signature finally lands and the turn completes normally.
+      connection.respondOk('agent.wait', { status: 'ok' });
+      await vi.advanceTimersByTimeAsync(1_000);
+      await waitFor(() => connection.sent.some((f) => f.method === 'chat.history'));
+      connection.respondOk('chat.history', { messages: [] });
+      await handled;
+      expect(logs.some((line) => line.includes('agent run failed'))).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('never re-posts a STALE chat.history message as this run\'s reply', async () => {

--- a/packages/ac2-sdk/src/providers/liquid-auth.ts
+++ b/packages/ac2-sdk/src/providers/liquid-auth.ts
@@ -135,6 +135,25 @@ const AC2_HEARTBEAT_MS = 20000;
  * long. 2.5× the send interval tolerates one missed round-trip plus jitter.
  */
 const AC2_DEFAULT_HEARTBEAT_TIMEOUT_MS = AC2_HEARTBEAT_MS * 2.5;
+/**
+ * Multiplier applied to the heartbeat timeout to obtain the SECOND-TIER
+ * ("hard") stale window, past which the heartbeat tears the peer down even
+ * though our signaling socket is up and presence still reports the wallet as
+ * present.
+ *
+ * The first tier deliberately defers to presence (see
+ * {@link shouldCloseOnHeartbeatTimeout}) because a backgrounded phone may
+ * legitimately suspend its heartbeat. But presence can be WRONG in exactly the
+ * way that hangs a reconnect: a mobile wallet whose WebRTC path died while its
+ * native service kept the signaling socket registered (and kept answering our
+ * pings from native code) is counted as present forever, so nothing ever
+ * corrects the stale peer and the wallet's re-offers land on a socket with no
+ * answer armed. Escalating after a much longer silence makes the heartbeat the
+ * authority of last resort: worst case we tear down a merely-quiet peer, and
+ * `connect()` is immediately re-armed on the same socket to answer it back in
+ * place.
+ */
+const AC2_HEARTBEAT_HARD_TIMEOUT_FACTOR = 4;
 /** Default ceiling for awaiting the signaling socket's initial `connect`. */
 const AC2_DEFAULT_PAIRING_TIMEOUT_MS = 120_000;
 /**
@@ -667,12 +686,63 @@ export function shouldTeardownOnPresence(
  * ignored — otherwise a still-present, merely-quiet peer is dropped, producing
  * spurious "peer went offline" churn on a link the server still reports as
  * present.
+ *
+ * That deference is bounded, though: presence is not infallible. A wallet
+ * whose data path died while its native service kept the signaling socket in
+ * the room stays "present" forever, so deferring to presence indefinitely
+ * meant NOTHING ever tore the stale peer down and the returning wallet's
+ * offers were never answered ("Reconnecting…" on the phone, silence in the
+ * agent log — no state transition, nothing to report). So a SECOND tier
+ * (`staleForFarTooLong`, see {@link AC2_HEARTBEAT_HARD_TIMEOUT_FACTOR}) closes
+ * the peer regardless of signaling/presence once the silence is far longer
+ * than any plausible backgrounding hiccup.
  */
 export function shouldCloseOnHeartbeatTimeout(state: {
   staleForTooLong: boolean;
   signalingConnected: boolean;
+  /**
+   * Silence has exceeded the second-tier ("hard") window. Optional so callers
+   * that only model the first tier keep their existing behaviour.
+   */
+  staleForFarTooLong?: boolean;
 }): boolean {
+  if (state.staleForFarTooLong === true) return true;
   return state.staleForTooLong && !state.signalingConnected;
+}
+
+/**
+ * Decide whether an INBOUND offer arriving on the live signaling socket means
+ * the peer restarted its side of the connection behind our back.
+ *
+ * A wallet only sends an `offer-description` when it wants a NEW peer session.
+ * If we believe we are still connected, that is unambiguous proof our peer is
+ * stale: the phone's WebRTC path died (typically while backgrounded) but its
+ * signaling socket never left the room, so presence still counts two devices
+ * and neither the presence rule (`shouldTeardownOnPresence`) nor the
+ * first-tier heartbeat rule (`shouldCloseOnHeartbeatTimeout`) ever fires. The
+ * SDK arms its answer listener only INSIDE `client.peer(...)` — a single
+ * `socket.once('offer-description')` per negotiation — so with nothing armed
+ * the wallet's offers vanish and it retries forever ("Reconnecting…"), while
+ * the agent logs nothing because no state ever transitions.
+ *
+ * Reacting to the offer breaks that deadlock from our side: tear the stale
+ * peer down so the caller re-arms `connect()` on the SAME socket. The offer
+ * that triggered this is necessarily lost (it arrived with no answer armed),
+ * but the wallet's own retry loop re-sends one, and by then we are listening.
+ *
+ * Ignored while a negotiation is already armed (`negotiating`) — that pending
+ * `peer(...)` is exactly what should consume the offer, and tearing down mid-
+ * handshake nulls its `peerClient` — and when we are not connected at all
+ * (nothing stale to replace).
+ */
+export function shouldTeardownOnRemoteOffer(state: {
+  connected: boolean;
+  negotiating: boolean;
+  closed: boolean;
+}): boolean {
+  if (state.closed) return false;
+  if (state.negotiating) return false;
+  return state.connected;
 }
 
 /**
@@ -882,6 +952,9 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
     const heartbeatTimeoutMs =
       this.defaults.heartbeatTimeoutMs ??
       resolveHeartbeatTimeoutMs(process.env['AC2_HEARTBEAT_TIMEOUT_MS']);
+    // Second-tier stale window: past this the heartbeat overrides presence
+    // (see `AC2_HEARTBEAT_HARD_TIMEOUT_FACTOR`).
+    const heartbeatHardTimeoutMs = heartbeatTimeoutMs * AC2_HEARTBEAT_HARD_TIMEOUT_FACTOR;
 
     // Build the signaling socket from the Node-native `socket.io-client` and
     // pass it to `SignalClient` via its `{ socket }` option. Replay any
@@ -1003,6 +1076,10 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
     let streamChannel: any;
     let heartbeatChannel: any;
     let onDataChannel: ((channel: any) => void) | undefined;
+    // The standing re-offer listener, bound ONCE below and detached only by
+    // `fullTeardown` (it must survive `teardownPeer`, whose whole point is to
+    // keep the socket usable between negotiations).
+    let onRemoteOffer: ((sdp: unknown) => void) | undefined;
 
     // Forward-declared so the presence subscription and the reactive re-offer
     // listener (both bound once, below) can trigger teardown before `connect()`
@@ -1060,6 +1137,15 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
         s?.off?.('offer-candidate');
         s?.off?.('answer-candidate');
         s?.off?.('answer-description');
+        // `SignalClient.signal()` arms a ONE-SHOT `offer-description` listener
+        // that stays attached when a negotiation is torn down before the offer
+        // arrives. Left behind, it would consume the returning wallet's next
+        // offer into the peer we just destroyed (`setRemoteDescription` on an
+        // undefined `peerClient`) instead of the freshly armed negotiation. Off
+        // by event name clears every handler — including our standing re-offer
+        // listener — so re-attach that one immediately afterwards.
+        s?.off?.('offer-description');
+        if (onRemoteOffer) (socket as any).on?.('offer-description', onRemoteOffer);
       } catch {
         // Best-effort.
       }
@@ -1107,9 +1193,11 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
       try {
         socket.off?.('disconnect', markSignalingUnstable);
         socket.off?.('connect', markSignalingStableSoon);
+        if (onRemoteOffer) socket.off?.('offer-description', onRemoteOffer);
       } catch {
         // Best-effort.
       }
+      onRemoteOffer = undefined;
       try {
         client.close(true);
       } catch {
@@ -1166,6 +1254,33 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
         void close();
       }
     });
+
+    // Reactive re-offer listener. Bound ONCE, for the lifetime of the socket,
+    // and deliberately OUTSIDE `connect()`: the SDK's `client.peer(...)` arms
+    // only a one-shot `socket.once('offer-description')` for the negotiation it
+    // is running, so between negotiations — and, critically, while we still
+    // believe we are connected — an offer from a returning wallet lands on a
+    // socket with nothing listening and is silently dropped.
+    //
+    // That is the other half of the "hangs on Reconnecting… forever" deadlock:
+    // the wallet's recovery preserves its signaling socket, so presence never
+    // drops to one device and neither presence nor the (presence-deferring)
+    // heartbeat tears our stale peer down; meanwhile the wallet renegotiates
+    // into the void. An inbound offer while `connected` is proof the peer
+    // restarted, so tear the stale peer down here and let the caller re-arm
+    // `connect()` on this same socket — the wallet's next retry is answered in
+    // place, with no QR rescan and no session switch (see
+    // `shouldTeardownOnRemoteOffer` for the exclusions).
+    onRemoteOffer = (): void => {
+      if (!shouldTeardownOnRemoteOffer({ connected, negotiating, closed })) return;
+      log(
+        'warn',
+        'received a new offer from the wallet while the peer was still considered live — ' +
+          'the peer restarted behind us; tearing down the stale peer to answer the next offer.',
+      );
+      void close();
+    };
+    socket.on?.('offer-description', onRemoteOffer);
 
     // Capture the wallet account from the Liquid Auth `link` response. The
     // `link-message` also marks the wallet as linked, arming the presence-driven
@@ -1366,7 +1481,9 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
         heartbeat = setInterval(() => {
           if (!heartbeatChannel || heartbeatChannel.readyState !== 'open') return;
 
-          const staleForTooLong = Date.now() - lastInboundAt > heartbeatTimeoutMs;
+          const silentForMs = Date.now() - lastInboundAt;
+          const staleForTooLong = silentForMs > heartbeatTimeoutMs;
+          const staleForFarTooLong = silentForMs > heartbeatHardTimeoutMs;
           // While our signaling socket is alive, presence is the authority for a
           // departed peer (it is faster and reflects the room membership the
           // server tracks). A mobile controller can legitimately suspend its
@@ -1376,11 +1493,22 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
           // still reported as present. Only when we have no connection to the
           // signaling server (no presence to trust) does the heartbeat become
           // authoritative again (see `shouldCloseOnHeartbeatTimeout`).
+          //
+          // …with one bound: presence can be stuck reporting a wallet that is
+          // no longer reachable over the data path (its native service holds
+          // the socket in the room). Past the much longer HARD window the
+          // heartbeat therefore escalates and closes anyway — otherwise the
+          // stale peer is never replaced and the wallet reconnects forever.
           const signalingConnected = (socket as { connected?: boolean }).connected === true;
-          if (shouldCloseOnHeartbeatTimeout({ staleForTooLong, signalingConnected })) {
+          if (
+            shouldCloseOnHeartbeatTimeout({ staleForTooLong, signalingConnected, staleForFarTooLong })
+          ) {
             log(
               'warn',
-              `Heartbeat timeout (${heartbeatTimeoutMs}ms with no inbound) and signaling is down — closing channel.`,
+              staleForFarTooLong && signalingConnected
+                ? `Heartbeat silent for ${silentForMs}ms (past the ${heartbeatHardTimeoutMs}ms hard window) ` +
+                    'while presence still reports the peer as present — closing the stale peer to await re-link.'
+                : `Heartbeat timeout (${heartbeatTimeoutMs}ms with no inbound) and signaling is down — closing channel.`,
             );
             void close();
             return;

--- a/packages/ac2-sdk/src/providers/liquid-auth.ts
+++ b/packages/ac2-sdk/src/providers/liquid-auth.ts
@@ -157,10 +157,10 @@ const AC2_HEARTBEAT_HARD_TIMEOUT_FACTOR = 4;
 /** Default ceiling for awaiting the signaling socket's initial `connect`. */
 const AC2_DEFAULT_PAIRING_TIMEOUT_MS = 120_000;
 /**
- * Once the signaling socket goes down mid-handshake, give socket.io's own
- * reconnection this long to recover before treating it as a genuine
- * ping-timeout/network failure. Deliberately independent of how long the
- * human takes to scan/approve — that phase has no ceiling of its own.
+ * How long to wait for socket.io's own reconnection before giving up on
+ * re-arming a dropped handshake in place (see `awaitSignalingUp`) and letting
+ * the caller rebuild on a fresh socket. Deliberately independent of how long
+ * the human takes to scan/approve — that phase has no ceiling of its own.
  */
 const AC2_DEFAULT_SIGNAL_DEAD_TIMEOUT_MS = 45_000;
 /** Poll interval for the wall-clock wake detector (see `startPairing`). */
@@ -263,13 +263,20 @@ export function resolveHeartbeatTimeoutMs(value?: string): number {
   return sanitizeHeartbeatTimeoutMs(Number(value));
 }
 
-/** Raised when the signaling socket never reaches `connect` in time. */
+/** Raised when the signaling socket cannot carry a pairing handshake. */
 export class SignalingConnectError extends Error {
-  readonly code: 'timeout' | 'aborted';
-  constructor(code: 'timeout' | 'aborted', message: string) {
+  readonly code: 'timeout' | 'aborted' | 'signaling-dropped';
+  /** For `signaling-dropped`: whether socket.io will bring this socket back. */
+  readonly reconnectable: boolean;
+  constructor(
+    code: 'timeout' | 'aborted' | 'signaling-dropped',
+    message: string,
+    reconnectable = false,
+  ) {
     super(message);
     this.name = 'SignalingConnectError';
     this.code = code;
+    this.reconnectable = reconnectable;
   }
 }
 
@@ -343,33 +350,94 @@ export function awaitSignalConnect(
 }
 
 /**
- * Race an arbitrary pairing-handshake promise against *sustained* signaling
- * socket disconnection (plus an optional abort `signal`) — never against a
- * flat wall-clock deadline. Used to bound the ICE offer/answer/candidate
- * exchange (`SignalClient#peer`), which waits on the human completing
- * pairing (scanning the QR, approving in their wallet) and can legitimately
- * take minutes. A flat timeout there would tear down a perfectly healthy
- * socket just because the human was slow. Instead, this only rejects once
- * `sock` has been continuously disconnected for `deadSocketTimeoutMs` — a
- * real ping-timeout/network failure that socket.io's own reconnection could
- * not recover from in time. Every reconnect (even after several blips)
- * clears the dead-socket timer, so the guard never fires while the socket is
- * healthy, however long the human takes. On failure, invokes `onFailure`
- * (torn down once) and rejects; a later resolution/rejection of `promise`
- * itself is ignored once the guard has already tripped.
- *
- * Disconnect reasons that socket.io will NOT auto-reconnect from (a
- * server-/client-initiated close) fail the current attempt immediately
- * rather than waiting out `deadSocketTimeoutMs` for a reconnect that can
- * never happen — handing off to the caller's re-pair loop (which opens a
- * fresh socket) sooner.
+ * Wait for socket.io's own reconnection to bring `sock` back, so a dropped
+ * handshake can be re-armed on the same socket. Resolves as soon as the
+ * socket is connected; rejects (after invoking `onFailure`) once the socket
+ * has stayed down for `timeoutMs` — a sustained outage the caller should
+ * treat as fatal and rebuild from scratch — or when `signal` aborts.
  */
+export function awaitSignalingUp(
+  sock: {
+    on: (event: string, listener: (...args: any[]) => void) => void;
+    off?: (event: string, listener: (...args: any[]) => void) => void;
+    connected?: boolean;
+  },
+  timeoutMs: number,
+  opts: { signal?: AbortSignal; onFailure?: () => void } = {},
+): Promise<void> {
+  if (sock.connected === true && opts.signal?.aborted !== true) return Promise.resolve();
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const done = (err?: SignalingConnectError): void => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      sock.off?.('connect', onConnect);
+      opts.signal?.removeEventListener('abort', onAbort);
+      if (!err) {
+        resolve();
+        return;
+      }
+      try {
+        opts.onFailure?.();
+      } catch {
+        // Teardown is best-effort; still reject the caller.
+      }
+      reject(err);
+    };
+    function onConnect(): void {
+      done();
+    }
+    function onAbort(): void {
+      done(
+        new SignalingConnectError(
+          'aborted',
+          '[ac2-open-claw] pairing aborted while waiting for the signaling socket to come back',
+        ),
+      );
+    }
+    if (opts.signal?.aborted) {
+      onAbort();
+      return;
+    }
+    timer = setTimeout(
+      () =>
+        done(
+          new SignalingConnectError(
+            'timeout',
+            `[ac2-open-claw] signaling socket stayed down for ${timeoutMs}ms; cannot re-arm the rendezvous`,
+          ),
+        ),
+      timeoutMs,
+    );
+    sock.on('connect', onConnect);
+    opts.signal?.addEventListener('abort', onAbort);
+  });
+}
+
+/** socket.io disconnect reasons the client will NOT auto-reconnect from. */
 export const SIGNALING_TERMINAL_DISCONNECT_REASONS: ReadonlySet<string> = new Set([
-  // socket.io reasons where the client does not attempt reconnection.
   'io server disconnect',
   'io client disconnect',
 ]);
 
+/**
+ * Fail an in-flight pairing handshake (`SignalClient#peer`) the moment the
+ * signaling socket drops — never on a wall-clock deadline, since the human
+ * scanning the QR may legitimately take minutes.
+ *
+ * Even a momentary drop is fatal to the handshake: socket.io discards pending
+ * acks in `Socket#onclose` (`_clearAcks`; `link()`'s plain ack has no
+ * `withError` flavor, so it is not even notified) and the server-side `link`
+ * subscription dies with the old session — so waiting for a reconnect to
+ * resume the rendezvous meant waiting forever. Re-arming on the recovered
+ * socket is the caller's job (see the retry loop in `connect()`), which is
+ * why `onFailure` fires only when the socket itself is unusable: a terminal
+ * disconnect reason (`reconnectable: false`) or an abort. A later
+ * resolution/rejection of `promise` itself is ignored once the guard has
+ * already tripped.
+ */
 export function withSignalingHealthGuard<T>(
   promise: Promise<T>,
   sock: {
@@ -377,23 +445,13 @@ export function withSignalingHealthGuard<T>(
     off?: (event: string, listener: (...args: any[]) => void) => void;
     connected?: boolean;
   },
-  opts: { deadSocketTimeoutMs: number; signal?: AbortSignal; onFailure?: () => void },
+  opts: { signal?: AbortSignal; onFailure?: () => void },
 ): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     let settled = false;
-    let deadTimer: ReturnType<typeof setTimeout> | undefined;
-
-    const clearDeadTimer = (): void => {
-      if (deadTimer !== undefined) {
-        clearTimeout(deadTimer);
-        deadTimer = undefined;
-      }
-    };
 
     const cleanup = (): void => {
-      clearDeadTimer();
       sock.off?.('disconnect', onDisconnect);
-      sock.off?.('connect', onReconnect);
       opts.signal?.removeEventListener('abort', onAbort);
     };
 
@@ -401,10 +459,12 @@ export function withSignalingHealthGuard<T>(
       if (settled) return;
       settled = true;
       cleanup();
-      try {
-        opts.onFailure?.();
-      } catch {
-        // Teardown is best-effort; still reject the caller.
+      if (!error.reconnectable) {
+        try {
+          opts.onFailure?.();
+        } catch {
+          // Teardown is best-effort; still reject the caller.
+        }
       }
       reject(error);
     };
@@ -420,44 +480,28 @@ export function withSignalingHealthGuard<T>(
 
     // socket.io passes the disconnect reason as the first listener arg.
     function onDisconnect(reason?: string): void {
-      // A server-/client-initiated close will never auto-reconnect this
-      // socket, so there is nothing to wait for — fail now and let the
-      // caller's re-pair loop open a fresh socket.
-      if (typeof reason === 'string' && SIGNALING_TERMINAL_DISCONNECT_REASONS.has(reason)) {
-        fail(
-          new SignalingConnectError(
-            'timeout',
-            `[ac2-open-claw] signaling connection closed during pairing and will not auto-reconnect (${reason})`,
-          ),
-        );
-        return;
-      }
-      clearDeadTimer();
-      deadTimer = setTimeout(() => {
-        fail(
-          new SignalingConnectError(
-            'timeout',
-            `[ac2-open-claw] signaling socket stayed disconnected for ${opts.deadSocketTimeoutMs}ms during pairing`,
-          ),
-        );
-      }, opts.deadSocketTimeoutMs);
-    }
-
-    function onReconnect(): void {
-      clearDeadTimer();
+      const reconnectable =
+        typeof reason !== 'string' || !SIGNALING_TERMINAL_DISCONNECT_REASONS.has(reason);
+      fail(
+        new SignalingConnectError(
+          'signaling-dropped',
+          `[ac2-open-claw] signaling socket dropped mid-handshake (${reason ?? 'unknown'}); ` +
+            'the rendezvous must be re-armed',
+          reconnectable,
+        ),
+      );
     }
 
     if (opts.signal?.aborted) {
       onAbort();
-      return;
+    } else if (sock.connected === false) {
+      // Already down when the guard was installed — the rendezvous cannot
+      // complete on this socket session; fail (reconnectably) right away.
+      onDisconnect();
+    } else {
+      sock.on('disconnect', onDisconnect);
+      opts.signal?.addEventListener('abort', onAbort);
     }
-
-    // Already down when the guard was installed — start counting right away.
-    if (sock.connected === false) onDisconnect();
-
-    sock.on('disconnect', onDisconnect);
-    sock.on('connect', onReconnect);
-    opts.signal?.addEventListener('abort', onAbort);
 
     promise.then(
       (value) => {
@@ -1143,6 +1187,15 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
       // Allow a fresh `client.peer(...)` on the reused SignalClient (it refuses
       // to run while a peer/requestId is still in progress).
       (client as any).peerClient = undefined;
+      // `link()` sets `SignalClient.requestId` on entry and only clears it in
+      // the wallet's ack — which socket.io silently discards when the socket
+      // session dies mid-wait — so an abandoned negotiation would leave the
+      // latch stuck and every later `peer()` throwing "Request is in process".
+      // Clearing the latch here is what lets a re-armed `peer()` re-link with
+      // the SAME pairing `requestId` (the identity lives in this closure and
+      // never rotates on a reconnect — only `ac2 forget` rotates it).
+      (client as any).requestId = undefined;
+      (client as any).authenticated = false;
       // Detach the listeners the SDK's `peer()` adds per negotiation so reusing
       // this socket doesn't accumulate duplicate handlers. The persistent
       // presence + signaling-stability listeners (bound once below) are left
@@ -1360,6 +1413,9 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
             const extra = details ? ` details=${JSON.stringify(details)}` : '';
             log('error', `Signaling socket disconnect reason: ${String(reason)}${extra}`);
           });
+          // Pairs with the disconnect line above: without it a log full of
+          // disconnects cannot be told apart from a permanent outage.
+          sock.on('connect', () => log('info', `Signaling socket connected (id=${sock.id})`));
           const engine = sock.io?.engine;
           if (engine && typeof engine.on === 'function') {
             engine.on('close', (reason: unknown) =>
@@ -1400,41 +1456,74 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
         closed = false;
         connected = false;
 
-        // `peer(...)` resolves with the primary channel; the rest arrive via
-        // `'data-channel'`. Track the collector so `teardownPeer` can detach
-        // exactly this listener before the next attempt re-registers its own.
-        onDataChannel = (channel: any): void => {
-          if (channel.label === AC2_CONTROL_LABEL) controlChannel = channel;
-          else if (channel.label === AC2_STREAM_LABEL) streamChannel = channel;
-          else if (channel.label === AC2_HEARTBEAT_LABEL) heartbeatChannel = channel;
-        };
-        client.on('data-channel', onDataChannel);
-
         type DataChannelInit = { ordered?: boolean };
         const dataChannels: Record<string, DataChannelInit> = {
           [AC2_CONTROL_LABEL]: { ordered: true },
           ...(includeStream ? { [AC2_STREAM_LABEL]: { ordered: true } } : {}),
           [AC2_HEARTBEAT_LABEL]: { ordered: true },
         };
-        // Bounded by sustained signaling-socket disconnection, not a flat
-        // deadline: `peer(...)`'s offer/answer/candidate exchange waits on the
-        // human scanning the QR and approving in their wallet, which can take
-        // minutes. Only a real, sustained network/ping-timeout failure (the
-        // socket staying down longer than the reconnect grace period) should
-        // tear this down — not the human simply taking their time. A genuine
-        // failure here means the socket itself is unusable, so fully tear it
-        // down (the caller then builds a fresh pairing handle).
-        const primary: any = await withSignalingHealthGuard(
-          client.peer(requestId, 'offer', AC2_ICE_CONFIG, { dataChannels }),
-          socket,
-          {
-            deadSocketTimeoutMs: AC2_DEFAULT_SIGNAL_DEAD_TIMEOUT_MS,
-            ...(opts.signal ? { signal: opts.signal } : {}),
-            onFailure: () => {
-              fullTeardown();
+
+        // One offer/answer/candidate exchange. Not bounded by a flat deadline:
+        // it waits on the human scanning the QR and approving in their wallet,
+        // which can take minutes. `withSignalingHealthGuard` bounds it by
+        // signaling-socket health instead; a genuinely unusable socket (terminal
+        // disconnect reason, abort) is fully torn down so the caller builds a
+        // fresh pairing handle.
+        const negotiate = (): Promise<any> => {
+          // `peer(...)` resolves with the primary channel; the rest arrive via
+          // `'data-channel'`. Track the collector so `teardownPeer` can detach
+          // exactly this listener before the next attempt re-registers its own.
+          onDataChannel = (channel: any): void => {
+            if (channel.label === AC2_CONTROL_LABEL) controlChannel = channel;
+            else if (channel.label === AC2_STREAM_LABEL) streamChannel = channel;
+            else if (channel.label === AC2_HEARTBEAT_LABEL) heartbeatChannel = channel;
+          };
+          client.on('data-channel', onDataChannel);
+          return withSignalingHealthGuard(
+            client.peer(requestId, 'offer', AC2_ICE_CONFIG, { dataChannels }),
+            socket,
+            {
+              ...(opts.signal ? { signal: opts.signal } : {}),
+              onFailure: () => {
+                fullTeardown();
+              },
             },
-          },
-        );
+          );
+        };
+
+        // A signaling drop destroys the rendezvous even when the socket comes
+        // straight back (the pending `link` ack is discarded and the server-side
+        // subscription dies with the old session — see
+        // `withSignalingHealthGuard`), so re-arm the handshake in place on the
+        // SAME socket and with the SAME `requestId` instead of waiting on a
+        // promise that can never settle. This is what stops the daemon going
+        // permanently deaf after a ping-timeout blip while it awaits the wallet.
+        // A sustained outage still escalates: `awaitSignalingUp` gives up after
+        // `AC2_DEFAULT_SIGNAL_DEAD_TIMEOUT_MS`, fully tears down, and rejects so
+        // the caller re-pairs on a fresh socket — exactly today's behavior.
+        let primary: any;
+        for (;;) {
+          try {
+            primary = await negotiate();
+            break;
+          } catch (err) {
+            if (
+              !(err instanceof SignalingConnectError) ||
+              err.code !== 'signaling-dropped' ||
+              !err.reconnectable
+            ) {
+              throw err;
+            }
+            log('warn', `${err.message} — re-arming on the same socket.`);
+            teardownPeer();
+            await awaitSignalingUp(socket, AC2_DEFAULT_SIGNAL_DEAD_TIMEOUT_MS, {
+              ...(opts.signal ? { signal: opts.signal } : {}),
+              onFailure: () => {
+                fullTeardown();
+              },
+            });
+          }
+        }
         controlChannel = controlChannel ?? primary;
 
         if (controlChannel.label !== AC2_CONTROL_LABEL) {

--- a/packages/ac2-sdk/src/providers/liquid-auth.ts
+++ b/packages/ac2-sdk/src/providers/liquid-auth.ts
@@ -245,13 +245,22 @@ export function closeAwareTransport(base: Ac2Transport): {
   return { transport, emitClose };
 }
 
+/**
+ * Enforce the heartbeat-timeout floor shared by BOTH configuration paths (the
+ * `AC2_HEARTBEAT_TIMEOUT_MS` env var and the `heartbeatTimeoutMs` option).
+ * Anything below 2× the ping cadence would let the derived hard window
+ * (`AC2_HEARTBEAT_HARD_TIMEOUT_FACTOR`) dip under the 20s ping interval and
+ * tear down a healthy link on nearly every tick, so sub-minimum or non-finite
+ * values fall back to the default instead of being honored.
+ */
+export function sanitizeHeartbeatTimeoutMs(value: number): number {
+  const minimum = AC2_HEARTBEAT_MS * 2;
+  return Number.isFinite(value) && value >= minimum ? value : AC2_DEFAULT_HEARTBEAT_TIMEOUT_MS;
+}
+
 export function resolveHeartbeatTimeoutMs(value?: string): number {
   if (value === undefined || value.trim().length === 0) return AC2_DEFAULT_HEARTBEAT_TIMEOUT_MS;
-  const parsed = Number(value);
-  const minimum = AC2_HEARTBEAT_MS * 2;
-  return Number.isFinite(parsed) && parsed >= minimum
-    ? parsed
-    : AC2_DEFAULT_HEARTBEAT_TIMEOUT_MS;
+  return sanitizeHeartbeatTimeoutMs(Number(value));
 }
 
 /** Raised when the signaling socket never reaches `connect` in time. */
@@ -866,7 +875,12 @@ export interface LiquidAuthChannelProviderOptions {
   requestId?: string;
   /** Request the optional `ac2-stream` channel (default `true`). */
   includeStreamChannel?: boolean;
-  /** Milliseconds without inbound heartbeat traffic before closing. */
+  /**
+   * Milliseconds without inbound heartbeat traffic before closing. Values
+   * below 2× the heartbeat ping cadence (40s) are rejected and fall back to
+   * the default, exactly like the `AC2_HEARTBEAT_TIMEOUT_MS` env var (see
+   * {@link sanitizeHeartbeatTimeoutMs}).
+   */
   heartbeatTimeoutMs?: number;
   /**
    * Optional presence listener. When provided, server-broadcast `presence`
@@ -950,8 +964,19 @@ export class LiquidAuthChannelProvider implements Ac2ChannelProvider {
       sink(level, `[ac2] [requestId=${requestId}] ${message}`);
     };
     const heartbeatTimeoutMs =
-      this.defaults.heartbeatTimeoutMs ??
-      resolveHeartbeatTimeoutMs(process.env['AC2_HEARTBEAT_TIMEOUT_MS']);
+      this.defaults.heartbeatTimeoutMs !== undefined
+        ? sanitizeHeartbeatTimeoutMs(this.defaults.heartbeatTimeoutMs)
+        : resolveHeartbeatTimeoutMs(process.env['AC2_HEARTBEAT_TIMEOUT_MS']);
+    if (
+      this.defaults.heartbeatTimeoutMs !== undefined &&
+      heartbeatTimeoutMs !== this.defaults.heartbeatTimeoutMs
+    ) {
+      log(
+        'warn',
+        `ignoring heartbeatTimeoutMs option ${this.defaults.heartbeatTimeoutMs} — below the ` +
+          `${AC2_HEARTBEAT_MS * 2}ms minimum (2x the ping cadence); using ${heartbeatTimeoutMs}ms`,
+      );
+    }
     // Second-tier stale window: past this the heartbeat overrides presence
     // (see `AC2_HEARTBEAT_HARD_TIMEOUT_FACTOR`).
     const heartbeatHardTimeoutMs = heartbeatTimeoutMs * AC2_HEARTBEAT_HARD_TIMEOUT_FACTOR;

--- a/packages/ac2-sdk/tests/liquid-auth-provider.test.ts
+++ b/packages/ac2-sdk/tests/liquid-auth-provider.test.ts
@@ -8,6 +8,7 @@ import {
   cookiePairsFromSetCookie,
   resolveHeartbeatTimeoutMs,
   shouldCloseOnHeartbeatTimeout,
+  shouldTeardownOnRemoteOffer,
   withSignalingHealthGuard,
 } from '../src/providers/liquid-auth.js';
 
@@ -406,6 +407,63 @@ describe('shouldCloseOnHeartbeatTimeout', () => {
     ).toBe(false);
     expect(
       shouldCloseOnHeartbeatTimeout({ staleForTooLong: false, signalingConnected: true }),
+    ).toBe(false);
+  });
+
+  it('escalates past the hard window even while signaling (and presence) says the peer is there', () => {
+    // Presence can be stuck: a wallet whose data path died while its native
+    // service kept the socket in the room is counted forever. Deferring to it
+    // indefinitely left the stale peer in place and the wallet reconnecting
+    // into the void, so the second tier overrides it.
+    expect(
+      shouldCloseOnHeartbeatTimeout({
+        staleForTooLong: true,
+        signalingConnected: true,
+        staleForFarTooLong: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps deferring to presence inside the hard window', () => {
+    expect(
+      shouldCloseOnHeartbeatTimeout({
+        staleForTooLong: true,
+        signalingConnected: true,
+        staleForFarTooLong: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('shouldTeardownOnRemoteOffer', () => {
+  it('tears the stale peer down when an offer arrives on a supposedly live link', () => {
+    // The wallet only offers when it wants a NEW peer session, so this is proof
+    // our peer is stale even though presence still reports two devices.
+    expect(
+      shouldTeardownOnRemoteOffer({ connected: true, negotiating: false, closed: false }),
+    ).toBe(true);
+  });
+
+  it('ignores an offer while a negotiation is already armed', () => {
+    // The pending `client.peer(...)` is what must consume that offer; tearing
+    // down mid-handshake nulls its `peerClient`.
+    expect(
+      shouldTeardownOnRemoteOffer({ connected: true, negotiating: true, closed: false }),
+    ).toBe(false);
+    expect(
+      shouldTeardownOnRemoteOffer({ connected: false, negotiating: true, closed: false }),
+    ).toBe(false);
+  });
+
+  it('ignores an offer when there is no live peer to replace', () => {
+    expect(
+      shouldTeardownOnRemoteOffer({ connected: false, negotiating: false, closed: false }),
+    ).toBe(false);
+  });
+
+  it('never re-triggers once already closed', () => {
+    expect(
+      shouldTeardownOnRemoteOffer({ connected: true, negotiating: false, closed: true }),
     ).toBe(false);
   });
 });

--- a/packages/ac2-sdk/tests/liquid-auth-provider.test.ts
+++ b/packages/ac2-sdk/tests/liquid-auth-provider.test.ts
@@ -3,6 +3,7 @@ import type { Ac2Transport } from '@algorandfoundation/ac2-sdk/transport';
 
 import {
   awaitSignalConnect,
+  awaitSignalingUp,
   closeAwareTransport,
   closeRtcDataChannel,
   cookiePairsFromSetCookie,
@@ -166,7 +167,6 @@ describe('withSignalingHealthGuard', () => {
     const sock = makeFakeSocket();
     let failures = 0;
     const pending = withSignalingHealthGuard(Promise.resolve('peer-channel'), sock, {
-      deadSocketTimeoutMs: 1_000,
       onFailure: () => {
         failures += 1;
       },
@@ -180,7 +180,6 @@ describe('withSignalingHealthGuard', () => {
     let failures = 0;
     const boom = new Error('peer negotiation failed');
     const pending = withSignalingHealthGuard(Promise.reject(boom), sock, {
-      deadSocketTimeoutMs: 1_000,
       onFailure: () => {
         failures += 1;
       },
@@ -199,13 +198,12 @@ describe('withSignalingHealthGuard', () => {
         resolveLate = resolve;
       });
       const pending = withSignalingHealthGuard(humanIsSlow, sock, {
-        deadSocketTimeoutMs: 1_000,
         onFailure: () => {
           failures += 1;
         },
       });
-      // Far longer than deadSocketTimeoutMs — simulates a human taking minutes
-      // to scan the QR and approve, with the socket healthy throughout.
+      // A human can take minutes to scan the QR and approve — with the socket
+      // healthy throughout, no amount of elapsed time may fail the handshake.
       await vi.advanceTimersByTimeAsync(10 * 60_000);
       resolveLate('approved');
       await expect(pending).resolves.toBe('approved');
@@ -215,97 +213,61 @@ describe('withSignalingHealthGuard', () => {
     }
   });
 
-  it('tolerates a disconnect that recovers before the dead-socket grace period', async () => {
-    vi.useFakeTimers();
-    try {
-      const sock = makeFakeSocket();
-      let failures = 0;
-      let resolveLate: (value: string) => void = () => { };
-      const pending = withSignalingHealthGuard(
-        new Promise<string>((resolve) => {
-          resolveLate = resolve;
-        }),
-        sock,
-        {
-          deadSocketTimeoutMs: 1_000,
-          onFailure: () => {
-            failures += 1;
-          },
-        },
-      );
-      sock.emit('disconnect');
-      await vi.advanceTimersByTimeAsync(500);
-      sock.emit('connect'); // recovers before the 1_000ms grace period elapses
-      await vi.advanceTimersByTimeAsync(5_000);
-      resolveLate('approved');
-      await expect(pending).resolves.toBe('approved');
-      expect(failures).toBe(0);
-    } finally {
-      vi.useRealTimers();
-    }
+  it('fails the handshake as soon as the socket disconnects, even if it reconnects', async () => {
+    // socket.io drops pending acks on `onclose` (`_clearAcks`; a plain ack has
+    // no `withError`, so it is not even notified) and the server tears down the
+    // `link` subscription with the old session — a reconnect cannot resume the
+    // rendezvous, it must be re-armed by the caller.
+    const sock = makeFakeSocket();
+    let failures = 0;
+    const pending = withSignalingHealthGuard(new Promise<never>(() => { }), sock, {
+      onFailure: () => {
+        failures += 1;
+      },
+    });
+    const assertion = expect(pending).rejects.toMatchObject({
+      code: 'signaling-dropped',
+      reconnectable: true,
+    });
+    sock.emit('disconnect', 'transport close');
+    sock.emit('connect');
+    await assertion;
+    // The socket itself is reusable, so the guard must not tear it down.
+    expect(failures).toBe(0);
   });
 
-  it('rejects and tears down once the socket stays disconnected past the grace period', async () => {
-    vi.useFakeTimers();
-    try {
-      const sock = makeFakeSocket();
-      let failures = 0;
-      const pending = withSignalingHealthGuard(new Promise<never>(() => { }), sock, {
-        deadSocketTimeoutMs: 1_000,
-        onFailure: () => {
-          failures += 1;
-        },
-      });
-      const assertion = expect(pending).rejects.toMatchObject({ code: 'timeout' });
-      sock.emit('disconnect');
-      await vi.advanceTimersByTimeAsync(1_000);
-      await assertion;
-      expect(failures).toBe(1);
-    } finally {
-      vi.useRealTimers();
-    }
+  it('fails immediately (reconnectably) when the socket is already disconnected', async () => {
+    const sock = makeFakeSocket(false);
+    let failures = 0;
+    const pending = withSignalingHealthGuard(new Promise<never>(() => { }), sock, {
+      onFailure: () => {
+        failures += 1;
+      },
+    });
+    await expect(pending).rejects.toMatchObject({
+      code: 'signaling-dropped',
+      reconnectable: true,
+    });
+    expect(failures).toBe(0);
   });
 
-  it('starts counting immediately if the socket is already disconnected', async () => {
-    vi.useFakeTimers();
-    try {
-      const sock = makeFakeSocket(false);
-      let failures = 0;
-      const pending = withSignalingHealthGuard(new Promise<never>(() => { }), sock, {
-        deadSocketTimeoutMs: 1_000,
-        onFailure: () => {
-          failures += 1;
-        },
-      });
-      const assertion = expect(pending).rejects.toMatchObject({ code: 'timeout' });
-      await vi.advanceTimersByTimeAsync(1_000);
-      await assertion;
-      expect(failures).toBe(1);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('rejects immediately on a server-initiated disconnect (no auto-reconnect)', async () => {
-    vi.useFakeTimers();
-    try {
-      const sock = makeFakeSocket();
-      let failures = 0;
-      const pending = withSignalingHealthGuard(new Promise<never>(() => { }), sock, {
-        deadSocketTimeoutMs: 45_000,
-        onFailure: () => {
-          failures += 1;
-        },
-      });
-      const assertion = expect(pending).rejects.toMatchObject({ code: 'timeout' });
-      // 'io server disconnect' will never auto-reconnect — must fail now,
-      // without waiting out the dead-socket grace period.
-      sock.emit('disconnect', 'io server disconnect');
-      await assertion;
-      expect(failures).toBe(1);
-    } finally {
-      vi.useRealTimers();
-    }
+  it('reports a server-initiated disconnect as not reconnectable and tears down', async () => {
+    const sock = makeFakeSocket();
+    let failures = 0;
+    const pending = withSignalingHealthGuard(new Promise<never>(() => { }), sock, {
+      onFailure: () => {
+        failures += 1;
+      },
+    });
+    const assertion = expect(pending).rejects.toMatchObject({
+      code: 'signaling-dropped',
+      reconnectable: false,
+    });
+    // 'io server disconnect' will never auto-reconnect — the socket is dead,
+    // so the guard tears down and hands off to the caller's re-pair loop.
+    sock.emit('disconnect', 'io server disconnect');
+    await assertion;
+    expect(failures).toBe(1);
   });
 
   it('rejects immediately when the abort signal is already aborted', async () => {
@@ -314,7 +276,6 @@ describe('withSignalingHealthGuard', () => {
     controller.abort();
     let failures = 0;
     const pending = withSignalingHealthGuard(new Promise<never>(() => { }), sock, {
-      deadSocketTimeoutMs: 5_000,
       signal: controller.signal,
       onFailure: () => {
         failures += 1;
@@ -329,7 +290,6 @@ describe('withSignalingHealthGuard', () => {
     const controller = new AbortController();
     let failures = 0;
     const pending = withSignalingHealthGuard(new Promise<never>(() => { }), sock, {
-      deadSocketTimeoutMs: 5_000,
       signal: controller.signal,
       onFailure: () => {
         failures += 1;
@@ -340,30 +300,93 @@ describe('withSignalingHealthGuard', () => {
     expect(failures).toBe(1);
   });
 
-  it('ignores a late settle once the dead-socket bound has already tripped', async () => {
+  it('ignores a late settle once the guard has already failed', async () => {
+    const sock = makeFakeSocket();
+    let resolveLate: (value: string) => void = () => { };
+    const late = new Promise<string>((resolve) => {
+      resolveLate = resolve;
+    });
+    const pending = withSignalingHealthGuard(late, sock, {});
+    const assertion = expect(pending).rejects.toMatchObject({ code: 'signaling-dropped' });
+    sock.emit('disconnect');
+    await assertion;
+    resolveLate('too-late');
+  });
+});
+
+describe('awaitSignalingUp', () => {
+  function makeFakeSocket(initialConnected = true): {
+    on: (event: string, listener: (...args: any[]) => void) => void;
+    off: (event: string, listener: (...args: any[]) => void) => void;
+    connected: boolean;
+    emit: (event: string, ...args: any[]) => void;
+  } {
+    const listeners: Record<string, Set<(...args: any[]) => void>> = {};
+    return {
+      connected: initialConnected,
+      on(event, listener) {
+        (listeners[event] ??= new Set()).add(listener);
+      },
+      off(event, listener) {
+        listeners[event]?.delete(listener);
+      },
+      emit(event, ...args) {
+        for (const listener of listeners[event] ?? []) listener(...args);
+      },
+    };
+  }
+
+  it('resolves immediately when the socket is already connected', async () => {
+    const sock = makeFakeSocket();
+    await expect(awaitSignalingUp(sock, 1_000)).resolves.toBeUndefined();
+  });
+
+  it('resolves as soon as socket.io reconnects', async () => {
+    const sock = makeFakeSocket(false);
+    let failures = 0;
+    const pending = awaitSignalingUp(sock, 1_000, {
+      onFailure: () => {
+        failures += 1;
+      },
+    });
+    sock.connected = true;
+    sock.emit('connect');
+    await expect(pending).resolves.toBeUndefined();
+    expect(failures).toBe(0);
+  });
+
+  it('rejects and tears down once the socket stays down past the bound', async () => {
     vi.useFakeTimers();
     try {
-      const sock = makeFakeSocket();
+      const sock = makeFakeSocket(false);
       let failures = 0;
-      let resolveLate: (value: string) => void = () => { };
-      const late = new Promise<string>((resolve) => {
-        resolveLate = resolve;
-      });
-      const pending = withSignalingHealthGuard(late, sock, {
-        deadSocketTimeoutMs: 1_000,
+      const pending = awaitSignalingUp(sock, 1_000, {
         onFailure: () => {
           failures += 1;
         },
       });
       const assertion = expect(pending).rejects.toMatchObject({ code: 'timeout' });
-      sock.emit('disconnect');
       await vi.advanceTimersByTimeAsync(1_000);
       await assertion;
-      resolveLate('too-late');
       expect(failures).toBe(1);
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('rejects and tears down when the abort signal fires while waiting', async () => {
+    const sock = makeFakeSocket(false);
+    const controller = new AbortController();
+    let failures = 0;
+    const pending = awaitSignalingUp(sock, 5_000, {
+      signal: controller.signal,
+      onFailure: () => {
+        failures += 1;
+      },
+    });
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ code: 'aborted' });
+    expect(failures).toBe(1);
   });
 });
 

--- a/packages/ac2-sdk/tests/liquid-auth-provider.test.ts
+++ b/packages/ac2-sdk/tests/liquid-auth-provider.test.ts
@@ -7,6 +7,7 @@ import {
   closeRtcDataChannel,
   cookiePairsFromSetCookie,
   resolveHeartbeatTimeoutMs,
+  sanitizeHeartbeatTimeoutMs,
   shouldCloseOnHeartbeatTimeout,
   shouldTeardownOnRemoteOffer,
   withSignalingHealthGuard,
@@ -380,6 +381,28 @@ describe('LiquidAuthChannelProvider heartbeat timeout', () => {
   it('falls back for invalid or too-small overrides', () => {
     expect(resolveHeartbeatTimeoutMs('not-a-number')).toBe(50_000);
     expect(resolveHeartbeatTimeoutMs('39999')).toBe(50_000);
+  });
+
+  it('sanitizes numeric option values with the same floor as the env path', () => {
+    // Valid values pass through untouched.
+    expect(sanitizeHeartbeatTimeoutMs(40_000)).toBe(40_000);
+    expect(sanitizeHeartbeatTimeoutMs(60_000)).toBe(60_000);
+    // Sub-minimum values would derive a hard window (4×) below the 20s ping
+    // cadence — they fall back to the default instead.
+    expect(sanitizeHeartbeatTimeoutMs(3_000)).toBe(50_000);
+    expect(sanitizeHeartbeatTimeoutMs(39_999)).toBe(50_000);
+    expect(sanitizeHeartbeatTimeoutMs(0)).toBe(50_000);
+    expect(sanitizeHeartbeatTimeoutMs(-1)).toBe(50_000);
+    expect(sanitizeHeartbeatTimeoutMs(Number.NaN)).toBe(50_000);
+    expect(sanitizeHeartbeatTimeoutMs(Number.POSITIVE_INFINITY)).toBe(50_000);
+  });
+
+  it('keeps the derived hard window above the ping cadence for any option value', () => {
+    const hardFactor = 4;
+    for (const requested of [1, 3_000, 19_999, 40_000, 120_000]) {
+      const sanitized = sanitizeHeartbeatTimeoutMs(requested);
+      expect(sanitized * hardFactor).toBeGreaterThanOrEqual(160_000);
+    }
   });
 });
 

--- a/packages/ac2-sdk/tests/liquid-auth-reconnect.test.ts
+++ b/packages/ac2-sdk/tests/liquid-auth-reconnect.test.ts
@@ -23,10 +23,14 @@ const H = vi.hoisted(() => {
     lastClient: null as any,
     lastIoOpts: null as any,
     peerCalls: 0,
+    /** The `requestId` each `peer()` attempt was invoked with, in call order. */
+    peerRequestIds: [] as string[],
     peerCloseSpies: [] as Array<ReturnType<typeof vi.fn>>,
     // When set, the fake `peer()` parks on this promise after creating its
     // `peerClient` — mimicking the real SDK awaiting the wallet's link/offer —
-    // so tests can interleave events with an in-flight negotiation.
+    // so tests can interleave events with an in-flight negotiation. Consumed
+    // once: the attempt that finds the gate takes it, so a re-armed attempt
+    // runs through.
     peerGate: null as Promise<void> | null,
   };
   return { clientCloseSpy, socketCloseSpy, socketDisconnectSpy, socketConnectSpy, state };
@@ -113,25 +117,36 @@ vi.mock('@algorandfoundation/liquid-client/signal', () => {
     }
 
     async peer(
-      _requestId: string,
+      requestId: string,
       _type: string,
       _config: unknown,
       opts: { dataChannels: Record<string, unknown> },
     ): Promise<any> {
       H.state.peerCalls += 1;
+      H.state.peerRequestIds.push(requestId);
+      // Mirror the real `link()` latch: it refuses to run while a requestId is
+      // still in progress, and only clears it when the wallet's link ack
+      // arrives — which never happens for a negotiation stranded by a
+      // signaling drop (socket.io discards the pending ack).
+      if (this.requestId !== undefined) throw new Error('Request is in process');
+      this.requestId = requestId;
       const peerCloseSpy = vi.fn();
       this.peerClient = { close: peerCloseSpy };
       H.state.peerCloseSpies.push(peerCloseSpy);
-      if (H.state.peerGate) {
+      const gate = H.state.peerGate;
+      if (gate) {
+        H.state.peerGate = null;
         // Park like the real `peer()` does while awaiting the wallet's
         // link/offer, then dereference `peerClient` exactly like the real SDK
         // (`this.peerClient.onicecandidate = …`) — a teardown that nulled it
         // mid-flight reproduces the production TypeError.
-        await H.state.peerGate;
+        await gate;
         if (!this.peerClient) {
           throw new TypeError("Cannot set properties of undefined (setting 'onicecandidate')");
         }
       }
+      delete this.requestId;
+      this.authenticated = true;
       const channels: Record<string, any> = {};
       for (const label of Object.keys(opts?.dataChannels ?? {})) {
         const ch = {
@@ -192,6 +207,7 @@ describe('LiquidAuthChannelProvider — socket-preserving reconnect', () => {
     H.state.lastClient = null;
     H.state.lastIoOpts = null;
     H.state.peerCalls = 0;
+    H.state.peerRequestIds = [];
     H.state.peerCloseSpies = [];
     H.state.peerGate = null;
   });
@@ -397,6 +413,45 @@ describe('LiquidAuthChannelProvider — socket-preserving reconnect', () => {
     await paired2.close();
   });
 
+  it('re-arms the handshake on the same socket (same requestId) when signaling drops mid-negotiation', async () => {
+    // The production hang: parked in `peer()` awaiting the wallet's re-link, a
+    // ping-timeout blip discards the pending `link` ack (socket.io `_clearAcks`)
+    // and kills the server-side subscription — socket.io reconnects fine, but
+    // the rendezvous is gone and the daemon waited on it forever, deaf to every
+    // one of the wallet's retries until process restart.
+    const { handle, paired } = await startAndConnect();
+    H.state.lastClient.emit('link-message', { wallet: 'W' });
+    await paired.close();
+
+    let releaseStranded!: () => void;
+    H.state.peerGate = new Promise<void>((resolve) => {
+      releaseStranded = resolve;
+    });
+    const reconnect = handle.connect();
+    await vi.waitFor(() => {
+      expect(H.state.peerCalls).toBe(2);
+    });
+
+    const socketBefore = H.state.lastSocket;
+    socketBefore.connected = false;
+    socketBefore.emit('disconnect', 'transport close');
+    socketBefore.connect();
+
+    const paired2 = await reconnect;
+    // Re-armed: a THIRD `peer()` attempt answered the wallet…
+    expect(H.state.peerCalls).toBe(3);
+    // …on the SAME socket — no full teardown, no fresh pairing handle…
+    expect(H.state.lastSocket).toBe(socketBefore);
+    expect(H.clientCloseSpy).not.toHaveBeenCalled();
+    expect(handle.isSignalingAlive?.()).toBe(true);
+    // …and with the SAME pairing requestId: the identity only rotates when the
+    // user forgets the pairing, never behind their back on a reconnect.
+    expect(H.state.peerRequestIds[2]).toBe(H.state.peerRequestIds[1]);
+
+    await paired2.close();
+    releaseStranded();
+  });
+
   it('does NOT tear down a live connection when a presence drop coincides with a signaling blip', async () => {
     const { handle, paired } = await startAndConnect();
     H.state.lastClient.emit('link-message', { wallet: 'W' });
@@ -423,6 +478,43 @@ describe('LiquidAuthChannelProvider — socket-preserving reconnect', () => {
   });
 });
 
+describe('LiquidAuthChannelProvider — signaling diagnostics', () => {
+  beforeEach(() => {
+    (globalThis as any).RTCPeerConnection ??= class {};
+    H.state.lastSocket = null;
+    H.state.lastClient = null;
+    H.state.peerCalls = 0;
+    H.state.peerRequestIds = [];
+    H.state.peerCloseSpies = [];
+    H.state.peerGate = null;
+  });
+
+  it('logs every signaling reconnect', async () => {
+    // Production logs showed long runs of disconnect lines with no matching
+    // connect line, making a recovered blip indistinguishable from a permanent
+    // outage. The provider now logs the reconnect alongside the disconnect.
+    const lines: string[] = [];
+    const provider = new LiquidAuthChannelProvider({
+      origin: 'https://example.test',
+      logger: (_level, line) => lines.push(line),
+    });
+    const handlePromise = provider.startPairing({ timeoutMs: 5_000 });
+    await vi.waitFor(() => {
+      expect(H.state.lastSocket).toBeTruthy();
+    });
+    H.state.lastSocket.emit('connect');
+    await handlePromise;
+
+    H.state.lastSocket.connected = false;
+    H.state.lastSocket.emit('disconnect', 'ping timeout');
+    H.state.lastSocket.connect();
+
+    await vi.waitFor(() => {
+      expect(lines.some((l) => /signaling socket connected/i.test(l))).toBe(true);
+    });
+  });
+});
+
 describe('LiquidAuthChannelProvider — wake-aware reconnect kick', () => {
   beforeEach(() => {
     (globalThis as any).RTCPeerConnection ??= class {};
@@ -430,6 +522,7 @@ describe('LiquidAuthChannelProvider — wake-aware reconnect kick', () => {
     H.state.lastSocket = null;
     H.state.lastClient = null;
     H.state.peerCalls = 0;
+    H.state.peerRequestIds = [];
     H.state.peerCloseSpies = [];
     H.state.peerGate = null;
     vi.useFakeTimers();

--- a/packages/ac2-sdk/tests/liquid-auth-reconnect.test.ts
+++ b/packages/ac2-sdk/tests/liquid-auth-reconnect.test.ts
@@ -292,6 +292,66 @@ describe('LiquidAuthChannelProvider — socket-preserving reconnect', () => {
     expect(handle.isSignalingAlive?.()).toBe(true);
   });
 
+  it('tears the stale peer down when the wallet re-offers while presence still reports it live', async () => {
+    // The failure this fixes: after a long background the wallet's native
+    // service keeps its signaling socket in the room (so presence never drops
+    // to one device) while its WebRTC path is dead. Nothing tore our peer
+    // down, and the SDK only arms an answer listener INSIDE `peer()`, so the
+    // wallet's renegotiation offers landed on a socket with nothing listening
+    // — "Reconnecting…" forever, and not a line in the agent log. An inbound
+    // offer while we still believe we are connected is proof the peer
+    // restarted, so tear it down and let the caller re-arm in place.
+    const { handle, paired } = await startAndConnect();
+    H.state.lastClient.emit('link-message', { wallet: 'W' });
+    let closed = 0;
+    paired.transport.onClose(() => {
+      closed += 1;
+    });
+
+    H.state.lastSocket.emit('offer-description', 'v=0 (the wallet restarted)');
+
+    await vi.waitFor(() => {
+      expect(H.state.peerCloseSpies[0]).toHaveBeenCalledTimes(1);
+    });
+    expect(closed).toBe(1);
+    // The socket is untouched: the very next offer is answered on it in place.
+    expect(H.clientCloseSpy).not.toHaveBeenCalled();
+    expect(H.socketDisconnectSpy).not.toHaveBeenCalled();
+    expect(handle.isSignalingAlive?.()).toBe(true);
+
+    const paired2 = await handle.connect();
+    expect(H.state.peerCalls).toBe(2);
+    await paired2.close();
+  });
+
+  it('does NOT act on the offer that an armed negotiation is itself waiting for', async () => {
+    // While `peer()` is parked awaiting the wallet, its own one-shot listener
+    // must consume the offer; tearing down here would null `peerClient` under
+    // the pending handshake (the crash the presence rule already guards).
+    const { handle, paired } = await startAndConnect();
+    H.state.lastClient.emit('link-message', { wallet: 'W' });
+    await paired.close();
+
+    let releaseWallet!: () => void;
+    H.state.peerGate = new Promise<void>((resolve) => {
+      releaseWallet = resolve;
+    });
+    const reconnect = handle.connect();
+    await vi.waitFor(() => {
+      expect(H.state.peerCalls).toBe(2);
+    });
+
+    H.state.lastSocket.emit('offer-description', 'v=0 (the awaited offer)');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(H.state.peerCloseSpies[1]).not.toHaveBeenCalled();
+    expect(H.state.lastClient.peerClient).toBeTruthy();
+
+    releaseWallet();
+    const paired2 = await reconnect;
+    expect(paired2.transport).toBeDefined();
+    await paired2.close();
+  });
+
   it('does NOT tear down an in-flight re-link negotiation on a presence drop', async () => {
     // Regression for the production crash: the wallet linked once, the session
     // dropped, and `connect()` was re-armed — parked inside `peer()` awaiting


### PR DESCRIPTION
# Overview

- increase agent response window for long running process (ie x402 that may take longer than 30 seconds)
- harden stale connection detection and renegotiate early when applicable (decrease the time it takes to recover)