### PR TITLE
feat: single-line install script for OpenClaw + AC2 plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,14 @@ jobs:
         run: pnpm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Rebase main onto release
+      # Carry the release commits (CHANGELOG, version bumps) back to master.
+      # Merge instead of rebase: a rebase rewrites any commits master gained
+      # since the promotion, making the push non-fast-forward.
+      - name: Merge release back into master
         if: github.ref == 'refs/heads/release' && steps.release.outputs.released == 'true'
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git checkout main
-          git rebase release
-          git push origin main
+          git checkout master
+          git merge --no-edit release
+          git push origin master

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# AC2 one-line setup for OpenClaw.
+#
+#   curl -fsSL https://raw.githubusercontent.com/algorandfoundation/ac2/master/install.sh | bash
+#
+# Installs the AC2 plugin (@algorandfoundation/ac2-open-claw-reference)
+# into an existing OpenClaw install — the plugin bundles the AC2 service,
+# so no separate @algorandfoundation/ac2-cli install is needed. Then wires
+# the plugin into openclaw.json, restarts the gateway, and starts wallet
+# pairing when run in a terminal.
+#
+# Requires OpenClaw to already be installed and set up; the script fails
+# early if it is not.
+#
+# Safe to re-run: every step is idempotent or degrades to an update.
+set -euo pipefail
+
+# Unversioned spec follows the stable (@latest) release channel; @next is
+# reserved for canary pre-releases.
+PLUGIN_SPEC='@algorandfoundation/ac2-open-claw-reference'
+PLUGIN_ID='ac2'
+
+log() { printf '\033[1;36m[ac2 setup]\033[0m %s\n' "$*"; }
+fail() {
+  printf '\033[1;31m[ac2 setup]\033[0m %s\n' "$*" >&2
+  exit 1
+}
+
+# --- 1. Prerequisites: Node.js 22+ and npm ---------------------------------
+
+command -v node >/dev/null 2>&1 ||
+  fail 'Node.js 22 or newer is required. Install it from https://nodejs.org and re-run this script.'
+
+node_major="$(node -p 'process.versions.node.split(".")[0]')"
+[ "$node_major" -ge 22 ] 2>/dev/null ||
+  fail "Node.js 22 or newer is required, found $(node --version)."
+
+command -v npm >/dev/null 2>&1 ||
+  fail 'npm was not found on PATH (it normally ships with Node.js).'
+
+# --- 2. OpenClaw ------------------------------------------------------------
+
+command -v openclaw >/dev/null 2>&1 ||
+  fail "OpenClaw is required but was not found on PATH. Install and set it up first (see https://docs.openclaw.ai/), e.g. 'npm install -g openclaw@latest', then re-run this script."
+
+log "Found OpenClaw: $(openclaw --version 2>/dev/null | head -n 1 || echo 'version unknown')"
+
+# --- 3. The AC2 plugin (bundles the AC2 service) ----------------------------
+
+log "Installing the AC2 plugin ($PLUGIN_SPEC)…"
+if ! openclaw plugins install "$PLUGIN_SPEC"; then
+  # Most likely already installed — fall back to an update so a re-run
+  # of this script also moves an existing install to the newest canary.
+  log 'Install did not apply cleanly; trying an update of the existing plugin instead…'
+  openclaw plugins update "$PLUGIN_ID"
+fi
+
+log 'Enabling the plugin…'
+openclaw plugins enable "$PLUGIN_ID"
+
+log 'Writing the channel + tools wiring into openclaw.json…'
+openclaw ac2 setup
+
+log 'Restarting the OpenClaw gateway so it picks up the plugin…'
+if ! openclaw gateway restart; then
+  log 'Gateway restart failed. If this is a brand-new OpenClaw install, finish its first-run setup (see https://docs.openclaw.ai/), then run: openclaw gateway restart && openclaw ac2 pair'
+  exit 1
+fi
+
+# --- 4. Pair a wallet -------------------------------------------------------
+
+if [ -t 1 ]; then
+  log 'Everything is installed. Starting wallet pairing — scan the QR code with your AC2 wallet (Ctrl+C to skip).'
+  openclaw ac2 pair
+else
+  log "Everything is installed. Run 'openclaw ac2 pair' in a terminal to connect your wallet."
+fi

