### PR TITLE
feat: simplify git signing

### DIFF
--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -14,8 +14,7 @@ You get four agent tools and one channel:
 | `ac2_x402_fetch` | Fetch an HTTP resource that charges with x402 on Algorand, paying with wallet approval. |
 | Channel `ac2` | The wallet becomes a chat channel: you message your agent from your phone. |
 
-It also turns the connected wallet into a git SSH signing key, so `git commit` /
-`git push` can be signed with the same approval flow — see
+It also turns the connected wallet into a git SSH signing key, so `git commit` can be signed with the same approval flow — see
 [Git commit signing over AC2](#git-commit-signing-over-ac2).
 
 The wallet connection itself is owned by the separate
@@ -125,22 +124,22 @@ blob. Since an Algorand address *is* an Ed25519 public key, the paired
 wallet's account key doubles as a git SSH signing key — no new key
 material, no protocol changes, and the private key never leaves the
 wallet. Signing itself needs **no setup**: no git signing settings are
-configured, no SSH agent, no provider account — see "How a commit gets
+configured, no SSH agent, no git platform account — see "How a commit gets
 signed" below. The committer identity is your normal git config
 (`git config user.name` / `user.email`) — usually already set up on your
 machine.
 
-### Before your first push
+### Before your first push (optional)
 
-Registering the wallet key with a git provider only affects whether a
+Registering the wallet key with a git platform only affects whether a
 *pushed* commit shows a verified badge there — it's not needed to sign or
-commit locally, so skip this section until you're about to push.
+commit locally, so skip this section until you're about to push and want your commits to show as verified.
 
 ```bash
 openclaw ac2 git-key        # print the wallet's key as an ssh-ed25519 line
 ```
 
-Add the printed line as an SSH signing key with your git provider
+Add the printed line as an SSH signing key with your git platform
 (usually under account settings → SSH keys). Until that key is
 registered, pushed commits show as unverified — the committer email must
 also match the account for verification to succeed.
@@ -151,12 +150,11 @@ signing key) — local-only work needs no auth at all.
 
 ### How a commit gets signed
 
-Commits are created unsigned and signed **in place** before push:
+Commits are created unsigned and signed **in place**:
 
 ```bash
 git commit -m "..."
 openclaw ac2 git-sign <repo-dir>   # or --base origin/<branch> for a chain
-git push
 ```
 
 1. `git-sign` reads the exact commit payload with

--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -129,11 +129,11 @@ signed" below. The committer identity is your normal git config
 (`git config user.name` / `user.email`) — usually already set up on your
 machine.
 
-### Before your first push (optional)
+### Verified badges on a git platform (optional)
 
 Registering the wallet key with a git platform only affects whether a
-*pushed* commit shows a verified badge there — it's not needed to sign or
-commit locally, so skip this section until you're about to push and want your commits to show as verified.
+commit shows a verified badge there — it is not needed to sign or commit,
+so skip this section unless you want that badge.
 
 ```bash
 openclaw ac2 git-key        # print the wallet's key as an ssh-ed25519 line
@@ -141,19 +141,15 @@ openclaw ac2 git-key        # print the wallet's key as an ssh-ed25519 line
 
 Add the printed line as an SSH signing key with your git platform
 (usually under account settings → SSH keys). Until that key is
-registered, pushed commits show as unverified — the committer email must
+registered, commits show as unverified there — the committer email must
 also match the account for verification to succeed.
-
-Pushing uses an SSH remote (e.g. `git@host:owner/repo.git`) authenticated
-by your own SSH key (an Authentication Key, separate from the wallet
-signing key) — local-only work needs no auth at all.
 
 ### How a commit gets signed
 
 Commits are created unsigned and signed **in place**:
 
 ```bash
