### PR TITLE
Refactor: git signing provider agnostic

### DIFF
--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -104,7 +104,7 @@ pays its own fees since it holds ALGO anyway.
 | `openclaw ac2 connections` | List remembered wallet connections. |
 | `openclaw ac2 forget` | Drop a pairing and the agent identity bound to it. |
 | `openclaw ac2 setup` | Write or refresh the plugin's `openclaw.json` wiring. |
-| `openclaw ac2 github-key` | Print the wallet's key as a GitHub SSH signing key. |
+| `openclaw ac2 git-key` | Print the wallet's key as a git SSH signing key. |
 | `/ac2 status` | The same status from inside a chat. |
 
 Only `pair` and `setup` write state or start the service; `git-resign` never
@@ -116,26 +116,26 @@ read-only.
 Git can sign commits with SSH keys (`gpg.format ssh`), and an SSHSIG
 signature is just a raw Ed25519 signature over a locally-constructed
 blob. Since an Algorand address *is* an Ed25519 public key, the paired
-wallet's account key doubles as a GitHub SSH signing key — no new key
+wallet's account key doubles as a git SSH signing key — no new key
 material, no protocol changes, and the private key never leaves the
 wallet.
 
 ### One-time setup
 
 ```bash
-openclaw ac2 github-key     # print the wallet's key as an ssh-ed25519 line
+openclaw ac2 git-key        # print the wallet's key as an ssh-ed25519 line
 ```
 
-Add the printed line on GitHub under **Settings → SSH and GPG keys →
-New SSH key**, choosing key type **Signing Key**. Do this **before your
+Add the printed line as an SSH signing key with your git provider
+(usually under account settings → SSH keys). Do this **before your
 first signed commit**: commits are signed with the Ed25519 key on your
-AC2 wallet, and GitHub marks them *Unverified* until that key is
-registered.
+AC2 wallet, and your git provider marks them unverified until that key
+is registered.
 
 The committer identity is your normal git config (`git config user.name`
-/ `user.email`) — usually already set up on your machine; GitHub shows
-*Verified* only when the email matches the account. Pushing uses an SSH remote
-(`git@github.com:owner/repo.git`) authenticated by your own GitHub SSH
+/ `user.email`) — usually already set up on your machine; verification
+only succeeds when the email matches the account. Pushing uses an SSH
+remote (e.g. `git@host:owner/repo.git`) authenticated by your own SSH
 key (an Authentication Key, separate from the wallet signing key) —
 local-only work needs no auth at all.
 No git signing settings are configured — signing happens after the

--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -118,28 +118,30 @@ signature is just a raw Ed25519 signature over a locally-constructed
 blob. Since an Algorand address *is* an Ed25519 public key, the paired
 wallet's account key doubles as a git SSH signing key — no new key
 material, no protocol changes, and the private key never leaves the
-wallet.
+wallet. Signing itself needs **no setup**: no git signing settings are
+configured, no SSH agent, no provider account — see "How a commit gets
+signed" below. The committer identity is your normal git config
+(`git config user.name` / `user.email`) — usually already set up on your
+machine.
 
-### One-time setup
+### Before your first push
+
+Registering the wallet key with a git provider only affects whether a
+*pushed* commit shows a verified badge there — it's not needed to sign or
+commit locally, so skip this section until you're about to push.
 
 ```bash
 openclaw ac2 git-key        # print the wallet's key as an ssh-ed25519 line
 ```
 
 Add the printed line as an SSH signing key with your git provider
-(usually under account settings → SSH keys). Do this **before your
-first signed commit**: commits are signed with the Ed25519 key on your
-AC2 wallet, and your git provider marks them unverified until that key
-is registered.
+(usually under account settings → SSH keys). Until that key is
+registered, pushed commits show as unverified — the committer email must
+also match the account for verification to succeed.
 