--- a/packages/CONTRIBUTING.md
+++ b/packages/CONTRIBUTING.md
@@ -102,13 +102,13 @@ pnpm docs             # typedoc
 1. Fork and create a feature branch.
 2. Add or update tests for any behavior change.
 3. Run `pnpm -r build && pnpm -r test` locally.
-4. Open a PR against `main`. Describe the change, link any related issues, and call out spec impact if any.
+4. Open a PR against `master`. Describe the change, link any related issues, and call out spec impact if any.
 
 ## Releasing
 
-Releases are automated by `.github/workflows/release.yml` on pushes to `main` / `release`. Maintainers should:
+Releases are automated by `.github/workflows/release.yml` on pushes to `master` / `release`. Maintainers should:
 
-- Land changes on `main` via PR.
+- Land changes on `master` via PR.
 - Promote `release` when ready to cut a version.
 - The workflow runs `pnpm install`, `pnpm run --if-present build`, and `pnpm run release`, then publishes with npm provenance (`publishConfig.provenance: true`).
 

--- a/packages/ac2-cli/README.md
+++ b/packages/ac2-cli/README.md
@@ -13,10 +13,13 @@ reconnects it, and stores keys in your operating system's keychain.
 npm install -g @algorandfoundation/ac2-cli
 ```
 
-Using it with OpenClaw? Install both:
+Using it with OpenClaw? Don't install this package at all — install the
+[OpenClaw plugin](../ac2-open-claw-reference) instead, which bundles this
+service as a dependency. With OpenClaw already installed, one line sets up
+the rest (the plugin, the bundled service, and wallet pairing):
 
 ```sh
-npm install -g openclaw @algorandfoundation/ac2-cli
+curl -fsSL https://raw.githubusercontent.com/algorandfoundation/ac2/master/install.sh | bash
 ```
 
 While AC2 is in pre-release, add the canary tag: `npm install -g

--- a/packages/ac2-cli/README.md
+++ b/packages/ac2-cli/README.md
@@ -25,13 +25,13 @@ curl -fsSL https://raw.githubusercontent.com/algorandfoundation/ac2/master/insta
 The script requires OpenClaw to already be installed and fails early if it
 is not — install it first with `npm install -g openclaw@latest`.
 
