### PR TITLE
fix: prep for clawhub

### DIFF
--- a/packages/ac2-open-claw-reference/README.md
+++ b/packages/ac2-open-claw-reference/README.md
@@ -22,15 +22,24 @@ The wallet connection itself is owned by the separate
 
 ## Install
 
-With OpenClaw already installed, the quickest path is the setup script, which
-installs this plugin, wires it up, restarts the gateway, and starts wallet
-pairing:
+**Prerequisites:** Node.js 22 or newer and an OpenClaw agent already set up. The AC2
+service (`@algorandfoundation/ac2-cli`) ships as a dependency of this plugin and
+is started for you from that bundled copy — you do **not** need to install it
+globally or have an `ac2` binary on your `PATH`. The native WebRTC and keychain
+dependencies belong to that bundled service, not to this plugin.
+
+### Automated installation
+
+The quickest path is the setup script, which installs this plugin, wires it up,
+restarts the gateway, and starts wallet pairing:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/algorandfoundation/ac2/master/install.sh | bash
 ```
 
-Or do the same by hand:
+### Manual installation
+
+Run these commands to install and configure the plugin:
 
 ```sh
 openclaw plugins install @algorandfoundation/ac2-open-claw-reference
@@ -39,15 +48,11 @@ openclaw ac2 setup          # writes the channel + tools into openclaw.json
 openclaw gateway restart
 ```
 
+### Installation notes
+
 Do not add `--pin`: OpenClaw records the moving spec, so both the OpenClaw
 updater and the plugin-only updater can find newer stable releases. To follow
 canary pre-releases instead, install with the `@next` tag.
-
-You need Node.js 22 or newer and an OpenClaw agent already set up. The AC2
-service (`@algorandfoundation/ac2-cli`) ships as a dependency of this plugin and
-is started for you from that bundled copy — you do **not** need to install it
-globally or have an `ac2` binary on your `PATH`. The native WebRTC and keychain
-dependencies belong to that bundled service, not to this plugin.
 
 ## Use it
 

--- a/packages/ac2-open-claw-reference/openclaw.plugin.json
+++ b/packages/ac2-open-claw-reference/openclaw.plugin.json
@@ -3,18 +3,9 @@
   "name": "AC2 Reference",
   "description": "Reference OpenClaw plugin for the AC2 protocol. The `ac2` channel owns pairing over Liquid Auth + WebRTC; signing, capabilities, and x402 paid fetch tools route through the active channel session.",
   "channels": ["ac2"],
-  "channelEnvVars": [
-    {
-      "name": "AC2_LIQUID_AUTH_SERVER",
-      "description": "Liquid Auth signaling server origin. Overrides the `liquidAuthServer` channel config at runtime. Defaults to https://debug.liquidauth.com when neither is set.",
-      "required": false
-    },
-    {
-      "name": "AC2_HEARTBEAT_TIMEOUT_MS",
-      "description": "Milliseconds without inbound ac2-heartbeat traffic before the plugin closes the channel. Defaults to 50000.",
-      "required": false
-    }
-  ],
+  "channelEnvVars": {
+    "ac2": ["AC2_LIQUID_AUTH_SERVER"]
+  },
   "skills": ["./skills"],
   "activation": {
     "onCommands": ["ac2"]
@@ -75,8 +66,7 @@
     "x402AlgodToken": { "label": "x402 Algod Token" }
   },
   "contracts": {
-    "tools": ["ac2_sign", "ac2_capabilities", "ac2_x402_fetch"],
-    "commands": ["ac2"]
+    "tools": ["ac2_sign", "ac2_capabilities", "ac2_x402_fetch"]
   },
   "toolMetadata": {
     "ac2_sign": {

--- a/packages/ac2-open-claw-reference/package.json
+++ b/packages/ac2-open-claw-reference/package.json
@@ -13,7 +13,8 @@
     "wallet",
     "signing",
     "x402",
-    "payments"
+    "payments",
+    "git"
   ],
   "license": "Apache-2.0",
   "homepage": "https://github.com/algorandfoundation/ac2/tree/main/packages/ac2-open-claw-reference#readme",
@@ -81,33 +82,16 @@
     "vitest": "^3.2.0"
   },
   "openclaw": {
+    "compat": {
+      "pluginApi": ">=2026.7.1-2",
+      "minGatewayVersion": "2026.7.1-2"
+    },
+    "build": {
+      "openclawVersion": "2026.7.1-2",
+      "pluginSdkVersion": "2026.7.1-2"
+    },
     "extensions": [
       "./dist/entry.js"
-    ],
-    "channels": [
-      "ac2"
-    ],
-    "channelEnvVars": [
-      {
-        "name": "AC2_LIQUID_AUTH_SERVER",
-        "description": "Liquid Auth signaling server origin. Overrides the `liquidAuthServer` channel config at runtime. Defaults to https://debug.liquidauth.com when neither is set.",
-        "required": false
-      },
-      {
-        "name": "AC2_HEARTBEAT_TIMEOUT_MS",
-        "description": "Milliseconds without inbound ac2-heartbeat traffic before the plugin closes the channel. Defaults to 50000.",
-        "required": false
-      }
-    ],
-    "contracts": {
-      "tools": [
-        "ac2_sign",
-        "ac2_capabilities",
-        "ac2_x402_fetch"
-      ],
-      "commands": [
-        "ac2"
-      ]
-    }
+    ]
   }
 }


### PR DESCRIPTION
- some fixes for clawhub integration
- package.json and openclaw.plugin.json modified
- targeted openclaw version `>=2026.7.1-2`
- tested locally for any regressions, didn't notice anything. (shouldn't be as no functional changes)