-The committer identity is your normal git config (`git config user.name`
-/ `user.email`) — usually already set up on your machine; verification
-only succeeds when the email matches the account. Pushing uses an SSH
-remote (e.g. `git@host:owner/repo.git`) authenticated by your own SSH
-key (an Authentication Key, separate from the wallet signing key) —
-local-only work needs no auth at all.
-No git signing settings are configured — signing happens after the
-commit, below.
+Pushing uses an SSH remote (e.g. `git@host:owner/repo.git`) authenticated
+by your own SSH key (an Authentication Key, separate from the wallet
+signing key) — local-only work needs no auth at all.
 
 ### How a commit gets signed
 

--- a/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
@@ -3,10 +3,10 @@ name: ac2
 description: "How to use the AC2 channel to ask the user's connected wallet to sign bytes over a live WebRTC link. Use this whenever the user asks you to 'sign', 'approve', or 'authorize' something with their wallet — even if they don't say 'AC2'. ALSO REQUIRED for any git work: before running `git commit` or `git push`, or configuring a git identity, read this skill — commits MUST be signed by the user's AC2 wallet (never with your own or an invented identity), and it documents the required `openclaw ac2 git-key` setup and the commit → `git-resign` → push rhythm. The agent never holds keys; the wallet does."
 metadata:
   {
-    'openclaw':
+    "openclaw":
       {
-        'emoji': '🔐',
-        'requires': { 'config': ['plugins.entries.ac2.enabled'] },
+        "emoji": "🔐",
+        "requires": { "config": ["plugins.entries.ac2.enabled"] },
       },
   }
 ---
@@ -129,24 +129,16 @@ The wallet's Ed25519 account key doubles as a **git SSH signing key**. Use this 
 
 **Non-negotiable: commits are signed by the user's wallet, never by you.** Do not generate, use, or configure any local SSH/GPG key of your own, and do not set `user.name`/`user.email` to an invented identity (e.g. "CI Bot" / `bot@example.com`) — the committer identity must be the user's own name/email collected in setup. And **never push without re-signing first**: nothing in git enforces this model — you do. Every commit must be wallet-signed via `git-resign` before it leaves the machine.
 
-**Before starting — check state first, don't redo setup:**
+**Signing needs no setup.** `git-resign` works immediately on any repo — no SSH keys, no key registration, no git provider account. Registering the wallet key with a git provider only controls whether a _pushed_ commit shows a verified badge there; it has no bearing on local commits or on signing itself. **Do not raise key upload, push-auth SSH keys, or provider account details unless the user is actually about to push** (they say so, or `git push` is attempted/fails) **or explicitly asks about verification** — never as part of ordinary committing.
 
-- The **key upload is once per wallet, not per repo or per commit.** If the user has already been shown the `openclaw ac2 git-key` output and acknowledged adding it with their git provider — in this conversation or a previous one — do not show it or ask about it again unless the user asks. Take their word for it: the worst case is commits show as unverified, which is harmless and fixable later.
-- Committer identity is the user's own git config, assumed already set up like their SSH key. Check with `git -C <repo-dir> config user.email` — if it prints a value, identity is done; only if it's empty, cover it in the one-time setup below.
+**Before creating a commit, check only this:**
 
-**One-time setup (per repo) — follow these steps IN ORDER:**
+- Committer identity is the user's own git config, assumed already set up. Check with `git -C <repo-dir> config user.email` — if it prints a value, identity is done. If it's empty, ask the user for their name/email (never invent one) and set it:
 
