### PR TITLE
fix: rename `ac2 git-resign` to `ac2 git-sign`

### DIFF
--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -110,10 +110,10 @@ pays its own fees since it holds ALGO anyway.
 | `openclaw ac2 forget` | Drop a pairing and the agent identity bound to it. |
 | `openclaw ac2 setup` | Write or refresh the plugin's `openclaw.json` wiring. |
 | `openclaw ac2 git-key` | Print the wallet's key as a git SSH signing key. |
-| `openclaw ac2 git-resign <repo-dir>` | Sign the latest commit (or a chain with `--base`) in place with the wallet key. |
+| `openclaw ac2 git-sign <repo-dir>` | Sign the latest commit (or a chain with `--base`) in place with the wallet key. |
 | `/ac2 status` | The same status from inside a chat. |
 
-Only `pair` and `setup` write state or start the service; `git-resign` never
+Only `pair` and `setup` write state or start the service; `git-sign` never
 starts the service but does rewrite repo refs in place. Everything else is
 read-only.
 
@@ -155,11 +155,11 @@ Commits are created unsigned and signed **in place** before push:
 
 ```bash
 git commit -m "..."
-openclaw ac2 git-resign <repo-dir>   # or --base origin/<branch> for a chain
+openclaw ac2 git-sign <repo-dir>   # or --base origin/<branch> for a chain
 git push
 ```
 
-1. `git-resign` reads the exact commit payload with
+1. `git-sign` reads the exact commit payload with
    `git cat-file commit` — for an unsigned commit this is byte-for-byte
    the SSHSIG signing input.
 2. It builds the SSHSIG signed-data blob and routes a standard
@@ -169,7 +169,7 @@ git push
    `SSH SIGNATURE` block as the commit's `gpgsig` header, writes the new
    object with `git hash-object`, and moves the ref with a
    compare-and-swap `git update-ref`. The commit hash changes; with
-   `--base`, a whole chain is re-signed oldest-first with parent hashes
+   `--base`, a whole chain is signed oldest-first with parent hashes
    rewritten along the way.
 
 Signing requires an active `ac2` session (`openclaw ac2 pair`) — each

--- a/packages/ac2-open-claw-reference/skills/ac2/AGENTS.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/AGENTS.md
@@ -204,7 +204,7 @@ This reference plugin additionally exposes `ac2_x402_fetch` as
 message: x402 Algorand payments still use ordinary `ac2/SigningRequest`
 messages for wallet approval.
 