-git commit -m "..."
+git commit --no-gpg-sign -m "..."
 openclaw ac2 git-sign <repo-dir>   # or --base origin/<branch> for a chain
 ```
 

--- a/packages/ac2-open-claw-reference/package.json
+++ b/packages/ac2-open-claw-reference/package.json
@@ -103,8 +103,7 @@
       "tools": [
         "ac2_sign",
         "ac2_capabilities",
-        "ac2_x402_fetch",
-        "ac2_git_sign"
+        "ac2_x402_fetch"
       ],
       "commands": [
         "ac2"

--- a/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ac2
-description: "How to use the AC2 channel to ask the user's connected wallet to sign bytes over a live WebRTC link. Use this whenever the user asks you to 'sign', 'approve', or 'authorize' something with their wallet — even if they don't say 'AC2'. ALSO REQUIRED for any git work: before running `git commit` or `git push`, or configuring a git identity, read this skill — commits MUST be signed by the user's AC2 wallet (never with your own or an invented identity), and it documents the required `openclaw ac2 git-key` setup and the commit → `git-sign` → push rhythm. The agent never holds keys; the wallet does."
+description: "How to use the AC2 channel to ask the user's connected wallet to sign bytes over a live WebRTC link. Use this whenever the user asks you to 'sign', 'approve', or 'authorize' something with their wallet — even if they don't say 'AC2'. ALSO REQUIRED for any git work: before running `git commit` read this skill — commits MUST be signed by the user's AC2 wallet (never with your own or an invented identity), and it documents the commit → `git-sign` rhythm. The agent never holds keys; the wallet does."
 metadata:
   {
     "openclaw":
@@ -125,44 +125,28 @@ Treat `{ status: "rejected" }` as a normal user decision. Do not retry the same 
 
 ## Git commit signing over AC2
 
-The wallet's Ed25519 account key doubles as a **git SSH signing key**. Use this flow for **any** git commit/push work on this channel — not just when the user explicitly says "sign my commits". Commits are created normally (unsigned) and then signed **in place** by the user's wallet with `openclaw ac2 git-sign` before every push — there is no git-side signing configuration.
+The wallet's Ed25519 account key doubles as a **git SSH signing key**. Use this flow for **any** git commit work on this channel — not just when the user explicitly says "sign my commits". Commits are created normally (unsigned) and then signed **in place** by the user's wallet with `openclaw ac2 git-sign`; there is no git-side signing configuration.
 
-**Non-negotiable: commits are signed by the user's wallet, never by you.** Do not generate, use, or configure any local SSH/GPG key of your own, and do not set `user.name`/`user.email` to an invented identity (e.g. "CI Bot" / `bot@example.com`) — the committer identity must be the user's own name/email collected in setup. And **never push without signing first**: nothing in git enforces this model — you do. Every commit must be wallet-signed via `git-sign` before it leaves the machine.
+**Non-negotiable: commits are signed by the user's wallet, never by you.** Do not generate, use, or configure any local SSH/GPG key of your own: nothing in git enforces this model — you do. Every commit gets wallet-signed via `git-sign` right after it is created.
 
-**Signing needs no setup.** `git-sign` works immediately on any repo — no SSH keys, no key registration, no git provider account. Registering the wallet key with a git provider only controls whether a _pushed_ commit shows a verified badge there; it has no bearing on local commits or on signing itself. **Do not raise key upload, push-auth SSH keys, or provider account details unless the user is actually about to push** (they say so, or `git push` is attempted/fails) **or explicitly asks about verification** — never as part of ordinary committing.
+**Signing needs no setup.** `git-sign` works immediately on any repo — no SSH keys, no key registration, no git platform account. Registering the wallet key with a git platform only controls whether a commit shows a verified badge there; it has no bearing on local commits or on signing itself. **Do not raise key upload, SSH keys, or git platform account details unless the user explicitly asks about verification** — never as part of ordinary committing.
 
-**Before creating a commit, check only this:**
-
-- Committer identity is the user's own git config, assumed already set up. Check with `git -C <repo-dir> config user.email` — if it prints a value, identity is done. If it's empty, ask the user for their name/email (never invent one) and set it:
-
-  ```bash
-  git config user.name <name>
-  git config user.email <email>
-  ```
-
-**Signing commits — the required rhythm, before every push:**
+**Signing commits — the required rhythm, after every commit:**
 
 ```bash
 git commit --no-gpg-sign -m "..."   # created unsigned — bypasses any local auto-signing config