-While AC2 is in pre-release, add the canary tag: `npm install -g
-@algorandfoundation/ac2-cli@next`.
+To follow canary pre-releases instead of stable releases, add the `@next`
+tag: `npm install -g @algorandfoundation/ac2-cli@next`.
 
 To try it without installing anything:
 
 ```sh
-npx @algorandfoundation/ac2-cli@next --help
+npx @algorandfoundation/ac2-cli --help
 ```
 
 Requirements: Node.js 22 or newer, and an OS keychain (macOS Keychain, Linux
@@ -160,7 +160,7 @@ it.
 earlier: the command detected "was I run directly?" by comparing paths in a way
 that never matched the `node_modules/.bin/ac2` symlink npm, pnpm and `npx`
 install (and never matched on Windows at all), so it exited silently with status
-0. Upgrade — `npm install -g @algorandfoundation/ac2-cli@next`.
+0. Upgrade — `npm install -g @algorandfoundation/ac2-cli`.
 
 **A supervised service ignores `AC2_STATE_DIR`.** Fixed: the units written by
 `ac2 service install` used to forward `AC2_HOME` only, so the state directory

--- a/packages/ac2-cli/README.md
+++ b/packages/ac2-cli/README.md
@@ -15,12 +15,15 @@ npm install -g @algorandfoundation/ac2-cli
 
 Using it with OpenClaw? Don't install this package at all — install the
 [OpenClaw plugin](../ac2-open-claw-reference) instead, which bundles this
-service as a dependency. With OpenClaw already installed, one line sets up
-the rest (the plugin, the bundled service, and wallet pairing):
+service as a dependency. One line sets up the plugin, the bundled service,
+and wallet pairing:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/algorandfoundation/ac2/master/install.sh | bash
 ```
+
+The script requires OpenClaw to already be installed and fails early if it
+is not — install it first with `npm install -g openclaw@latest`.
 
 While AC2 is in pre-release, add the canary tag: `npm install -g
 @algorandfoundation/ac2-cli@next`.

--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -18,6 +18,16 @@ The wallet connection itself is owned by the separate
 
 ## Install
 
+With OpenClaw already installed, the quickest path is the setup script, which
+installs this plugin, wires it up, restarts the gateway, and starts wallet
+pairing:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/algorandfoundation/ac2/master/install.sh | bash
+```
+
+Or do the same by hand:
+
 ```sh
 openclaw plugins install @algorandfoundation/ac2-open-claw-reference@next
 openclaw plugins enable ac2

--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -29,16 +29,15 @@ curl -fsSL https://raw.githubusercontent.com/algorandfoundation/ac2/master/insta
 Or do the same by hand:
 
 ```sh
-openclaw plugins install @algorandfoundation/ac2-open-claw-reference@next
+openclaw plugins install @algorandfoundation/ac2-open-claw-reference
 openclaw plugins enable ac2
 openclaw ac2 setup          # writes the channel + tools into openclaw.json
 openclaw gateway restart
 ```
 
-Keep the `@next` tag and do not add `--pin`: OpenClaw records that moving spec, so
-both the OpenClaw updater and the plugin-only updater can find newer AC2 canary
-releases. The unversioned package and `@latest` follow stable releases and will
-not pick up canaries.
+Do not add `--pin`: OpenClaw records the moving spec, so both the OpenClaw
+updater and the plugin-only updater can find newer stable releases. To follow
+canary pre-releases instead, install with the `@next` tag.
 
 You need Node.js 22 or newer and an OpenClaw agent already set up. The AC2
 service (`@algorandfoundation/ac2-cli`) ships as a dependency of this plugin and
@@ -202,7 +201,7 @@ gateway runs (e.g. its service unit or shell) and restart the gateway:
 ## Update and remove
 
 ```sh
-openclaw update                     # updates OpenClaw and @next plugins together
+openclaw update                     # updates OpenClaw and its plugins together
 openclaw plugins update ac2         # AC2 only
 openclaw gateway restart
 ```


### PR DESCRIPTION
## Why

The ac2-cli README suggested `npm install -g openclaw @algorandfoundation/ac2-cli` as the OpenClaw setup path, but that line never installed the OpenClaw plugin (`@algorandfoundation/ac2-open-claw-reference`) — and the global `ac2-cli` install it did include is unnecessary for OpenClaw users, since the plugin bundles the service as a dependency.

## What

- **`install.sh`** at the repo root, for `curl -fsSL https://raw.githubusercontent.com/algorandfoundation/ac2/master/install.sh | bash`:
  - Requires Node 22+ and an existing OpenClaw install — fails early with guidance otherwise (it does not install OpenClaw itself).
  - Installs the plugin from the stable channel (unversioned spec → `@latest`); on re-runs, a failed install falls back to `openclaw plugins update ac2`, so the script is idempotent.
  - Then `plugins enable ac2` → `ac2 setup` → `gateway restart`, and finishes with `openclaw ac2 pair` when stdout is a terminal (prints the pair instruction otherwise, which is the `curl | bash` case).
- **CI fix (`release.yml`)**: the post-release sync step checked out `main`, which this repo does not have, so the job would have failed right after the first stable publish from the `release` branch. It now merges `release` back into `master` (merge instead of rebase — a rebase rewrites commits master gained since the promotion, making the plain push non-fast-forward). Same `main`→`master` fixes in `packages/CONTRIBUTING.md`.
- **Docs**: both READMEs now point installs at the stable channel, with `@next` as the opt-in for canary pre-releases; the ac2-cli README tells OpenClaw users to skip the global `ac2-cli` install and use the one-liner.

## Rollout note

`@latest` for the plugin currently resolves to the stale `0.0.1-beta.0`. After this merges, promote the `release` branch (fast-forward it to master and push) to cut the first stable `1.0.0` — that makes the curl one-liner and the updated docs live. The release pipeline already supports this; the CI fix above is what makes the first promotion succeed cleanly.

## Verification

Script verified with stubbed `openclaw`/`node` binaries across: happy path, install-fails→update fallback, missing OpenClaw (fails early), and Node 18 (rejected). Workflow YAML parse-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)