-It also exposes the `ac2 git-resign` command (which signs existing commits
+It also exposes the `ac2 git-sign` command (which signs existing commits
 in place after `git commit`) as `ac2-ext-git/sign`.
 This too is a tool capability, not a wire extension: the SSHSIG signed-data
 blob is built locally and signed with an ordinary `ac2/SigningRequest` using

--- a/packages/ac2-open-claw-reference/skills/ac2/IDENTITY.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/IDENTITY.md
@@ -73,7 +73,7 @@ Per AC2 SPEC §Capability Identifier Namespacing (three-tier convention):
 | Identifier            | Surface                                                                 |
 | --------------------- | ----------------------------------------------------------------------- |
 | `ac2-ext-x402/fetch`  | x402 exact Algorand paid HTTP fetch via the `ac2_x402_fetch` tool.      |
-| `ac2-ext-git/sign`    | Git SSHSIG signing via the `ac2 git-resign` command.                     |
+| `ac2-ext-git/sign`    | Git SSHSIG signing via the `ac2 git-sign` command.                     |
 
 Downstream wallet plugins MAY add chain-specific `sig_hint`s (e.g.
 `message-algorand`, `transaction-evm`). When such a plugin is loaded, prefer

--- a/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ac2
-description: "How to use the AC2 channel to ask the user's connected wallet to sign bytes over a live WebRTC link. Use this whenever the user asks you to 'sign', 'approve', or 'authorize' something with their wallet — even if they don't say 'AC2'. ALSO REQUIRED for any git work: before running `git commit` or `git push`, or configuring a git identity, read this skill — commits MUST be signed by the user's AC2 wallet (never with your own or an invented identity), and it documents the required `openclaw ac2 git-key` setup and the commit → `git-resign` → push rhythm. The agent never holds keys; the wallet does."
+description: "How to use the AC2 channel to ask the user's connected wallet to sign bytes over a live WebRTC link. Use this whenever the user asks you to 'sign', 'approve', or 'authorize' something with their wallet — even if they don't say 'AC2'. ALSO REQUIRED for any git work: before running `git commit` or `git push`, or configuring a git identity, read this skill — commits MUST be signed by the user's AC2 wallet (never with your own or an invented identity), and it documents the required `openclaw ac2 git-key` setup and the commit → `git-sign` → push rhythm. The agent never holds keys; the wallet does."
 metadata:
   {
     "openclaw":
@@ -125,11 +125,11 @@ Treat `{ status: "rejected" }` as a normal user decision. Do not retry the same 
 
 ## Git commit signing over AC2
 
-The wallet's Ed25519 account key doubles as a **git SSH signing key**. Use this flow for **any** git commit/push work on this channel — not just when the user explicitly says "sign my commits". Commits are created normally (unsigned) and then signed **in place** by the user's wallet with `openclaw ac2 git-resign` before every push — there is no git-side signing configuration.
+The wallet's Ed25519 account key doubles as a **git SSH signing key**. Use this flow for **any** git commit/push work on this channel — not just when the user explicitly says "sign my commits". Commits are created normally (unsigned) and then signed **in place** by the user's wallet with `openclaw ac2 git-sign` before every push — there is no git-side signing configuration.
 
-**Non-negotiable: commits are signed by the user's wallet, never by you.** Do not generate, use, or configure any local SSH/GPG key of your own, and do not set `user.name`/`user.email` to an invented identity (e.g. "CI Bot" / `bot@example.com`) — the committer identity must be the user's own name/email collected in setup. And **never push without re-signing first**: nothing in git enforces this model — you do. Every commit must be wallet-signed via `git-resign` before it leaves the machine.
+**Non-negotiable: commits are signed by the user's wallet, never by you.** Do not generate, use, or configure any local SSH/GPG key of your own, and do not set `user.name`/`user.email` to an invented identity (e.g. "CI Bot" / `bot@example.com`) — the committer identity must be the user's own name/email collected in setup. And **never push without signing first**: nothing in git enforces this model — you do. Every commit must be wallet-signed via `git-sign` before it leaves the machine.
 
-**Signing needs no setup.** `git-resign` works immediately on any repo — no SSH keys, no key registration, no git provider account. Registering the wallet key with a git provider only controls whether a _pushed_ commit shows a verified badge there; it has no bearing on local commits or on signing itself. **Do not raise key upload, push-auth SSH keys, or provider account details unless the user is actually about to push** (they say so, or `git push` is attempted/fails) **or explicitly asks about verification** — never as part of ordinary committing.
+**Signing needs no setup.** `git-sign` works immediately on any repo — no SSH keys, no key registration, no git provider account. Registering the wallet key with a git provider only controls whether a _pushed_ commit shows a verified badge there; it has no bearing on local commits or on signing itself. **Do not raise key upload, push-auth SSH keys, or provider account details unless the user is actually about to push** (they say so, or `git push` is attempted/fails) **or explicitly asks about verification** — never as part of ordinary committing.
 
 **Before creating a commit, check only this:**
 
@@ -144,18 +144,18 @@ The wallet's Ed25519 account key doubles as a **git SSH signing key**. Use this 
 
 ```bash
 git commit --no-gpg-sign -m "..."   # created unsigned — bypasses any local auto-signing config
-openclaw ac2 git-resign <repo-dir>  # wallet approval; commit rewritten signed in place
+openclaw ac2 git-sign <repo-dir>  # wallet approval; commit rewritten signed in place
 git push                            # only ever push signed commits
 ```
 
-- **Always pass `--no-gpg-sign`** to `git commit` (and to `git commit --amend`, and rebase via `git rebase -c commit.gpgsign=false` or re-sign after): the machine's git config may auto-sign with the user's own SSH/GPG key, and that key is never the wallet. `git-resign` strips and replaces a foreign signature (with a wallet approval), so a slip-through is recoverable — but creating commits unsigned is the correct path.
-- `git-resign <repo-dir>` signs the tip of `HEAD` in place. The commit hash changes; the ref is moved with a compare-and-swap, so re-sign before anything records the old hash.
-- Made several commits (or a rebase/merge produced a chain)? Sign them all in one pass: `openclaw ac2 git-resign <repo-dir> --base origin/<branch>` — each commit gets its own wallet approval (`Sign git commit: "…"`), oldest first, with parent hashes rewritten along the chain. Tell the user approvals are coming before you run it.
+- **Always pass `--no-gpg-sign`** to `git commit` (and to `git commit --amend`, and rebase via `git rebase -c commit.gpgsign=false` or re-sign after): the machine's git config may auto-sign with the user's own SSH/GPG key, and that key is never the wallet. `git-sign` strips and replaces a foreign signature (with a wallet approval), so a slip-through is recoverable — but creating commits unsigned is the correct path.
+- `git-sign <repo-dir>` signs the tip of `HEAD` in place. The commit hash changes; the ref is moved with a compare-and-swap, so sign before anything records the old hash.
+- Made several commits (or a rebase/merge produced a chain)? Sign them all in one pass: `openclaw ac2 git-sign <repo-dir> --base origin/<branch>` — each commit gets its own wallet approval (`Sign git commit: "…"`), oldest first, with parent hashes rewritten along the chain. Tell the user approvals are coming before you run it.
 - `already signed — nothing to do` is a success, not an error.
-- A declined wallet approval aborts with the ref untouched — a normal user decision, don't retry. If it fails with `no active AC2 wallet session`, **stop the push entirely**: ask the user to connect/pair their wallet (`openclaw ac2 pair`) and only push once `git-resign` has succeeded — don't retry in a loop, and never push while signing is unavailable.
+- A declined wallet approval aborts with the ref untouched — a normal user decision, don't retry. If it fails with `no active AC2 wallet session`, **stop the push entirely**: ask the user to connect/pair their wallet (`openclaw ac2 pair`) and only push once `git-sign` has succeeded — don't retry in a loop, and never push while signing is unavailable.
 - Never work around a signing failure by pushing unsigned or substituting a different key — the user's wallet approval is the point. If the user asks why commits show as unverified, that's when to point back at the push-only setup below (key upload) and the email match — don't volunteer it otherwise.
 
-`git-resign` is the only git signing surface: never hand-build SSHSIG envelopes or commit objects via `ac2_sign` — a malformed envelope shows as unverified with no local error. (Signed tags are not covered yet.)
+`git-sign` is the only git signing surface: never hand-build SSHSIG envelopes or commit objects via `ac2_sign` — a malformed envelope shows as unverified with no local error. (Signed tags are not covered yet.)
 
 **Push-only setup — only once the user intends to push, never before:**
 

--- a/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
+++ b/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
@@ -1,9 +1,9 @@
-/** The `ac2` shell + slash command: `pair`, `status`, `connections`, `forget`, `git-key`, `git-resign`. */
+/** The `ac2` shell + slash command: `pair`, `status`, `connections`, `forget`, `git-key`, `git-sign`. */
 
-const GIT_RESIGN_USAGE =
-  'Usage: ac2 git-resign <repo-dir> [--ref <ref>] [--base <ref>]\n' +
+const GIT_SIGN_USAGE =
+  'Usage: ac2 git-sign <repo-dir> [--ref <ref>] [--base <ref>]\n' +
   'Signs the tip commit of <ref> (default HEAD) in place via the paired wallet.\n' +
-  'With --base, re-signs every commit in <base>..<ref>, rewriting the chain.';
+  'With --base, signs every commit in <base>..<ref>, rewriting the chain.';
 
 import qrcode from 'qrcode-terminal';
 import { Ac2Client } from '@algorandfoundation/ac2-sdk';
@@ -23,7 +23,7 @@ import {
   type ControlEvents,
 } from '@algorandfoundation/ac2-cli/control';
 import { sendNotice } from '../channel/index.js';
-import { resignCommits } from '../git/resign.js';
+import { signCommits } from '../git/sign.js';
 import { toAuthorizedKeyLine } from '../git/sshsig.js';
 import { NO_WALLET_KEY_MESSAGE, resolveWalletSigningPublicKey } from '../git/config.js';
 
@@ -204,8 +204,8 @@ export function buildAc2Command(api: OpenClawApi): unknown {
     name: 'ac2',
     description:
       'AC2 channel control: pair | status | connections | forget | git-key | ' +
-      'git-resign <repo-dir> [--ref <ref>] [--base <ref>]. ' +
-      '`git-key` prints the wallet SSH signing key; `git-resign` ' +
+      'git-sign <repo-dir> [--ref <ref>] [--base <ref>]. ' +
+      '`git-key` prints the wallet SSH signing key; `git-sign` ' +
       'signs commits in place via the paired wallet before push.',
     acceptsArgs: true,
     requireAuth: false,
@@ -326,12 +326,12 @@ export function buildAc2Command(api: OpenClawApi): unknown {
             'verified there once the committer email matches your account.',
             '',
             "Committer identity is your normal git config (`git config user.name` /",
-            '`user.email`); sign commits before pushing with: openclaw ac2 git-resign',
+            '`user.email`); sign commits before pushing with: openclaw ac2 git-sign',
           ].join('\n'),
         };
       }
 
-      if (sub === 'git-resign') {
+      if (sub === 'git-sign') {
         // Sign-after-commit: signs the tip (or a range) of an existing repo
         // in place via the active session — no git signing config involved.
         const rest = tokens.slice(1);
@@ -343,12 +343,12 @@ export function buildAc2Command(api: OpenClawApi): unknown {
           if (token === '--ref') ref = rest[++i];
           else if (token === '--base') base = rest[++i];
           else if (!token.startsWith('--') && repoDir === undefined) repoDir = token;
-          else return { text: `git-resign: unexpected argument '${token}'\n${GIT_RESIGN_USAGE}` };
+          else return { text: `git-sign: unexpected argument '${token}'\n${GIT_SIGN_USAGE}` };
         }
-        if (!repoDir) return { text: `git-resign: missing <repo-dir>\n${GIT_RESIGN_USAGE}` };
+        if (!repoDir) return { text: `git-sign: missing <repo-dir>\n${GIT_SIGN_USAGE}` };
 
         const cfg = resolveConfig(api);
-        const result = await resignCommits(
+        const result = await signCommits(
           { repoDir, ...(ref !== undefined ? { ref } : {}), ...(base !== undefined ? { base } : {}) },
           cfg,
         );
@@ -356,18 +356,18 @@ export function buildAc2Command(api: OpenClawApi): unknown {
           if (result.reason === 'no_active_session') {
             return {
               text:
-                'git-resign: no active AC2 wallet session — pair the wallet first ' +
+                'git-sign: no active AC2 wallet session — pair the wallet first ' +
                 '(`openclaw ac2 pair`), then retry.',
             };
           }
           if (result.reason === 'already_signed') {
-            return { text: 'git-resign: every commit in range is already signed — nothing to do.' };
+            return { text: 'git-sign: every commit in range is already signed — nothing to do.' };
           }
-          return { text: `git-resign: ${result.reason}` };
+          return { text: `git-sign: ${result.reason}` };
         }
         return {
           text: [
-            `Re-signed ${result.commits.length} commit(s) on ${result.ref}:`,
+            `Signed ${result.commits.length} commit(s) on ${result.ref}:`,
             '',
             ...result.commits.map(
               (c) => `  ${c.oldSha.slice(0, 8)} → ${c.newSha.slice(0, 8)}  ${c.subject}`,
@@ -586,7 +586,7 @@ export function buildAc2Command(api: OpenClawApi): unknown {
       }
 
       return {
-        text: `Unknown subcommand: ${sub}. Use 'pair', 'status', 'connections', 'forget', 'git-key', or 'git-resign'.`,
+        text: `Unknown subcommand: ${sub}. Use 'pair', 'status', 'connections', 'forget', 'git-key', or 'git-sign'.`,
       };
     },
   };

--- a/packages/ac2-open-claw-reference/src/entry.ts
+++ b/packages/ac2-open-claw-reference/src/entry.ts
@@ -121,7 +121,7 @@ async function runAc2SlashCommand(ctx: { args?: string }): Promise<{ text: strin
       '  openclaw ac2 forget       Clear the saved pairing record.',
       '  openclaw ac2 setup        Print/update channel configuration.',
       '  openclaw ac2 git-key      Print the wallet key as a git SSH signing key.',
-      '  openclaw ac2 git-resign <repo-dir> [--ref r] [--base r]',
+      '  openclaw ac2 git-sign <repo-dir> [--ref r] [--base r]',
       '                            Sign commits in place via the AC2 wallet before pushing.',
     ].join('\n'),
   };

--- a/packages/ac2-open-claw-reference/src/git/config.ts
+++ b/packages/ac2-open-claw-reference/src/git/config.ts
@@ -1,6 +1,6 @@
 /**
  * Resolve the wallet's git signing key. Signing itself needs no git
- * configuration — see `./resign.ts`; committer identity is the user's own
+ * configuration — see `./sign.ts`; committer identity is the user's own
  * `git config user.name`/`user.email`.
  */
 

--- a/packages/ac2-open-claw-reference/src/git/sign.ts
+++ b/packages/ac2-open-claw-reference/src/git/sign.ts
@@ -3,8 +3,8 @@
  * rewritten in place. An unsigned commit's raw payload IS the SSHSIG
  * signed-data input, so no git-side signing configuration is needed.
  *
- * Trade-offs: commits exist unsigned until re-signed (nothing in git enforces
- * the re-sign — the skill instructions do), and rewriting a parent changes
+ * Trade-offs: commits exist unsigned until signed (nothing in git enforces
+ * the signing step — the skill instructions do), and rewriting a parent changes
  * every descendant hash, so ranges are signed oldest first with parent headers
  * rewritten along the way.
  */
@@ -106,7 +106,7 @@ export function insertGpgsigHeader(payload: Buffer, armored: string): Buffer {
   return joinHeaders([...headerLines, ...sigLines], message);
 }
 
-/** Rewrite `parent <sha>` headers through an old→new mapping (chain re-sign). */
+/** Rewrite `parent <sha>` headers through an old→new mapping (chain signing). */
 export function rewriteParentHeaders(
   payload: Buffer,
   mapping: ReadonlyMap<string, string>,
@@ -124,13 +124,13 @@ export function rewriteParentHeaders(
   return changed ? joinHeaders(rewritten, message) : payload;
 }
 
-export interface GitResignOptions {
+export interface SignCommitsOptions {
   /** Absolute path to the git repository. */
   repoDir: string;
-  /** Ref whose tip to re-sign; defaults to `HEAD`. */
+  /** Ref whose tip to sign; defaults to `HEAD`. */
   ref?: string;
   /**
-   * When set, re-sign every commit in `base..ref` (oldest first), rewriting
+   * When set, sign every commit in `base..ref` (oldest first), rewriting
    * parent hashes along the chain. Without it only the tip commit is signed.
    */
   base?: string;
@@ -149,28 +149,28 @@ function isWalletSignature(armor: string, payload: Buffer, walletKey: Uint8Array
   }
 }
 
-export type GitResignResult =
+export type SignCommitsResult =
   | {
       status: 'signed';
       ref: string;
       oldTip: string;
       newTip: string;
-      /** Old→new sha per re-signed commit, oldest first. */
+      /** Old→new sha per signed commit, oldest first. */
       commits: Array<{ oldSha: string; newSha: string; subject: string }>;
     }
   | { status: 'rejected'; reason: string };
 
 /**
- * Re-sign the commit(s) at `ref` via the active AC2 session and move the ref
+ * Sign the commit(s) at `ref` via the active AC2 session and move the ref
  * to the rewritten tip. One wallet approval per commit; a rejection aborts
  * before any ref is touched (loose objects already written are harmless).
  */
-export async function resignCommits(
-  options: GitResignOptions,
+export async function signCommits(
+  options: SignCommitsOptions,
   config: PluginConfig,
   deps: ResolveSignDeps = {},
   context: ToolContext = {},
-): Promise<GitResignResult> {
+): Promise<SignCommitsResult> {
   const ref = options.ref ?? 'HEAD';
   let oldTip: string;
   let shas: string[];
@@ -231,8 +231,12 @@ export async function resignCommits(
       return { status: 'rejected', reason: signed.reason };
     }
 
-    const resigned = insertGpgsigHeader(payload, signed.armored);
-    const newSha = git(options.repoDir, ['hash-object', '-t', 'commit', '-w', '--stdin'], resigned)
+    const signedPayload = insertGpgsigHeader(payload, signed.armored);
+    const newSha = git(
+      options.repoDir,
+      ['hash-object', '-t', 'commit', '-w', '--stdin'],
+      signedPayload,
+    )
       .toString('utf8')
       .trim();
     mapping.set(sha, newSha);
@@ -248,7 +252,7 @@ export async function resignCommits(
   // never clobbered. `update-ref HEAD` follows the symbolic ref to the
   // underlying branch (and works detached), so `ref` is passed as given.
   try {
-    git(options.repoDir, ['update-ref', '-m', 'ac2 git-resign', ref, newTip, oldTip]);
+    git(options.repoDir, ['update-ref', '-m', 'ac2 git-sign', ref, newTip, oldTip]);
   } catch (err) {
     return { status: 'rejected', reason: `git_error: ${(err as Error).message}` };
   }

--- a/packages/ac2-open-claw-reference/tests/cli-command.test.ts
+++ b/packages/ac2-open-claw-reference/tests/cli-command.test.ts
@@ -133,8 +133,8 @@ describe('ac2 pair command AC2_RUNTIME commitment', () => {
 
 describe('tokenizeArgs', () => {
   it('splits on whitespace and honours quotes', () => {
-    expect(tokenizeArgs('git-resign /r --base "origin/main"')).toEqual([
-      'git-resign',
+    expect(tokenizeArgs('git-sign /r --base "origin/main"')).toEqual([
+      'git-sign',
       '/r',
       '--base',
       'origin/main',

--- a/packages/ac2-open-claw-reference/tests/git-sign.test.ts
+++ b/packages/ac2-open-claw-reference/tests/git-sign.test.ts
@@ -10,10 +10,10 @@ import { SessionManager } from '../src/session/manager.js';
 import { walletFixture } from './wallet-fixture.js';
 import {
   insertGpgsigHeader,
-  resignCommits,
+  signCommits,
   rewriteParentHeaders,
   stripGpgsigHeader,
-} from '../src/git/resign.js';
+} from '../src/git/sign.js';
 import {
   buildSshSigSignedData,
   decodeSshSigArmor,
@@ -45,7 +45,7 @@ function git(repoDir: string, args: string[], input?: Buffer): Buffer {
 
 /** A fresh repo with signing off and a deterministic identity. */
 function makeRepo(): string {
-  const repoDir = mkdtempSync(join(tmpdir(), 'ac2-resign-'));
+  const repoDir = mkdtempSync(join(tmpdir(), 'ac2-git-sign-'));
   git(repoDir, ['init', '-q', '-b', 'main']);
   git(repoDir, ['config', 'user.name', 'Ada']);
   git(repoDir, ['config', 'user.email', 'ada@example.com']);
@@ -107,13 +107,13 @@ describe('gpgsig header helpers', () => {
   });
 });
 
-describe('resignCommits', () => {
+describe('signCommits', () => {
   it('signs HEAD in place with a verifiable SSHSIG and moves the branch', async () => {
     const { manager, rawPublicKey } = walletFixture();
     const repoDir = makeRepo();
     const oldSha = commit(repoDir, 'feat: one');
 
-    const result = await resignCommits({ repoDir }, {}, { manager });
+    const result = await signCommits({ repoDir }, {}, { manager });
     expect(result.status).toBe('signed');
     if (result.status !== 'signed') return;
     expect(result.oldTip).toBe(oldSha);
@@ -145,7 +145,7 @@ describe('resignCommits', () => {
     const repoDir = makeRepo();
     commit(repoDir, 'feat: verified');
 
-    const result = await resignCommits({ repoDir }, {}, { manager });
+    const result = await signCommits({ repoDir }, {}, { manager });
     expect(result.status).toBe('signed');
 
     const signersPath = join(repoDir, 'allowed_signers');
@@ -158,20 +158,20 @@ describe('resignCommits', () => {
     git(repoDir, ['verify-commit', 'HEAD']);
   });
 
-  it('re-signs a range oldest-first, rewriting the parent chain', async () => {
+  it('signs a range oldest-first, rewriting the parent chain', async () => {
     const { manager } = walletFixture();
     const repoDir = makeRepo();
     const base = commit(repoDir, 'feat: base');
     const first = commit(repoDir, 'feat: first');
     const second = commit(repoDir, 'feat: second');
 
-    const result = await resignCommits({ repoDir, base }, {}, { manager });
+    const result = await signCommits({ repoDir, base }, {}, { manager });
     expect(result.status).toBe('signed');
     if (result.status !== 'signed') return;
     expect(result.commits.map((c) => c.oldSha)).toEqual([first, second]);
     expect(result.commits.map((c) => c.subject)).toEqual(['feat: first', 'feat: second']);
 
-    // The new tip's parent is the re-signed first commit, and both carry sigs.
+    // The new tip's parent is the signed first commit, and both carry sigs.
     const newFirst = result.commits[0]!.newSha;
     const tip = git(repoDir, ['cat-file', 'commit', 'HEAD']).toString('utf8');
     expect(tip).toContain(`parent ${newFirst}`);
@@ -182,15 +182,15 @@ describe('resignCommits', () => {
 
   it('strips and re-signs a tip signed by a foreign key', async () => {
     // The "machine's own git signing config" case: the tip carries a valid
-    // SSHSIG by some other key — resign must replace it, not skip it.
+    // SSHSIG by some other key — signing must replace it, not skip it.
     const foreign = walletFixture();
     const { manager, rawPublicKey, requests } = walletFixture();
     const repoDir = makeRepo();
     commit(repoDir, 'feat: locally-signed');
-    const foreignResult = await resignCommits({ repoDir }, {}, { manager: foreign.manager });
+    const foreignResult = await signCommits({ repoDir }, {}, { manager: foreign.manager });
     expect(foreignResult.status).toBe('signed');
 
-    const result = await resignCommits({ repoDir }, {}, { manager });
+    const result = await signCommits({ repoDir }, {}, { manager });
     expect(result.status).toBe('signed');
     expect(requests).toHaveLength(1);
 
@@ -214,10 +214,10 @@ describe('resignCommits', () => {
     const { manager, requests } = walletFixture();
     const repoDir = makeRepo();
     commit(repoDir, 'feat: once');
-    await resignCommits({ repoDir }, {}, { manager });
+    await signCommits({ repoDir }, {}, { manager });
     const signedTip = git(repoDir, ['rev-parse', 'HEAD']).toString('utf8').trim();
 
-    const again = await resignCommits({ repoDir }, {}, { manager });
+    const again = await signCommits({ repoDir }, {}, { manager });
     expect(again).toEqual({ status: 'rejected', reason: 'already_signed' });
     expect(git(repoDir, ['rev-parse', 'HEAD']).toString('utf8').trim()).toBe(signedTip);
     expect(requests).toHaveLength(1);
@@ -231,7 +231,7 @@ describe('resignCommits', () => {
     const repoDir = makeRepo();
     const sha = commit(repoDir, 'feat: declined');
 
-    const result = await resignCommits({ repoDir }, {}, { manager });
+    const result = await signCommits({ repoDir }, {}, { manager });
     expect(result).toEqual({ status: 'rejected', reason: 'user_declined' });
     expect(git(repoDir, ['rev-parse', 'HEAD']).toString('utf8').trim()).toBe(sha);
   });
@@ -239,7 +239,7 @@ describe('resignCommits', () => {
   it('rejects with no_active_session when no wallet is paired and no daemon runs', async () => {
     const repoDir = makeRepo();
     commit(repoDir, 'feat: offline');
-    const result = await resignCommits(
+    const result = await signCommits(
       { repoDir },
       {},
       { manager: new SessionManager(), connect: async () => undefined },
@@ -270,7 +270,7 @@ describe('resignCommits', () => {
 
     const repoDir = makeRepo();
     commit(repoDir, 'feat: daemon-signed');
-    const result = await resignCommits(
+    const result = await signCommits(
       { repoDir },
       {},
       { manager: new SessionManager(), connect: async () => daemon as never },
@@ -294,8 +294,8 @@ describe('resignCommits', () => {
 
   it('rejects on a directory that is not a git repo', async () => {
     const { manager } = walletFixture();
-    const dir = mkdtempSync(join(tmpdir(), 'ac2-resign-notrepo-'));
-    const result = await resignCommits({ repoDir: dir }, {}, { manager });
+    const dir = mkdtempSync(join(tmpdir(), 'ac2-git-sign-notrepo-'));
+    const result = await signCommits({ repoDir: dir }, {}, { manager });
     expect(result.status).toBe('rejected');
     if (result.status === 'rejected') expect(result.reason).toMatch(/^git_error:/);
   });


### PR DESCRIPTION
The command signs commits; "resign" only described the rewrite mechanic and read as "re-sign" or "resign" depending on the reader. Renames the command, the module (src/git/resign.ts -> src/git/sign.ts), the exported API (resignCommits/GitResignOptions/GitResignResult -> signCommits/SignCommitsOptions/SignCommitsResult), and all docs and skill text.