-openclaw ac2 git-sign <repo-dir>  # wallet approval; commit rewritten signed in place
-git push                            # only ever push signed commits
+openclaw ac2 git-sign <repo-dir>    # wallet approval; commit rewritten signed in place
 ```
 
 - **Always pass `--no-gpg-sign`** to `git commit` (and to `git commit --amend`, and rebase via `git rebase -c commit.gpgsign=false` or re-sign after): the machine's git config may auto-sign with the user's own SSH/GPG key, and that key is never the wallet. `git-sign` strips and replaces a foreign signature (with a wallet approval), so a slip-through is recoverable — but creating commits unsigned is the correct path.
 - `git-sign <repo-dir>` signs the tip of `HEAD` in place. The commit hash changes; the ref is moved with a compare-and-swap, so sign before anything records the old hash.
 - Made several commits (or a rebase/merge produced a chain)? Sign them all in one pass: `openclaw ac2 git-sign <repo-dir> --base origin/<branch>` — each commit gets its own wallet approval (`Sign git commit: "…"`), oldest first, with parent hashes rewritten along the chain. Tell the user approvals are coming before you run it.
 - `already signed — nothing to do` is a success, not an error.
-- A declined wallet approval aborts with the ref untouched — a normal user decision, don't retry. If it fails with `no active AC2 wallet session`, **stop the push entirely**: ask the user to connect/pair their wallet (`openclaw ac2 pair`) and only push once `git-sign` has succeeded — don't retry in a loop, and never push while signing is unavailable.
-- Never work around a signing failure by pushing unsigned or substituting a different key — the user's wallet approval is the point. If the user asks why commits show as unverified, that's when to point back at the push-only setup below (key upload) and the email match — don't volunteer it otherwise.
+- A declined wallet approval aborts with the ref untouched — a normal user decision, don't retry. If it fails with `no active AC2 wallet session`, ask the user to connect/pair their wallet (`openclaw ac2 pair`) — don't retry in a loop.
+- Never work around a signing failure by substituting a different key — the user's wallet approval is the point. If the user asks why commits show as unverified, that's when to mention `openclaw ac2 git-key` (registering the key with their git platform) and the committer email match — don't volunteer it otherwise.
+- If `git commit` itself fails because `user.name`/`user.email` are unset, relay git's error and ask the user for their name and email — or use an appropriate identity.
 
 `git-sign` is the only git signing surface: never hand-build SSHSIG envelopes or commit objects via `ac2_sign` — a malformed envelope shows as unverified with no local error. (Signed tags are not covered yet.)
-
-**Push-only setup — only once the user intends to push, never before:**
-
-1. **Key upload (once per wallet, not per repo or commit).** If the user has already been shown the `openclaw ac2 git-key` output and acknowledged adding it with their git provider — in this conversation or a previous one — skip this; take their word for it. Otherwise: run `openclaw ac2 git-key` (shell), output the full `ssh-ed25519 …` line in chat, and ask them to add it as an SSH signing key with their git provider (account settings → SSH keys, choosing a "Signing Key" type if the provider distinguishes one from an authentication key). It is a public key — safe and expected to show. Explain that pushed commits show unverified until it's registered. Wait for their acknowledgment, then **never bring it up again** unless they ask.
-2. **Push auth.** Their **own SSH key** (a normal **Authentication Key**, e.g. `~/.ssh/id_ed25519.pub` — separate from the wallet signing key): assume it is already added with their git provider, and make sure the repo remote uses the SSH form (`git@host:owner/repo.git`, not `https://…`). If they haven't added an SSH key yet, advise them to add it as an authentication/access SSH key with their git provider.
-
-**Adding push access later:** if a repo was set up local-only and the user later wants to push (`git push` fails to authenticate, or they ask you to push), run the push-only setup above.
 
 ## `sig_hint` catalog (what the core reference defines)
 

--- a/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
+++ b/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
@@ -206,7 +206,7 @@ export function buildAc2Command(api: OpenClawApi): unknown {
       'AC2 channel control: pair | status | connections | forget | git-key | ' +
       'git-sign <repo-dir> [--ref <ref>] [--base <ref>]. ' +
       '`git-key` prints the wallet SSH signing key; `git-sign` ' +
-      'signs commits in place via the paired wallet before push.',
+      'signs commits in place via the paired wallet after each commit.',
     acceptsArgs: true,
     requireAuth: false,
     async handler(ctx: any): Promise<{ text: string; keepAlive?: boolean }> {
@@ -321,12 +321,12 @@ export function buildAc2Command(api: OpenClawApi): unknown {
             '',
             `  ${line}`,
             '',
-            'Add it as an SSH signing key with your git provider (usually under',
+            'Add it as an SSH signing key with your git platform (usually under',
             'account settings → SSH keys). Commits signed over AC2 then show as',
             'verified there once the committer email matches your account.',
             '',
             "Committer identity is your normal git config (`git config user.name` /",
-            '`user.email`); sign commits before pushing with: openclaw ac2 git-sign',
+            '`user.email`); sign commits with: openclaw ac2 git-sign',
           ].join('\n'),
         };
       }