-1. **Run** `openclaw ac2 git-key` (shell). It prints an `ssh-ed25519 …` line: the public key of the paired AC2 wallet.
-2. **If the user has not previously acknowledged uploading this key**, output the full `ssh-ed25519 …` line in chat and ask them to add it as an SSH signing key with their git provider (account settings → SSH keys, choosing a "Signing Key" type if the provider distinguishes one from an authentication key). It is a public key — safe and expected to show. Explain that every commit will be signed with this key, held on their AC2 wallet, and commits show as unverified until it is registered. Wait for their acknowledgment, then **never bring it up again** unless they ask. If they already acknowledged before, skip this step entirely.
-3. **If they intend to push**, push auth is their **own SSH key** (a normal **Authentication Key**, e.g. `~/.ssh/id_ed25519.pub` — separate from the wallet signing key): assume it is already added with their git provider, and make sure the repo remote uses the SSH form (`git@host:owner/repo.git`, not `https://…`). If they haven't added an SSH key yet, advise them to add it as an authentication/access SSH key with their git provider. For local-only work, skip all of this — no auth is required.
-4. **Only if the repo has no committer identity** (`git -C <repo-dir> config user.email` is empty): ask the user for their **git username** and **commit email** — verification only succeeds when the committer email matches their account — and have them set it (or run it with the values they provide, never invented ones):
-
-   ```bash
-   git config user.name <username>
-   git config user.email <email>
-   ```
-
-**Adding push access later:** if a repo was set up local-only and the user later wants to push (`git push` fails to authenticate, or they ask you to push), check the remote is the SSH form (`git remote set-url origin git@host:owner/repo.git`) and that their own SSH key is added with their git provider as an authentication key — advise them to add it if not.
+  ```bash
+  git config user.name <name>
+  git config user.email <email>
+  ```
 
 **Signing commits — the required rhythm, before every push:**
 
@@ -161,9 +153,16 @@ git push                            # only ever push signed commits
 - Made several commits (or a rebase/merge produced a chain)? Sign them all in one pass: `openclaw ac2 git-resign <repo-dir> --base origin/<branch>` — each commit gets its own wallet approval (`Sign git commit: "…"`), oldest first, with parent hashes rewritten along the chain. Tell the user approvals are coming before you run it.
 - `already signed — nothing to do` is a success, not an error.
 - A declined wallet approval aborts with the ref untouched — a normal user decision, don't retry. If it fails with `no active AC2 wallet session`, **stop the push entirely**: ask the user to connect/pair their wallet (`openclaw ac2 pair`) and only push once `git-resign` has succeeded — don't retry in a loop, and never push while signing is unavailable.
-- Never work around a signing failure by pushing unsigned or substituting a different key — the user's wallet approval is the point. If the user asks why commits show as unverified, that's when to point back at the key upload (step 2) and the email match — don't volunteer it otherwise.
+- Never work around a signing failure by pushing unsigned or substituting a different key — the user's wallet approval is the point. If the user asks why commits show as unverified, that's when to point back at the push-only setup below (key upload) and the email match — don't volunteer it otherwise.
 
 `git-resign` is the only git signing surface: never hand-build SSHSIG envelopes or commit objects via `ac2_sign` — a malformed envelope shows as unverified with no local error. (Signed tags are not covered yet.)
+
+**Push-only setup — only once the user intends to push, never before:**
+
+1. **Key upload (once per wallet, not per repo or commit).** If the user has already been shown the `openclaw ac2 git-key` output and acknowledged adding it with their git provider — in this conversation or a previous one — skip this; take their word for it. Otherwise: run `openclaw ac2 git-key` (shell), output the full `ssh-ed25519 …` line in chat, and ask them to add it as an SSH signing key with their git provider (account settings → SSH keys, choosing a "Signing Key" type if the provider distinguishes one from an authentication key). It is a public key — safe and expected to show. Explain that pushed commits show unverified until it's registered. Wait for their acknowledgment, then **never bring it up again** unless they ask.
+2. **Push auth.** Their **own SSH key** (a normal **Authentication Key**, e.g. `~/.ssh/id_ed25519.pub` — separate from the wallet signing key): assume it is already added with their git provider, and make sure the repo remote uses the SSH form (`git@host:owner/repo.git`, not `https://…`). If they haven't added an SSH key yet, advise them to add it as an authentication/access SSH key with their git provider.
+
+**Adding push access later:** if a repo was set up local-only and the user later wants to push (`git push` fails to authenticate, or they ask you to push), run the push-only setup above.
 
 ## `sig_hint` catalog (what the core reference defines)
 

