### PR TITLE
fix: use `public key` over `wallet address` in git signing context

### DIFF
--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -14,7 +14,7 @@ You get four agent tools and one channel:
 | `ac2_x402_fetch` | Fetch an HTTP resource that charges with x402 on Algorand, paying with wallet approval. |
 | Channel `ac2` | The wallet becomes a chat channel: you message your agent from your phone. |
 
-It also turns the connected wallet into a git SSH signing key, so `git commit` can be signed with the same approval flow — see
+It also exposes the paired account's public key as a git SSH signing key, so `git commit` can be signed with the same approval flow — see
 [Git commit signing over AC2](#git-commit-signing-over-ac2).
 
 The wallet connection itself is owned by the separate
@@ -108,8 +108,8 @@ pays its own fees since it holds ALGO anyway.
 | `openclaw ac2 connections` | List remembered wallet connections. |
 | `openclaw ac2 forget` | Drop a pairing and the agent identity bound to it. |
 | `openclaw ac2 setup` | Write or refresh the plugin's `openclaw.json` wiring. |
-| `openclaw ac2 git-key` | Print the wallet's key as a git SSH signing key. |
-| `openclaw ac2 git-sign <repo-dir>` | Sign the latest commit (or a chain with `--base`) in place with the wallet key. |
+| `openclaw ac2 git-key` | Print the SSH signing public key for git. |
+| `openclaw ac2 git-sign <repo-dir>` | Sign the latest commit (or a chain with `--base`) in place with the paired account's key. |
 | `/ac2 status` | The same status from inside a chat. |
 
 Only `pair` and `setup` write state or start the service; `git-sign` never
@@ -121,7 +121,7 @@ read-only.
 Git can sign commits with SSH keys (`gpg.format ssh`), and an SSHSIG
 signature is just a raw Ed25519 signature over a locally-constructed
 blob. Since an Algorand address *is* an Ed25519 public key, the paired
-wallet's account key doubles as a git SSH signing key — no new key
+account's public key doubles as a git SSH signing public key — no new key
 material, no protocol changes, and the private key never leaves the
 wallet. Signing itself needs **no setup**: no git signing settings are
 configured, no SSH agent, no git platform account — see "How a commit gets
@@ -131,16 +131,16 @@ machine.
 
 ### Verified badges on a git platform (optional)
 
-Registering the wallet key with a git platform only affects whether a
+Registering that public key with a git platform only affects whether a
 commit shows a verified badge there — it is not needed to sign or commit,
 so skip this section unless you want that badge.
 
 ```bash
-openclaw ac2 git-key        # print the wallet's key as an ssh-ed25519 line
+openclaw ac2 git-key        # print the signing public key (SSH format)
 ```
 
 Add the printed line as an SSH signing key with your git platform
-(usually under account settings → SSH keys). Until that key is
+(usually under account settings → SSH keys). Until that public key is
 registered, commits show as unverified there — the committer email must
 also match the account for verification to succeed.
 

--- a/packages/ac2-open-claw-reference/skills/ac2/AGENTS.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/AGENTS.md
@@ -208,4 +208,4 @@ It also exposes the `ac2 git-sign` command (which signs existing commits
 in place after `git commit`) as `ac2-ext-git/sign`.
 This too is a tool capability, not a wire extension: the SSHSIG signed-data
 blob is built locally and signed with an ordinary `ac2/SigningRequest` using
-`sig_hint: raw-ed25519` over the wallet's account key.
+`sig_hint: raw-ed25519` over the paired account's Ed25519 key.

--- a/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
+++ b/packages/ac2-open-claw-reference/skills/ac2/SKILL.md
@@ -125,11 +125,11 @@ Treat `{ status: "rejected" }` as a normal user decision. Do not retry the same 
 
 ## Git commit signing over AC2
 
-The wallet's Ed25519 account key doubles as a **git SSH signing key**. Use this flow for **any** git commit work on this channel — not just when the user explicitly says "sign my commits". Commits are created normally (unsigned) and then signed **in place** by the user's wallet with `openclaw ac2 git-sign`; there is no git-side signing configuration.
+The paired account's Ed25519 **public key** doubles as a **git SSH signing public key**. Use this flow for **any** git commit work on this channel — not just when the user explicitly says "sign my commits". Commits are created normally (unsigned) and then signed **in place** by the user's wallet with `openclaw ac2 git-sign`; there is no git-side signing configuration.
 
 **Non-negotiable: commits are signed by the user's wallet, never by you.** Do not generate, use, or configure any local SSH/GPG key of your own: nothing in git enforces this model — you do. Every commit gets wallet-signed via `git-sign` right after it is created.
 
-**Signing needs no setup.** `git-sign` works immediately on any repo — no SSH keys, no key registration, no git platform account. Registering the wallet key with a git platform only controls whether a commit shows a verified badge there; it has no bearing on local commits or on signing itself. **Do not raise key upload, SSH keys, or git platform account details unless the user explicitly asks about verification** — never as part of ordinary committing.
+**Signing needs no setup.** `git-sign` works immediately on any repo — no SSH keys, no key registration, no git platform account. Registering that public key with a git platform only controls whether a commit shows a verified badge there; it has no bearing on local commits or on signing itself. **Do not raise key upload, SSH keys, or git platform account details unless the user explicitly asks about verification** — never as part of ordinary committing.
 
 **Signing commits — the required rhythm, after every commit:**
 
@@ -138,12 +138,12 @@ git commit --no-gpg-sign -m "..."   # created unsigned — bypasses any local au
 openclaw ac2 git-sign <repo-dir>    # wallet approval; commit rewritten signed in place
 ```
 
-- **Always pass `--no-gpg-sign`** to `git commit` (and to `git commit --amend`, and rebase via `git rebase -c commit.gpgsign=false` or re-sign after): the machine's git config may auto-sign with the user's own SSH/GPG key, and that key is never the wallet. `git-sign` strips and replaces a foreign signature (with a wallet approval), so a slip-through is recoverable — but creating commits unsigned is the correct path.
+- **Always pass `--no-gpg-sign`** to `git commit` (and to `git commit --amend`, and rebase via `git rebase -c commit.gpgsign=false` or re-sign after): the machine's git config may auto-sign with the user's own SSH/GPG key, and that key is never the AC2 signing key. `git-sign` strips and replaces a foreign signature (with a wallet approval), so a slip-through is recoverable — but creating commits unsigned is the correct path.
 - `git-sign <repo-dir>` signs the tip of `HEAD` in place. The commit hash changes; the ref is moved with a compare-and-swap, so sign before anything records the old hash.
 - Made several commits (or a rebase/merge produced a chain)? Sign them all in one pass: `openclaw ac2 git-sign <repo-dir> --base origin/<branch>` — each commit gets its own wallet approval (`Sign git commit: "…"`), oldest first, with parent hashes rewritten along the chain. Tell the user approvals are coming before you run it.
 - `already signed — nothing to do` is a success, not an error.
 - A declined wallet approval aborts with the ref untouched — a normal user decision, don't retry. If it fails with `no active AC2 wallet session`, ask the user to connect/pair their wallet (`openclaw ac2 pair`) — don't retry in a loop.
-- Never work around a signing failure by substituting a different key — the user's wallet approval is the point. If the user asks why commits show as unverified, that's when to mention `openclaw ac2 git-key` (registering the key with their git platform) and the committer email match — don't volunteer it otherwise.
+- Never work around a signing failure by substituting a different key — the user's wallet approval is the point. If the user asks why commits show as unverified, that's when to mention `openclaw ac2 git-key` (registering that public key with their git platform) and the committer email match — don't volunteer it otherwise.
 - If `git commit` itself fails because `user.name`/`user.email` are unset, relay git's error and ask the user for their name and email — or use an appropriate identity.
 
 `git-sign` is the only git signing surface: never hand-build SSHSIG envelopes or commit objects via `ac2_sign` — a malformed envelope shows as unverified with no local error. (Signed tags are not covered yet.)

--- a/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
+++ b/packages/ac2-open-claw-reference/src/cli/ac2-command.ts
@@ -205,7 +205,7 @@ export function buildAc2Command(api: OpenClawApi): unknown {
     description:
       'AC2 channel control: pair | status | connections | forget | git-key | ' +
       'git-sign <repo-dir> [--ref <ref>] [--base <ref>]. ' +
-      '`git-key` prints the wallet SSH signing key; `git-sign` ' +
+      '`git-key` prints the public key (in SSH format); `git-sign` ' +
       'signs commits in place via the paired wallet after each commit.',
     acceptsArgs: true,
     requireAuth: false,
@@ -315,15 +315,15 @@ export function buildAc2Command(api: OpenClawApi): unknown {
         const line = toAuthorizedKeyLine(key.publicKey, `ac2-${key.address.slice(0, 8)}`);
         return {
           text: [
-            `Wallet account: ${key.address}`,
+            `Signing account: ${key.address}  (paired AC2 account)`,
             '',
             'SSH signing public key (Ed25519):',
             '',
             `  ${line}`,
             '',
-            'Add it as an SSH signing key with your git platform (usually under',
-            'account settings → SSH keys). Commits signed over AC2 then show as',
-            'verified there once the committer email matches your account.',
+            'Add the public key above as an SSH signing key with your git platform',
+            '(usually under account settings → SSH keys). Commits signed over AC2',
+            'then show as verified there once the committer email matches your account.',
             '',
             "Committer identity is your normal git config (`git config user.name` /",
             '`user.email`); sign commits with: openclaw ac2 git-sign',

--- a/packages/ac2-open-claw-reference/src/entry.ts
+++ b/packages/ac2-open-claw-reference/src/entry.ts
@@ -120,7 +120,7 @@ async function runAc2SlashCommand(ctx: { args?: string }): Promise<{ text: strin
       '  openclaw ac2 connections  List known connections + agent identities.',
       '  openclaw ac2 forget       Clear the saved pairing record.',
       '  openclaw ac2 setup        Print/update channel configuration.',
-      '  openclaw ac2 git-key      Print the wallet key as a git SSH signing key.',
+      '  openclaw ac2 git-key      Print the public key (SSH format) for git.',
       '  openclaw ac2 git-sign <repo-dir> [--ref r] [--base r]',
       '                            Sign commits in place via the AC2 wallet after each commit.',
     ].join('\n'),

--- a/packages/ac2-open-claw-reference/src/git/config.ts
+++ b/packages/ac2-open-claw-reference/src/git/config.ts
@@ -1,7 +1,7 @@
 /**
- * Resolve the wallet's git signing key. Signing itself needs no git
- * configuration — see `./sign.ts`; committer identity is the user's own
- * `git config user.name`/`user.email`.
+ * Resolve the git signing public key of the paired AC2 account. Signing
+ * itself needs no git configuration — see `./sign.ts`; committer identity is
+ * the user's own `git config user.name`/`user.email`.
  */
 
 import { decodeAddress } from '@algorandfoundation/algokit-utils/common';
@@ -14,10 +14,10 @@ import {
 } from '../session/wallet-address.js';
 
 /**
- * The wallet's account Ed25519 public key, used as the git signing key. An
- * Algorand address *is* the account's Ed25519 key, so decoding it yields the
- * SSH signing key directly. Falls back to the persisted bound controller when
- * no session is live (e.g. a fresh CLI process).
+ * The paired account's Ed25519 public key, used as the git signing public
+ * key. An Algorand address *is* the account's Ed25519 public key, so decoding
+ * it yields the public key directly. Falls back to the persisted
+ * bound controller when no session is live (e.g. a fresh CLI process).
  */
 export function resolveWalletSigningPublicKey(
   manager: SessionManager = sessionManager,
@@ -34,5 +34,5 @@ export function resolveWalletSigningPublicKey(
 }
 
 export const NO_WALLET_KEY_MESSAGE =
-  'No wallet key available: pair a wallet first (`openclaw ac2 pair`) so the ' +
-  "controller's account key is known.";
+  'No signing public key available: pair a wallet first (`openclaw ac2 pair`) ' +
+  "so the controller's public key is known.";

--- a/packages/ac2-open-claw-reference/src/git/sign-flow.ts
+++ b/packages/ac2-open-claw-reference/src/git/sign-flow.ts
@@ -153,8 +153,9 @@ export async function gitSignFlow(
     return {
       status: 'rejected',
       reason:
-        'public_key_mismatch: the wallet signed with a different key than expected — ' +
-        'check `openclaw ac2 git-key` and update the signing key with your git platform.',
+        'public_key_mismatch: the wallet signed with a different public key than ' +
+        'expected — check `openclaw ac2 git-key` and update the signing public key ' +
+        'with your git platform.',
       thid: result.thid,
     };
   }


### PR DESCRIPTION
-use `public key` over `wallet address` in git signing context