@@ -373,7 +373,7 @@ export function buildAc2Command(api: OpenClawApi): unknown {
               (c) => `  ${c.oldSha.slice(0, 8)} → ${c.newSha.slice(0, 8)}  ${c.subject}`,
             ),
             '',
-            `Ref moved: ${result.oldTip.slice(0, 8)} → ${result.newTip.slice(0, 8)}. Push to publish.`,
+            `Ref moved: ${result.oldTip.slice(0, 8)} → ${result.newTip.slice(0, 8)}.`,
           ].join('\n'),
         };
       }

--- a/packages/ac2-open-claw-reference/src/entry.ts
+++ b/packages/ac2-open-claw-reference/src/entry.ts
@@ -122,7 +122,7 @@ async function runAc2SlashCommand(ctx: { args?: string }): Promise<{ text: strin
       '  openclaw ac2 setup        Print/update channel configuration.',
       '  openclaw ac2 git-key      Print the wallet key as a git SSH signing key.',
       '  openclaw ac2 git-sign <repo-dir> [--ref r] [--base r]',
-      '                            Sign commits in place via the AC2 wallet before pushing.',
+      '                            Sign commits in place via the AC2 wallet after each commit.',
     ].join('\n'),
   };
 }

--- a/packages/ac2-open-claw-reference/src/git/sign-flow.ts
+++ b/packages/ac2-open-claw-reference/src/git/sign-flow.ts
@@ -154,7 +154,7 @@ export async function gitSignFlow(
       status: 'rejected',
       reason:
         'public_key_mismatch: the wallet signed with a different key than expected — ' +
-        'check `openclaw ac2 git-key` and update the signing key with your git provider.',
+        'check `openclaw ac2 git-key` and update the signing key with your git platform.',
       thid: result.thid,
     };
   }

--- a/packages/ac2-open-claw-reference/src/git/sshsig.ts
+++ b/packages/ac2-open-claw-reference/src/git/sshsig.ts
@@ -1,7 +1,7 @@
 /**
  * SSHSIG (OpenSSH `PROTOCOL.sshsig`) encoding for Ed25519 keys and
  * signatures. This is the format `git` produces/consumes when
- * `gpg.format = ssh`, and the format git hosting providers verify for SSH
+ * `gpg.format = ssh`, and the format git hosting platforms verify for SSH
  * signing keys.
  *
  * The crucial property exploited by the AC2 git-signing flow: an SSHSIG
@@ -60,12 +60,12 @@ function assertPublicKey(publicKey: Uint8Array): Buffer {
   return buf;
 }
 
-/** SSH wire encoding of an Ed25519 public key (what git providers store as your signing key). */
+/** SSH wire encoding of an Ed25519 public key (what git platforms store as your signing key). */
 export function encodeSshEd25519PublicKey(publicKey: Uint8Array): Buffer {
   return Buffer.concat([sshString(KEY_TYPE), sshString(assertPublicKey(publicKey))]);
 }
 
-/** `ssh-ed25519 AAAA… comment` line the user adds to their git provider as a signing key. */
+/** `ssh-ed25519 AAAA… comment` line the user adds to their git platform as a signing key. */
 export function toAuthorizedKeyLine(publicKey: Uint8Array, comment = 'ac2-wallet'): string {
   const blob = encodeSshEd25519PublicKey(publicKey).toString('base64');
   return comment.length > 0 ? `${KEY_TYPE} ${blob} ${comment}` : `${KEY_TYPE} ${blob}`;


### PR DESCRIPTION
- just sign after commits, don't tie the flow to `git push` operations
- don't prompt the user through an awkward setup process, just handle commits over ac2
- remove strict `user.email` and `user.name` requirements before any commit, just let the user/bot deal with everything
- remove a dead tool reference in `openclaw.plugin.json` (there is no git_sign tool, this functionality has been greatly simplified).