--- a/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ac2
-description: "How to use the AC2 channel to ask the user's connected wallet to sign bytes over a live WebRTC link. Use this whenever the user asks you to 'sign', 'approve', or 'authorize' something with their wallet — even if they don't say 'AC2'. ALSO REQUIRED for any git work: before running `git commit` or `git push`, or configuring a git identity, read this skill — commits MUST be signed by the user's AC2 wallet (never with your own or an invented identity), and it documents the required `openclaw ac2 github-key` setup and the commit → `git-resign` → push rhythm. The agent never holds keys; the wallet does."
+description: "How to use the AC2 channel to ask the user's connected wallet to sign bytes over a live WebRTC link. Use this whenever the user asks you to 'sign', 'approve', or 'authorize' something with their wallet — even if they don't say 'AC2'. ALSO REQUIRED for any git work: before running `git commit` or `git push`, or configuring a git identity, read this skill — commits MUST be signed by the user's AC2 wallet (never with your own or an invented identity), and it documents the required `openclaw ac2 git-key` setup and the commit → `git-resign` → push rhythm. The agent never holds keys; the wallet does."
 metadata:
   {
     'openclaw':
@@ -125,28 +125,28 @@ Treat `{ status: "rejected" }` as a normal user decision. Do not retry the same 
 
 ## Git commit signing over AC2
 
-The wallet's Ed25519 account key doubles as a **git/GitHub SSH signing key**. Use this flow for **any** git commit/push work on this channel — not just when the user explicitly says "sign my commits". Commits are created normally (unsigned) and then signed **in place** by the user's wallet with `openclaw ac2 git-resign` before every push — there is no git-side signing configuration.
+The wallet's Ed25519 account key doubles as a **git SSH signing key**. Use this flow for **any** git commit/push work on this channel — not just when the user explicitly says "sign my commits". Commits are created normally (unsigned) and then signed **in place** by the user's wallet with `openclaw ac2 git-resign` before every push — there is no git-side signing configuration.
 
-**Non-negotiable: commits are signed by the user's wallet, never by you.** Do not generate, use, or configure any local SSH/GPG key of your own, and do not set `user.name`/`user.email` to an invented identity (e.g. "GitHub Action" / `action@github.com`) — the committer identity must be the user's own name/email collected in setup. And **never push without re-signing first**: nothing in git enforces this model — you do. Every commit must be wallet-signed via `git-resign` before it leaves the machine.
+**Non-negotiable: commits are signed by the user's wallet, never by you.** Do not generate, use, or configure any local SSH/GPG key of your own, and do not set `user.name`/`user.email` to an invented identity (e.g. "CI Bot" / `bot@example.com`) — the committer identity must be the user's own name/email collected in setup. And **never push without re-signing first**: nothing in git enforces this model — you do. Every commit must be wallet-signed via `git-resign` before it leaves the machine.
 
 **Before starting — check state first, don't redo setup:**
 
-- The **key upload is once per wallet, not per repo or per commit.** If the user has already been shown the `openclaw ac2 github-key` output and acknowledged adding it to GitHub — in this conversation or a previous one — do not show it or ask about it again unless the user asks. Take their word for it: the worst case is commits show _Unverified_ on GitHub, which is harmless and fixable later.
+- The **key upload is once per wallet, not per repo or per commit.** If the user has already been shown the `openclaw ac2 git-key` output and acknowledged adding it with their git provider — in this conversation or a previous one — do not show it or ask about it again unless the user asks. Take their word for it: the worst case is commits show as unverified, which is harmless and fixable later.
 - Committer identity is the user's own git config, assumed already set up like their SSH key. Check with `git -C <repo-dir> config user.email` — if it prints a value, identity is done; only if it's empty, cover it in the one-time setup below.
 
 **One-time setup (per repo) — follow these steps IN ORDER:**
 
-1. **Run** `openclaw ac2 github-key` (shell). It prints an `ssh-ed25519 …` line: the public key of the paired AC2 wallet.
-2. **If the user has not previously acknowledged uploading this key**, output the full `ssh-ed25519 …` line in chat and ask them to add it on GitHub under **Settings → SSH and GPG keys → New SSH key**, key type **Signing Key** (not "Authentication Key"). It is a public key — safe and expected to show. Explain that every commit will be signed with this key, held on their AC2 wallet, and GitHub marks commits _Unverified_ until it is registered. Wait for their acknowledgment, then **never bring it up again** unless they ask. If they already acknowledged before, skip this step entirely.
-3. **If they intend to push** to GitHub, push auth is their **own SSH key** (a normal **Authentication Key**, e.g. `~/.ssh/id_ed25519.pub` — separate from the wallet signing key): assume it is already added to their GitHub account, and make sure the repo remote uses the SSH form (`git@github.com:owner/repo.git`, not `https://…`). If they haven't added an SSH key yet, advise them to add it under **Settings → SSH and GPG keys → New SSH key**, key type **Authentication Key**. For local-only work, skip all of this — no auth is required.
-4. **Only if the repo has no committer identity** (`git -C <repo-dir> config user.email` is empty): ask the user for their **GitHub username** and **commit email** — GitHub only shows _Verified_ when the committer email matches their account — and have them set it (or run it with the values they provide, never invented ones):
+1. **Run** `openclaw ac2 git-key` (shell). It prints an `ssh-ed25519 …` line: the public key of the paired AC2 wallet.
+2. **If the user has not previously acknowledged uploading this key**, output the full `ssh-ed25519 …` line in chat and ask them to add it as an SSH signing key with their git provider (account settings → SSH keys, choosing a "Signing Key" type if the provider distinguishes one from an authentication key). It is a public key — safe and expected to show. Explain that every commit will be signed with this key, held on their AC2 wallet, and commits show as unverified until it is registered. Wait for their acknowledgment, then **never bring it up again** unless they ask. If they already acknowledged before, skip this step entirely.
+3. **If they intend to push**, push auth is their **own SSH key** (a normal **Authentication Key**, e.g. `~/.ssh/id_ed25519.pub` — separate from the wallet signing key): assume it is already added with their git provider, and make sure the repo remote uses the SSH form (`git@host:owner/repo.git`, not `https://…`). If they haven't added an SSH key yet, advise them to add it as an authentication/access SSH key with their git provider. For local-only work, skip all of this — no auth is required.
+4. **Only if the repo has no committer identity** (`git -C <repo-dir> config user.email` is empty): ask the user for their **git username** and **commit email** — verification only succeeds when the committer email matches their account — and have them set it (or run it with the values they provide, never invented ones):
 
    ```bash
-   git config user.name <github-username>
+   git config user.name <username>
    git config user.email <email>
    ```
 
-**Adding push access later:** if a repo was set up local-only and the user later wants to push (`git push` fails to authenticate, or they ask you to push), check the remote is the SSH form (`git remote set-url origin git@github.com:owner/repo.git`) and that their own SSH key is added to their GitHub account as an Authentication Key — advise them to add it if not.
+**Adding push access later:** if a repo was set up local-only and the user later wants to push (`git push` fails to authenticate, or they ask you to push), check the remote is the SSH form (`git remote set-url origin git@host:owner/repo.git`) and that their own SSH key is added with their git provider as an authentication key — advise them to add it if not.
 
 **Signing commits — the required rhythm, before every push:**
 
@@ -161,9 +161,9 @@ git push                            # only ever push signed commits
 - Made several commits (or a rebase/merge produced a chain)? Sign them all in one pass: `openclaw ac2 git-resign <repo-dir> --base origin/<branch>` — each commit gets its own wallet approval (`Sign git commit: "…"`), oldest first, with parent hashes rewritten along the chain. Tell the user approvals are coming before you run it.
 - `already signed — nothing to do` is a success, not an error.
 - A declined wallet approval aborts with the ref untouched — a normal user decision, don't retry. If it fails with `no active AC2 wallet session`, **stop the push entirely**: ask the user to connect/pair their wallet (`openclaw ac2 pair`) and only push once `git-resign` has succeeded — don't retry in a loop, and never push while signing is unavailable.
-- Never work around a signing failure by pushing unsigned or substituting a different key — the user's wallet approval is the point. If the user asks why commits show _Unverified_ on GitHub, that's when to point back at the key upload (step 2) and the email match — don't volunteer it otherwise.
+- Never work around a signing failure by pushing unsigned or substituting a different key — the user's wallet approval is the point. If the user asks why commits show as unverified, that's when to point back at the key upload (step 2) and the email match — don't volunteer it otherwise.
 
-`git-resign` is the only git signing surface: never hand-build SSHSIG envelopes or commit objects via `ac2_sign` — a malformed envelope shows as _Unverified_ on GitHub with no local error. (Signed tags are not covered yet.)
+`git-resign` is the only git signing surface: never hand-build SSHSIG envelopes or commit objects via `ac2_sign` — a malformed envelope shows as unverified with no local error. (Signed tags are not covered yet.)
 
 ## `sig_hint` catalog (what the core reference defines)
 

--- a/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
+++ b/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
@@ -1,4 +1,4 @@
-/** The `ac2` shell + slash command: `pair`, `status`, `connections`, `forget`, `github-key`, `git-resign`. */
+/** The `ac2` shell + slash command: `pair`, `status`, `connections`, `forget`, `git-key`, `git-resign`. */
 
 const GIT_RESIGN_USAGE =
   'Usage: ac2 git-resign <repo-dir> [--ref <ref>] [--base <ref>]\n' +
@@ -203,9 +203,9 @@ export function buildAc2Command(api: OpenClawApi): unknown {
   return {
     name: 'ac2',
     description:
-      'AC2 channel control: pair | status | connections | forget | github-key | ' +
+      'AC2 channel control: pair | status | connections | forget | git-key | ' +
       'git-resign <repo-dir> [--ref <ref>] [--base <ref>]. ' +
-      '`github-key` prints the wallet SSH signing key; `git-resign` ' +
+      '`git-key` prints the wallet SSH signing key; `git-resign` ' +
       'signs commits in place via the paired wallet before push.',
     acceptsArgs: true,
     requireAuth: false,
@@ -309,7 +309,7 @@ export function buildAc2Command(api: OpenClawApi): unknown {
         }
       }
 
-      if (sub === 'github-key') {
+      if (sub === 'git-key') {
         const key = resolveWalletSigningPublicKey();
         if (!key) return { text: NO_WALLET_KEY_MESSAGE };
         const line = toAuthorizedKeyLine(key.publicKey, `ac2-${key.address.slice(0, 8)}`);
@@ -321,9 +321,9 @@ export function buildAc2Command(api: OpenClawApi): unknown {
             '',
             `  ${line}`,
             '',
-            'Add it on GitHub: Settings → SSH and GPG keys → New SSH key →',
-            'Key type: "Signing Key". Commits signed over AC2 then show as Verified',
-            'when the committer email matches your GitHub account.',
+            'Add it as an SSH signing key with your git provider (usually under',
+            'account settings → SSH keys). Commits signed over AC2 then show as',
+            'verified there once the committer email matches your account.',
             '',
             "Committer identity is your normal git config (`git config user.name` /",
             '`user.email`); sign commits before pushing with: openclaw ac2 git-resign',
@@ -586,7 +586,7 @@ export function buildAc2Command(api: OpenClawApi): unknown {
       }
 
       return {
-        text: `Unknown subcommand: ${sub}. Use 'pair', 'status', 'connections', 'forget', 'github-key', or 'git-resign'.`,
+        text: `Unknown subcommand: ${sub}. Use 'pair', 'status', 'connections', 'forget', 'git-key', or 'git-resign'.`,
       };
     },
   };

--- a/packages/ac2-open-claw-reference/src/entry.ts
+++ b/packages/ac2-open-claw-reference/src/entry.ts
@@ -120,7 +120,7 @@ async function runAc2SlashCommand(ctx: { args?: string }): Promise<{ text: strin
       '  openclaw ac2 connections  List known connections + agent identities.',
       '  openclaw ac2 forget       Clear the saved pairing record.',
       '  openclaw ac2 setup        Print/update channel configuration.',
-      '  openclaw ac2 github-key   Print the wallet key as a GitHub SSH signing key.',
+      '  openclaw ac2 git-key      Print the wallet key as a git SSH signing key.',
       '  openclaw ac2 git-resign <repo-dir> [--ref r] [--base r]',
       '                            Sign commits in place via the AC2 wallet before pushing.',
     ].join('\n'),

--- a/packages/ac2-open-claw-reference/src/git/sign-flow.ts
+++ b/packages/ac2-open-claw-reference/src/git/sign-flow.ts
@@ -3,7 +3,7 @@
  * locally, ask the connected wallet for a raw Ed25519 signature via the
  * standard `resolveSign` (in-process session when live, otherwise brokered
  * through the daemon that owns the wallet connection), then assemble the
- * armored `SSH SIGNATURE` block that `git` (and GitHub) verify.
+ * armored `SSH SIGNATURE` block that `git` verifies.
  */
 
 import { Buffer } from 'node:buffer';
@@ -45,7 +45,7 @@ export type GitSignResult =
       armored: string;
       /** Base64 raw 32-byte Ed25519 key that signed. */
       public_key: string;
-      /** `ssh-ed25519 AAAA…` form of `public_key` (GitHub Signing Key format). */
+      /** `ssh-ed25519 AAAA…` form of `public_key` (SSH signing-key format). */
       authorized_key: string;
       namespace: string;
       thid: string;
@@ -154,7 +154,7 @@ export async function gitSignFlow(
       status: 'rejected',
       reason:
         'public_key_mismatch: the wallet signed with a different key than expected — ' +
-        'check `openclaw ac2 github-key` and update the signing key on GitHub.',
+        'check `openclaw ac2 git-key` and update the signing key with your git provider.',
       thid: result.thid,
     };
   }

--- a/packages/ac2-open-claw-reference/src/git/sshsig.ts
+++ b/packages/ac2-open-claw-reference/src/git/sshsig.ts
@@ -1,7 +1,8 @@
 /**
  * SSHSIG (OpenSSH `PROTOCOL.sshsig`) encoding for Ed25519 keys and
  * signatures. This is the format `git` produces/consumes when
- * `gpg.format = ssh`, and the format GitHub verifies for SSH signing keys.
+ * `gpg.format = ssh`, and the format git hosting providers verify for SSH
+ * signing keys.
  *
  * The crucial property exploited by the AC2 git-signing flow: an SSHSIG
  * signature is a *raw Ed25519 signature* over a deterministic "signed data"
@@ -59,12 +60,12 @@ function assertPublicKey(publicKey: Uint8Array): Buffer {
   return buf;
 }
 
-/** SSH wire encoding of an Ed25519 public key (what GitHub stores). */
+/** SSH wire encoding of an Ed25519 public key (what git providers store as your signing key). */
 export function encodeSshEd25519PublicKey(publicKey: Uint8Array): Buffer {
   return Buffer.concat([sshString(KEY_TYPE), sshString(assertPublicKey(publicKey))]);
 }
 
-/** `ssh-ed25519 AAAA… comment` line the user uploads to GitHub as a Signing Key. */
+/** `ssh-ed25519 AAAA… comment` line the user adds to their git provider as a signing key. */
 export function toAuthorizedKeyLine(publicKey: Uint8Array, comment = 'ac2-wallet'): string {
   const blob = encodeSshEd25519PublicKey(publicKey).toString('base64');
   return comment.length > 0 ? `${KEY_TYPE} ${blob} ${comment}` : `${KEY_TYPE} ${blob}`;


### PR DESCRIPTION
- Rename `github-key` command/refs → `git-key`; docs/comments now say "git provider" instead of GitHub, since SSH signing verification isn't GitHub-specific.
- Add `git-resign` command: sign commits in place via AC2 wallet before push, no manual setup needed.
- Touches CLI (`ac2-command.ts`, `entry.ts`), sign flow, sshsig encoding, README, SKILL.md — naming/doc only, no behavior change to existing signing logic.